### PR TITLE
fix(claude-native): recover sub-agent terminal status across resumes

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -618,6 +618,22 @@ class TranscriptRecordItems:
 
 
 @dataclass(frozen=True)
+class ClaudeTaskNotification:
+    """One sub-agent lifecycle record parsed from a Claude transcript.
+
+    ``<task-notification>`` records (background stops) and foreground
+    ``tool_result`` records with terminal ``toolUseResult`` both land
+    here; only correlation and result fields are kept.
+    """
+
+    task_id: str | None
+    tool_use_id: str | None
+    status: str | None
+    result: str | None
+    timestamp: str | None = None
+
+
+@dataclass(frozen=True)
 class TranscriptReadResult:
     """
     Result of reading Claude transcript JSONL records.
@@ -645,6 +661,8 @@ class TranscriptReadResult:
     :param record_items: Parsed items grouped by their complete source JSONL
         record, with the byte offset immediately after each record. Native
         child-transcript batching uses these boundaries for partial checkpoints.
+    :param task_notifications: Sub-agent lifecycle records parsed from
+        the complete records after the caller's cursor (parsing only).
     """
 
     line_cursor: int
@@ -655,6 +673,7 @@ class TranscriptReadResult:
     latest_model: str | None = None
     latest_custom_title: str | None = None
     record_items: tuple[TranscriptRecordItems, ...] = ()
+    task_notifications: tuple[ClaudeTaskNotification, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -2826,6 +2845,7 @@ def read_transcript_items_since_with_position(
     latest_model: str | None = None
     latest_custom_title: str | None = None
     record_items: list[TranscriptRecordItems] = []
+    task_notifications: list[ClaudeTaskNotification] = []
     for record in read_result.records:
         parsed: list[ClaudeTranscriptItem] = []
         if record.text is None:
@@ -2845,6 +2865,7 @@ def read_transcript_items_since_with_position(
                 TranscriptRecordItems(next_byte_offset=record.next_byte_offset, items=())
             )
             continue
+        task_notifications.extend(_task_notifications_from_entry(entry))
         active_response_id, parsed = _transcript_items_from_entry(
             entry,
             line_number=record.line_number,
@@ -2892,6 +2913,7 @@ def read_transcript_items_since_with_position(
         latest_model=latest_model,
         latest_custom_title=latest_custom_title,
         record_items=tuple(record_items),
+        task_notifications=_dedupe_task_notifications(task_notifications),
     )
 
 
@@ -2946,6 +2968,7 @@ def read_transcript_items_from_offset(
     latest_model: str | None = None
     latest_custom_title: str | None = None
     record_items: list[TranscriptRecordItems] = []
+    task_notifications: list[ClaudeTaskNotification] = []
     for record in read_result.records:
         parsed: list[ClaudeTranscriptItem] = []
         if record.text is None:
@@ -2965,6 +2988,7 @@ def read_transcript_items_from_offset(
                 TranscriptRecordItems(next_byte_offset=record.next_byte_offset, items=())
             )
             continue
+        task_notifications.extend(_task_notifications_from_entry(entry))
         active_response_id, parsed = _transcript_items_from_entry(
             entry,
             line_number=record.line_number,
@@ -3013,6 +3037,7 @@ def read_transcript_items_from_offset(
         latest_model=latest_model,
         latest_custom_title=latest_custom_title,
         record_items=tuple(record_items),
+        task_notifications=_dedupe_task_notifications(task_notifications),
     )
 
 
@@ -6911,6 +6936,99 @@ def _is_task_notification_text(text: str) -> bool:
     return stripped.startswith("<task-notification>") and all(
         marker in stripped for marker in _TASK_NOTIFICATION_REQUIRED_MARKERS
     )
+
+
+_TASK_NOTIFICATION_RESULT_MAX_CHARS = 4000
+
+
+def _task_notification_field(text: str, field: str) -> str | None:
+    """Return one ``<field>…</field>`` value from notification markup."""
+    match = re.search(
+        rf"<{re.escape(field)}>(.*?)</{re.escape(field)}>",
+        text,
+        re.DOTALL,
+    )
+    if match is None:
+        return None
+    value = match.group(1).strip()
+    return value or None
+
+
+def _record_timestamp(entry: _JsonObject) -> str | None:
+    """Return the record's top-level ``timestamp`` string, if it carries one."""
+    timestamp = entry.get("timestamp")
+    return timestamp if isinstance(timestamp, str) and timestamp else None
+
+
+def _capped_notification_result(value: object) -> str | None:
+    """Return *value* capped for notification retention, if it is usable text."""
+    if not isinstance(value, str) or not value:
+        return None
+    return value[:_TASK_NOTIFICATION_RESULT_MAX_CHARS]
+
+
+def _task_notification_from_text(
+    text: str, *, timestamp: str | None = None
+) -> ClaudeTaskNotification | None:
+    """Parse correlation/result fields from one ``<task-notification>`` blob."""
+    if not _is_task_notification_text(text):
+        return None
+    task_id = _task_notification_field(text, "task-id")
+    tool_use_id = _task_notification_field(text, "tool-use-id")
+    if task_id is None and tool_use_id is None:
+        return None
+    result = _task_notification_field(text, "result")
+    if result is None:
+        # Failed stops carry no ``<result>``; keep the ``<summary>`` instead.
+        result = _task_notification_field(text, "summary")
+    return ClaudeTaskNotification(
+        task_id=task_id,
+        tool_use_id=tool_use_id,
+        status=_task_notification_field(text, "status"),
+        result=_capped_notification_result(result),
+        timestamp=timestamp,
+    )
+
+
+def _task_notifications_from_entry(entry: _JsonObject) -> list[ClaudeTaskNotification]:
+    """Extract sub-agent lifecycle records without touching item parsing."""
+    notifications: list[ClaudeTaskNotification] = []
+    record_timestamp = _record_timestamp(entry)
+    texts: list[str] = []
+    message = entry.get("message")
+    if isinstance(message, dict) and message.get("role") == "user":
+        content = message.get("content")
+        if isinstance(content, str):
+            texts.append(content)
+        elif isinstance(content, list):
+            texts.extend(
+                text
+                for block in content
+                if isinstance(block, dict)
+                and block.get("type") == "text"
+                and isinstance((text := block.get("text")), str)
+            )
+    attachment = entry.get("attachment")
+    if (
+        entry.get("type") == "attachment"
+        and isinstance(attachment, dict)
+        and attachment.get("type") == "queued_command"
+        and attachment.get("commandMode") == "task-notification"
+        and isinstance(attachment.get("prompt"), str)
+    ):
+        texts.append(attachment["prompt"])
+    for text in texts:
+        parsed = _task_notification_from_text(text, timestamp=record_timestamp)
+        if parsed is not None:
+            notifications.append(parsed)
+    return notifications
+
+
+def _dedupe_task_notifications(
+    notifications: list[ClaudeTaskNotification],
+) -> tuple[ClaudeTaskNotification, ...]:
+    """Collapse exact repeats while preserving distinct runs and their order."""
+    return tuple(dict.fromkeys(notifications))
 
 
 def _local_command_transcript_items_from_entry(

--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -594,6 +594,11 @@ class ClaudeTranscriptItem:
         source=compact`` completion signal follows; the forwarder uses this
         flag to dismiss the stranded "Compacting…" spinner. Never rendered
         as a bubble. Defaults to ``False``.
+    :param is_coordinator_resume: ``True`` when this item was parsed
+        from a coordinator SendMessage resume record (``isMeta`` with
+        ``origin.kind == "coordinator"``) — a real user-visible prompt
+        the child must show, and the signal that reopens a finished
+        sub-agent. Never sent to the server; defaults to ``False``.
     """
 
     source_id: str
@@ -602,6 +607,7 @@ class ClaudeTranscriptItem:
     response_id: str
     is_compact_summary: bool = False
     is_compact_noop: bool = False
+    is_coordinator_resume: bool = False
 
 
 @dataclass(frozen=True)
@@ -611,10 +617,12 @@ class TranscriptRecordItems:
     ``next_byte_offset`` is safe to persist only after every item in
     ``items`` has been accepted by the server. Records that produce no visible
     items are included so a forwarder can advance past them without rescanning.
+    ``timestamp`` is the record's ``timestamp``, ordering resumes vs evidence.
     """
 
     next_byte_offset: int
     items: tuple[ClaudeTranscriptItem, ...]
+    timestamp: str | None = None
 
 
 @dataclass(frozen=True)
@@ -2893,6 +2901,7 @@ def read_transcript_items_since_with_position(
             TranscriptRecordItems(
                 next_byte_offset=record.next_byte_offset,
                 items=tuple(parsed),
+                timestamp=_record_timestamp(entry),
             )
         )
     items = _dedupe_compact_noop_echo(items)
@@ -2901,6 +2910,7 @@ def read_transcript_items_since_with_position(
         TranscriptRecordItems(
             next_byte_offset=record.next_byte_offset,
             items=tuple(item for item in record.items if item.source_id in retained_source_ids),
+            timestamp=record.timestamp,
         )
         for record in record_items
     ]
@@ -3017,6 +3027,7 @@ def read_transcript_items_from_offset(
             TranscriptRecordItems(
                 next_byte_offset=record.next_byte_offset,
                 items=tuple(parsed),
+                timestamp=_record_timestamp(entry),
             )
         )
     items = _dedupe_compact_noop_echo(items)
@@ -3025,6 +3036,7 @@ def read_transcript_items_from_offset(
         TranscriptRecordItems(
             next_byte_offset=record.next_byte_offset,
             items=tuple(item for item in record.items if item.source_id in retained_source_ids),
+            timestamp=record.timestamp,
         )
         for record in record_items
     ]
@@ -6938,6 +6950,13 @@ def _is_task_notification_text(text: str) -> bool:
     )
 
 
+# Lifecycle statuses a ``toolUseResult`` / ``<task-notification>`` status
+# field may carry when the agent actually stopped. ``async_launched``
+# (and any unknown value) means the agent is still running.
+_TERMINAL_TASK_STATUSES: frozenset[str] = frozenset({"completed", "failed", "stopped", "killed"})
+
+# A notification ``<result>`` can hold a full agent report; cap what we
+# retain so one record cannot bloat the forwarder state or status POST.
 _TASK_NOTIFICATION_RESULT_MAX_CHARS = 4000
 
 
@@ -6958,6 +6977,55 @@ def _record_timestamp(entry: _JsonObject) -> str | None:
     """Return the record's top-level ``timestamp`` string, if it carries one."""
     timestamp = entry.get("timestamp")
     return timestamp if isinstance(timestamp, str) and timestamp else None
+
+
+def _is_coordinator_resume_entry(entry: _JsonObject) -> bool:
+    """Return True for a coordinator SendMessage resume in a child transcript."""
+    origin = entry.get("origin")
+    return (
+        entry.get("isMeta") is True
+        and isinstance(origin, dict)
+        and origin.get("kind") == "coordinator"
+    )
+
+
+def _coordinator_resume_items_from_entry(
+    entry: _JsonObject,
+    *,
+    line_number: int,
+    record_offset: int | None,
+    current_response_id: str | None,
+) -> tuple[str | None, list[ClaudeTranscriptItem]]:
+    """Surface a coordinator resume record as one flagged user message."""
+    message = entry.get("message")
+    content = message.get("content") if isinstance(message, dict) else None
+    if isinstance(content, str):
+        texts = [content]
+    elif isinstance(content, list):
+        texts = [
+            text
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance((text := block.get("text")), str)
+        ]
+    else:
+        texts = []
+    if not (texts := [text for text in texts if text]):
+        return current_response_id, []
+    source_key = _transcript_source_key(entry, line_number, record_offset)
+    return None, [
+        ClaudeTranscriptItem(
+            source_id=_source_id(source_key, 0, "message"),
+            item_type="message",
+            data={
+                "role": "user",
+                "content": [{"type": "input_text", "text": text} for text in texts],
+            },
+            response_id=_response_id_from_source(source_key),
+            is_coordinator_resume=True,
+        )
+    ]
 
 
 def _capped_notification_result(value: object) -> str | None:
@@ -6988,6 +7056,38 @@ def _task_notification_from_text(
         result=_capped_notification_result(result),
         timestamp=timestamp,
     )
+
+
+def _tool_result_task_notification(entry: _JsonObject) -> ClaudeTaskNotification | None:
+    """Parse a foreground Agent result whose ``toolUseResult`` stopped."""
+    tool_use_result = entry.get("toolUseResult")
+    if not isinstance(tool_use_result, dict):
+        return None
+    status = tool_use_result.get("status")
+    if not isinstance(status, str) or status not in _TERMINAL_TASK_STATUSES:
+        return None
+    message = entry.get("message")
+    if not isinstance(message, dict) or message.get("role") != "user":
+        return None
+    content = message.get("content")
+    if not isinstance(content, list):
+        return None
+    agent_id = tool_use_result.get("agentId")
+    task_id = agent_id if isinstance(agent_id, str) and agent_id else None
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != "tool_result":
+            continue
+        tool_use_id = block.get("tool_use_id")
+        if not isinstance(tool_use_id, str) or not tool_use_id:
+            continue
+        return ClaudeTaskNotification(
+            task_id=task_id,
+            tool_use_id=tool_use_id,
+            status=status,
+            result=_capped_notification_result(_tool_result_output(entry, block)),
+            timestamp=_record_timestamp(entry),
+        )
+    return None
 
 
 def _task_notifications_from_entry(entry: _JsonObject) -> list[ClaudeTaskNotification]:
@@ -7021,6 +7121,9 @@ def _task_notifications_from_entry(entry: _JsonObject) -> list[ClaudeTaskNotific
         parsed = _task_notification_from_text(text, timestamp=record_timestamp)
         if parsed is not None:
             notifications.append(parsed)
+    tool_result_notification = _tool_result_task_notification(entry)
+    if tool_result_notification is not None:
+        notifications.append(tool_result_notification)
     return notifications
 
 
@@ -7183,8 +7286,16 @@ def _user_transcript_items_from_entry(
         items.
     """
     # ``isMeta=true`` carries CLI scaffolding like
-    # ``<local-command-caveat>``; no user-visible content.
+    # ``<local-command-caveat>``; no user-visible content — except a
+    # coordinator resume, which is a real prompt the child must show.
     if entry.get("isMeta") is True:
+        if _is_coordinator_resume_entry(entry):
+            return _coordinator_resume_items_from_entry(
+                entry,
+                line_number=line_number,
+                record_offset=record_offset,
+                current_response_id=current_response_id,
+            )
         return current_response_id, []
     message = entry["message"]
     content = message.get("content") if isinstance(message, dict) else None

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -2015,6 +2015,8 @@ async def _forward_one_subagent(
     batch_capability: _SessionEventBatchCapability,
 ) -> None:
     """Drain one child's transcript in ordered, byte-capped batches."""
+    if entry.terminal_evidence_pending:
+        return
     jsonl_path = subagents_dir / f"agent-{entry.subagent_id}.jsonl"
     if not jsonl_path.exists():
         return
@@ -2243,7 +2245,7 @@ async def _forward_one_subagent(
 
     delivery_pending = any(item.item.source_id not in seen for item in pending)
     desired_status: str | None = None
-    if had_item:
+    if had_item or (new_entry.terminal_status is None and new_entry.status_reconcile_pending):
         desired_status = "running"
     elif (
         not delivery_pending
@@ -2251,7 +2253,20 @@ async def _forward_one_subagent(
         and now - new_entry.last_activity_ts > _SUBAGENT_IDLE_QUIESCENCE_S
     ):
         desired_status = "failed" if new_entry.delivery_error else "idle"
-    if desired_status is None or desired_status == new_entry.last_status:
+    # Authoritative parent evidence overrides the quiescence guess; a
+    # failed POST retries next tick since ``last_status`` moves on success.
+    desired_output: str | None = None
+    terminal_post = _SUBAGENT_TERMINAL_STATUS_POSTS.get(new_entry.terminal_status or "")
+    if terminal_post is not None:
+        desired_status = terminal_post
+        desired_output = new_entry.terminal_output or (
+            _SUBAGENT_FAILED_NO_RESULT_OUTPUT if terminal_post == "failed" else None
+        )
+    elif desired_status == "failed":
+        desired_output = new_entry.delivery_error
+    if desired_status is None or (
+        desired_status == new_entry.last_status and not new_entry.status_reconcile_pending
+    ):
         return
     retry_key = f"subagent_status:{entry.child_conversation_id}"
     if status_retry_tracker.retry_delay_s(retry_key) is not None:
@@ -2261,7 +2276,7 @@ async def _forward_one_subagent(
             client,
             session_id=entry.child_conversation_id,
             status=desired_status,
-            output=new_entry.delivery_error if desired_status == "failed" else None,
+            output=desired_output,
         )
     except httpx.HTTPError as exc:
         decision = status_retry_tracker.record_failure(retry_key, exc)
@@ -2278,7 +2293,9 @@ async def _forward_one_subagent(
         )
         return
     status_retry_tracker.clear(retry_key)
-    await checkpoint.put(replace(new_entry, last_status=desired_status))
+    await checkpoint.put(
+        replace(new_entry, last_status=desired_status, status_reconcile_pending=False)
+    )
 
 
 def _tool_use_ids_in_transcript(
@@ -2600,15 +2617,13 @@ async def _forward_available_subagents(
                             subagent_id,
                             parent_subagent_id,
                         )
-                        updated = SubagentForwardState(
-                            subagents={
-                                **updated.subagents,
-                                subagent_id: SubagentEntry(
-                                    subagent_id=subagent_id,
-                                    child_conversation_id="",
-                                    parent_subagent_id=parent_subagent_id,
-                                ),
-                            }
+                        updated = _with_entry(
+                            updated,
+                            SubagentEntry(
+                                subagent_id=subagent_id,
+                                child_conversation_id="",
+                                parent_subagent_id=parent_subagent_id,
+                            ),
                         )
                         await _write_subagent_forward_state_async(bridge_dir, updated)
                         made_progress = True
@@ -2649,15 +2664,13 @@ async def _forward_available_subagents(
                         delivered_ambiguous=False,
                         http_status=_http_status_for_log(exc),
                     )
-                    updated = SubagentForwardState(
-                        subagents={
-                            **updated.subagents,
-                            subagent_id: SubagentEntry(
-                                subagent_id=subagent_id,
-                                child_conversation_id="",
-                                parent_subagent_id=parent_subagent_id,
-                            ),
-                        }
+                    updated = _with_entry(
+                        updated,
+                        SubagentEntry(
+                            subagent_id=subagent_id,
+                            child_conversation_id="",
+                            parent_subagent_id=parent_subagent_id,
+                        ),
                     )
                     await _write_subagent_forward_state_async(bridge_dir, updated)
                     continue
@@ -2676,16 +2689,13 @@ async def _forward_available_subagents(
                 )
                 continue
             start_retry_tracker.clear(retry_key)
-            updated = SubagentForwardState(
-                subagents={
-                    **updated.subagents,
-                    subagent_id: SubagentEntry(
-                        subagent_id=subagent_id,
-                        child_conversation_id=child_id,
-                        parent_subagent_id=parent_subagent_id,
-                    ),
-                }
+            entry = SubagentEntry(
+                subagent_id=subagent_id,
+                child_conversation_id=child_id,
+                parent_subagent_id=parent_subagent_id,
+                tool_use_id=meta["toolUseId"],
             )
+            updated = _with_entry(updated, entry)
             await _write_subagent_forward_state_async(bridge_dir, updated)
             made_progress = True
         if not made_progress:
@@ -2701,6 +2711,71 @@ async def _forward_available_subagents(
                 )
             break
         pending = deferred
+
+    # ── Drain parent task evidence ────────────────────────
+    # Notifications apply by task id, then spawn tool-use id, else park.
+    parent_result = await asyncio.to_thread(
+        read_transcript_items_from_offset,
+        transcript_path,
+        updated.parent_byte_offset,
+        start_line=updated.parent_line_cursor,
+        agent_name=agent_name,
+        include_sidechains=False,
+    )
+    pre_drain = updated
+    for notification in parent_result.task_notifications:
+        updated = _apply_terminal_notification(updated, notification)
+    pending_rows = dict(updated.pending_terminal_notifications)
+    aliases = dict(updated.pending_terminal_tool_use_ids)
+    for sid, entry in updated.subagents.items():
+        if entry.terminal_evidence_pending:
+            continue
+        keys = [
+            key
+            for key in pending_rows
+            if key == sid
+            or (
+                entry.tool_use_id is not None
+                and (key == entry.tool_use_id or aliases.get(key) == entry.tool_use_id)
+            )
+        ]
+        selected = (
+            sid
+            if sid in keys
+            else max(
+                keys,
+                key=lambda key: (
+                    _parse_record_timestamp(pending_rows[key][2])
+                    or datetime.min.replace(tzinfo=timezone.utc)
+                ),
+                default=None,
+            )
+        )
+        if selected is not None:
+            status, output, observed_at = pending_rows[selected]
+            updated = _apply_terminal_notification(
+                updated,
+                ClaudeTaskNotification(
+                    task_id=sid,
+                    tool_use_id=entry.tool_use_id,
+                    status=status,
+                    result=output,
+                    timestamp=observed_at,
+                ),
+            )
+        for key in keys:
+            pending_rows.pop(key)
+            aliases.pop(key, None)
+    updated = replace(
+        updated, pending_terminal_notifications=pending_rows, pending_terminal_tool_use_ids=aliases
+    )
+    updated = replace(
+        updated,
+        parent_byte_offset=parent_result.byte_offset,
+        parent_line_cursor=parent_result.line_cursor,
+    )
+    if updated != pre_drain:
+        await _write_subagent_forward_state_async(bridge_dir, updated)
 
     checkpoint = _SubagentStateCheckpoint(bridge_dir, updated)
     semaphore = asyncio.Semaphore(_SUBAGENT_FORWARD_CONCURRENCY)

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -611,6 +611,7 @@ class _PendingSubagentItem:
     item: ClaudeTranscriptItem
     checkpoint_after: int | None = None
     drop_reason: str | None = None
+    record_timestamp: str | None = None
 
 
 @dataclass
@@ -1918,7 +1919,10 @@ def _pending_items_from_records(
     for record in result.record_items:
         unseen = [item for item in record.items if item.source_id not in seen]
         if unseen:
-            pending.extend(_PendingSubagentItem(item=item) for item in unseen)
+            pending.extend(
+                _PendingSubagentItem(item=item, record_timestamp=record.timestamp)
+                for item in unseen
+            )
             pending[-1] = replace(pending[-1], checkpoint_after=record.next_byte_offset)
         elif pending:
             pending[-1] = replace(pending[-1], checkpoint_after=record.next_byte_offset)
@@ -2055,6 +2059,7 @@ async def _forward_one_subagent(
             break
         drop_reason = batch[0].drop_reason if len(batch) == 1 else None
         completed_items: list[_PendingSubagentItem] = []
+        delivered_now: list[_PendingSubagentItem] = []
         delivered = False
         stop_after_batch = False
         if drop_reason is not None:
@@ -2158,6 +2163,7 @@ async def _forward_one_subagent(
                     retry_individually = True
             else:
                 completed_items.extend(batch)
+                delivered_now.extend(batch)
                 delivered = True
                 item_retry_tracker.clear(retry_key)
         if retry_individually and drop_reason is None:
@@ -2221,6 +2227,7 @@ async def _forward_one_subagent(
                     )
                 else:
                     item_retry_tracker.clear(item_retry_key)
+                    delivered_now.append(pending_item)
                     delivered = True
                 completed_items.append(pending_item)
         had_item = had_item or delivered
@@ -2233,6 +2240,10 @@ async def _forward_one_subagent(
             for pending_item in completed_items
             if pending_item.checkpoint_after is not None
         ]
+        for delivered_item in delivered_now:
+            new_entry = _observe_resume(
+                new_entry, delivered_item.item, delivered_item.record_timestamp
+            )
         new_entry = replace(
             new_entry,
             byte_offset=max(completed_offsets, default=new_entry.byte_offset),
@@ -2433,6 +2444,48 @@ def _terminal_is_current(entry: SubagentEntry, observed_at: str | None) -> bool:
     baseline = _parse_record_timestamp(entry.terminal_observed_at)
     candidate = _parse_record_timestamp(observed_at)
     return baseline is None or (candidate is not None and candidate >= baseline)
+
+
+def _observe_resume(
+    entry: SubagentEntry, item: ClaudeTranscriptItem, timestamp: str | None
+) -> SubagentEntry:
+    """Persist accepted prompt order even when its preceding completion is late."""
+    if not _is_user_resume_item(item) or _parse_record_timestamp(timestamp) is None:
+        return entry
+    if entry.resume_observed_at is not None and not _record_timestamp_is_newer(
+        timestamp, entry.resume_observed_at
+    ):
+        return entry
+    entry = replace(entry, resume_observed_at=timestamp)
+    if entry.terminal_status is not None and _record_timestamp_is_newer(
+        timestamp, entry.terminal_observed_at
+    ):
+        entry = replace(
+            entry,
+            terminal_status=None,
+            terminal_output=None,
+            terminal_observed_at=None,
+            last_status=None,
+            status_reconcile_pending=True,
+        )
+    return entry
+
+
+def _is_user_resume_item(item: ClaudeTranscriptItem) -> bool:
+    """Return True for a delivered user prompt that may resume a stopped child."""
+    if (
+        item.item_type != "message"
+        or item.is_compact_summary
+        or item.is_compact_noop
+        or item.data.get("role") != "user"
+    ):
+        return False
+    if item.data.get("is_meta") is True and not item.is_coordinator_resume:
+        return False
+    content = item.data.get("content")
+    return isinstance(content, list) and any(
+        isinstance(block, dict) and block.get("type") == "input_text" for block in content
+    )
 
 
 def _apply_terminal_notification(

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -13,6 +13,7 @@ import tempfile
 import time
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, replace
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
@@ -2242,6 +2243,34 @@ def _subagent_parents_by_tool_use(
     for tool_use_id in ambiguous:
         owners.pop(tool_use_id, None)
     return owners
+
+
+def _parse_record_timestamp(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 record timestamp into an aware UTC datetime.
+
+    Raw strings are never compared: precisions vary, so this
+    normalizes to UTC first. ``None`` when unparsable.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _record_timestamp_is_newer(candidate: str | None, baseline: str | None) -> bool:
+    """Return True only when both timestamps parse and candidate is later."""
+    if candidate is None or baseline is None:
+        return False
+    parsed = (_parse_record_timestamp(candidate), _parse_record_timestamp(baseline))
+    return parsed[0] is not None and parsed[1] is not None and parsed[0] > parsed[1]
 
 
 async def _forward_available_subagents(

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -12,7 +12,7 @@ import os
 import tempfile
 import time
 from collections.abc import AsyncIterator, Mapping, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -24,6 +24,7 @@ from omnigent.harnesses.claude_native.bridge import (
     OBSERVER_HOOK_STDERR_FILE,
     ClaudeHookRecord,
     ClaudeMessageDelta,
+    ClaudeTaskNotification,
     ClaudeTranscriptItem,
     HookReadResult,
     TranscriptReadResult,
@@ -94,6 +95,18 @@ _MAX_SEEN_DELTA_KEYS = 5000
 # flickering the badge. Phase B will replace this with an authoritative
 # hook signal and drop the heuristic.
 _SUBAGENT_IDLE_QUIESCENCE_S = 5.0
+
+# Authoritative stop vocabulary mapped to its ``external_session_status``.
+# The task id survives a resume; the spawn tool-use id is the fallback key.
+_SUBAGENT_TERMINAL_STATUS_POSTS: dict[str, str] = {
+    "completed": "idle",
+    "failed": "failed",
+    "stopped": "failed",
+    "killed": "failed",
+}
+
+# Output of a failed edge that carries no result text.
+_SUBAGENT_FAILED_NO_RESULT_OUTPUT = "Sub-agent ended without reporting a result."
 
 # Meta-file glob inside ``~/.claude/projects/<encoded>/<session>/subagents/``.
 # One per Claude Task-tool subagent; appears alongside the matching
@@ -534,6 +547,12 @@ class SubagentEntry:
         means no status has been posted yet.
     :param delivery_error: Durable reason the mirrored transcript is
         incomplete. Its quiescence edge is ``failed`` instead of ``idle``.
+    :param tool_use_id: Spawn tool-call id (``None`` when unknown).
+    :param terminal_status: Authoritative stop status (``None`` pending evidence).
+    :param terminal_output: Result text from that evidence.
+    :param terminal_observed_at: Notifying record's ``timestamp``.
+    :param resume_observed_at: Latest accepted user prompt's record timestamp.
+    :param status_reconcile_pending: A status correction still awaiting acknowledgement.
     """
 
     subagent_id: str
@@ -544,6 +563,14 @@ class SubagentEntry:
     last_activity_ts: float | None = None
     last_status: str | None = None
     delivery_error: str | None = None
+    tool_use_id: str | None = None
+    terminal_status: str | None = None
+    terminal_output: str | None = None
+    terminal_observed_at: str | None = None
+    resume_observed_at: str | None = None
+    terminal_evidence_pending: bool = False
+    tool_use_id_pending: bool = False
+    status_reconcile_pending: bool = False
 
 
 @dataclass(frozen=True)
@@ -560,9 +587,21 @@ class SubagentForwardState:
         per-sub-agent entry. New sub-agents discovered on disk are
         inserted here after the Omnigent server returns a child
         Conversation id.
+    :param parent_byte_offset: Parent bytes scanned for task evidence.
+    :param parent_line_cursor: Complete parent records scanned.
+    :param pending_terminal_notifications: Terminal evidence keyed by task id.
+    :param pending_terminal_tool_use_ids: Spawn-id aliases retained with parked evidence.
+    :param terminal_evidence_version: Version of the accepted-prompt ordering repair.
     """
 
     subagents: dict[str, SubagentEntry]
+    parent_byte_offset: int = 0
+    parent_line_cursor: int = 0
+    pending_terminal_notifications: dict[str, tuple[str, str | None, str | None]] = field(
+        default_factory=dict
+    )
+    pending_terminal_tool_use_ids: dict[str, str] = field(default_factory=dict)
+    terminal_evidence_version: int = 1
 
 
 @dataclass(frozen=True)
@@ -597,8 +636,9 @@ class _SubagentStateCheckpoint:
     async def put(self, entry: SubagentEntry) -> None:
         """Merge and durably write one child cursor without losing peers."""
         async with self._lock:
-            self._state = SubagentForwardState(
-                subagents={**self._state.subagents, entry.subagent_id: entry}
+            self._state = replace(
+                self._state,
+                subagents={**self._state.subagents, entry.subagent_id: entry},
             )
             await _write_subagent_forward_state_async(self._bridge_dir, self._state)
 
@@ -1452,8 +1492,69 @@ def _read_subagent_forward_state(bridge_dir: Path) -> SubagentForwardState:
             delivery_error=(
                 row.get("delivery_error") if isinstance(row.get("delivery_error"), str) else None
             ),
+            tool_use_id=(
+                row.get("tool_use_id") if isinstance(row.get("tool_use_id"), str) else None
+            ),
+            terminal_status=(
+                row.get("terminal_status") if isinstance(row.get("terminal_status"), str) else None
+            ),
+            terminal_output=(
+                row.get("terminal_output") if isinstance(row.get("terminal_output"), str) else None
+            ),
+            terminal_evidence_pending=row.get("terminal_evidence_pending") is True,
+            tool_use_id_pending=row.get(
+                "tool_use_id_pending", not isinstance(row.get("tool_use_id"), str)
+            )
+            is True,
+            resume_observed_at=(
+                row.get("resume_observed_at")
+                if isinstance(row.get("resume_observed_at"), str)
+                else None
+            ),
+            status_reconcile_pending=row.get("status_reconcile_pending") is True,
+            terminal_observed_at=(
+                row.get("terminal_observed_at")
+                if isinstance(row.get("terminal_observed_at"), str)
+                else None
+            ),
         )
-    return SubagentForwardState(subagents=entries)
+    parent_byte_offset = raw.get("parent_byte_offset", 0)
+    if not isinstance(parent_byte_offset, int) or parent_byte_offset < 0:
+        parent_byte_offset = 0
+    parent_line_cursor = raw.get("parent_line_cursor", 0)
+    if not isinstance(parent_line_cursor, int) or parent_line_cursor < 0:
+        parent_line_cursor = 0
+    pending: dict[str, tuple[str, str | None, str | None]] = {}
+    pending_raw = raw.get("pending_terminal_notifications", {})
+    if isinstance(pending_raw, dict):
+        for task_id, notification_row in pending_raw.items():
+            if not isinstance(task_id, str) or not (
+                isinstance(notification_row, list) and len(notification_row) == 3
+            ):
+                continue
+            status, output, observed_at = notification_row
+            if not isinstance(status, str):
+                continue
+            if (output is not None and not isinstance(output, str)) or (
+                observed_at is not None and not isinstance(observed_at, str)
+            ):
+                continue
+            pending[task_id] = (status, output, observed_at)
+    aliases = raw.get("pending_terminal_tool_use_ids", {})
+    aliases = (
+        {k: v for k, v in aliases.items() if isinstance(k, str) and isinstance(v, str)}
+        if isinstance(aliases, dict)
+        else {}
+    )
+    version = raw.get("terminal_evidence_version", 0)
+    return SubagentForwardState(
+        pending_terminal_tool_use_ids=aliases,
+        terminal_evidence_version=version if isinstance(version, int) else 0,
+        subagents=entries,
+        parent_byte_offset=parent_byte_offset,
+        parent_line_cursor=parent_line_cursor,
+        pending_terminal_notifications=pending,
+    )
 
 
 def _write_subagent_forward_state(bridge_dir: Path, state: SubagentForwardState) -> None:
@@ -1475,8 +1576,28 @@ def _write_subagent_forward_state(bridge_dir: Path, state: SubagentForwardState)
                 "last_activity_ts": entry.last_activity_ts,
                 "last_status": entry.last_status,
                 "delivery_error": entry.delivery_error,
+                "tool_use_id": entry.tool_use_id,
+                "terminal_status": entry.terminal_status,
+                "terminal_output": entry.terminal_output,
+                "terminal_observed_at": entry.terminal_observed_at,
+                "resume_observed_at": entry.resume_observed_at,
+                "terminal_evidence_pending": entry.terminal_evidence_pending,
+                "tool_use_id_pending": entry.tool_use_id_pending,
+                "status_reconcile_pending": entry.status_reconcile_pending,
             }
             for entry in state.subagents.values()
+        },
+        "parent_byte_offset": state.parent_byte_offset,
+        "parent_line_cursor": state.parent_line_cursor,
+        "pending_terminal_tool_use_ids": state.pending_terminal_tool_use_ids,
+        "terminal_evidence_version": state.terminal_evidence_version,
+        "pending_terminal_notifications": {
+            task_id: [status, output, observed_at]
+            for task_id, (
+                status,
+                output,
+                observed_at,
+            ) in state.pending_terminal_notifications.items()
         },
         "updated_at": time.time(),
     }
@@ -2245,6 +2366,11 @@ def _subagent_parents_by_tool_use(
     return owners
 
 
+def _with_entry(state: SubagentForwardState, entry: SubagentEntry) -> SubagentForwardState:
+    """Return state with one entry inserted, preserving cursor/parked rows."""
+    return replace(state, subagents={**state.subagents, entry.subagent_id: entry})
+
+
 def _parse_record_timestamp(value: str | None) -> datetime | None:
     """Parse an ISO-8601 record timestamp into an aware UTC datetime.
 
@@ -2271,6 +2397,84 @@ def _record_timestamp_is_newer(candidate: str | None, baseline: str | None) -> b
         return False
     parsed = (_parse_record_timestamp(candidate), _parse_record_timestamp(baseline))
     return parsed[0] is not None and parsed[1] is not None and parsed[0] > parsed[1]
+
+
+def _terminal_is_current(entry: SubagentEntry, observed_at: str | None) -> bool:
+    """Reject terminal evidence from before the latest accepted user prompt."""
+    if entry.resume_observed_at is not None and not _record_timestamp_is_newer(
+        observed_at, entry.resume_observed_at
+    ):
+        return False
+    baseline = _parse_record_timestamp(entry.terminal_observed_at)
+    candidate = _parse_record_timestamp(observed_at)
+    return baseline is None or (candidate is not None and candidate >= baseline)
+
+
+def _apply_terminal_notification(
+    state: SubagentForwardState,
+    notification: ClaudeTaskNotification,
+) -> SubagentForwardState:
+    """Fold terminal evidence into an entry (task id, then tool-use id) or park it."""
+    status = notification.status
+    if status not in _SUBAGENT_TERMINAL_STATUS_POSTS:
+        return state
+    park_key = notification.task_id or notification.tool_use_id
+    if (
+        park_key is not None
+        and notification.tool_use_id is not None
+        and state.pending_terminal_notifications.get(park_key)
+        == (status, notification.result, notification.timestamp)
+        and park_key not in state.pending_terminal_tool_use_ids
+    ):
+        state = replace(
+            state,
+            pending_terminal_tool_use_ids={
+                **state.pending_terminal_tool_use_ids,
+                park_key: notification.tool_use_id,
+            },
+        )
+    entry = state.subagents.get(notification.task_id or "")
+    if entry is None and notification.tool_use_id is not None:
+        for candidate in state.subagents.values():
+            if candidate.tool_use_id == notification.tool_use_id:
+                entry = candidate
+                break
+    if entry is not None and not entry.terminal_evidence_pending:
+        if not _terminal_is_current(entry, notification.timestamp):
+            return state
+        return _with_entry(
+            state,
+            replace(
+                entry,
+                terminal_status=status,
+                terminal_output=notification.result,
+                terminal_observed_at=notification.timestamp,
+                status_reconcile_pending=entry.status_reconcile_pending
+                or (entry.terminal_status, entry.terminal_output, entry.terminal_observed_at)
+                != (status, notification.result, notification.timestamp),
+            ),
+        )
+    key = notification.task_id or notification.tool_use_id
+    if key is None:
+        return state
+    current = state.pending_terminal_notifications.get(key)
+    candidate = notification.timestamp
+    baseline = current[2] if current is not None else None
+    if _parse_record_timestamp(baseline) is not None and not _record_timestamp_is_newer(
+        candidate, baseline
+    ):
+        return state
+    return replace(
+        state,
+        pending_terminal_tool_use_ids={
+            **state.pending_terminal_tool_use_ids,
+            **({key: notification.tool_use_id} if notification.tool_use_id else {}),
+        },
+        pending_terminal_notifications={
+            **state.pending_terminal_notifications,
+            key: (status, notification.result, candidate),
+        },
+    )
 
 
 async def _forward_available_subagents(

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -2252,7 +2252,15 @@ async def _forward_one_subagent(
         and new_entry.last_activity_ts is not None
         and now - new_entry.last_activity_ts > _SUBAGENT_IDLE_QUIESCENCE_S
     ):
-        desired_status = "failed" if new_entry.delivery_error else "idle"
+        # A root child with a spawn id stays running until its Task
+        # evidence arrives; nested children, id-less entries, and
+        # delivery errors keep today's quiescence edge.
+        if not (
+            new_entry.delivery_error is None
+            and new_entry.parent_subagent_id is None
+            and new_entry.tool_use_id is not None
+        ):
+            desired_status = "failed" if new_entry.delivery_error else "idle"
     # Authoritative parent evidence overrides the quiescence guess; a
     # failed POST retries next tick since ``last_status`` moves on success.
     desired_output: str | None = None

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -2471,6 +2471,71 @@ def _observe_resume(
     return entry
 
 
+async def _repair_terminal_evidence_order(
+    state: SubagentForwardState,
+    *,
+    subagents_dir: Path,
+    transcript_path: Path,
+    bridge_dir: Path,
+    agent_name: str,
+) -> SubagentForwardState:
+    """Repair each old child independently, preserving settled replay acknowledgements."""
+    initial = state.terminal_evidence_version < 1
+    if not initial and not any(
+        entry.terminal_evidence_pending for entry in state.subagents.values()
+    ):
+        return state
+    try:
+        with transcript_path.open("rb") as stream:
+            stream.read(1)
+    except OSError:
+        return state
+    entries = dict(state.subagents)
+    for sid, entry in entries.items():
+        if not initial and not entry.terminal_evidence_pending:
+            continue
+        # A cursor includes deduplicated history. It cannot reopen an already
+        # acknowledged terminal; only new delivery can establish that intent.
+        if not entry.child_conversation_id or (
+            entry.terminal_status is not None and entry.last_status in {"idle", "failed"}
+        ):
+            entries[sid] = replace(entry, terminal_evidence_pending=False)
+            continue
+        if entry.byte_offset or entry.seen_source_ids:
+            path = subagents_dir / f"agent-{sid}.jsonl"
+            try:
+                with path.open("rb") as stream:
+                    stream.read(1)
+                result = await asyncio.to_thread(
+                    read_transcript_items_from_offset,
+                    path,
+                    0,
+                    start_line=0,
+                    agent_name=agent_name,
+                    include_sidechains=True,
+                )
+            except (OSError, ValueError):
+                entries[sid] = replace(entry, terminal_evidence_pending=True)
+                continue
+            for record in result.record_items:
+                for item in record.items:
+                    if (
+                        record.next_byte_offset <= entry.byte_offset
+                        or item.source_id in entry.seen_source_ids
+                    ):
+                        entry = _observe_resume(entry, item, record.timestamp)
+        entries[sid] = replace(entry, terminal_evidence_pending=False)
+    state = replace(
+        state,
+        subagents=entries,
+        parent_byte_offset=0 if initial else state.parent_byte_offset,
+        parent_line_cursor=0 if initial else state.parent_line_cursor,
+        terminal_evidence_version=1,
+    )
+    await _write_subagent_forward_state_async(bridge_dir, state)
+    return state
+
+
 def _is_user_resume_item(item: ClaudeTranscriptItem) -> bool:
     """Return True for a delivered user prompt that may resume a stopped child."""
     if (
@@ -2772,6 +2837,29 @@ async def _forward_available_subagents(
                 )
             break
         pending = deferred
+
+    # Upgrade older entries that predate persistent spawn identifiers.
+    for sid, entry in updated.subagents.items():
+        if entry.tool_use_id is None and (
+            entry.tool_use_id_pending or updated.terminal_evidence_version < 1
+        ):
+            meta = await asyncio.to_thread(
+                _read_subagent_meta, subagents_dir / f"agent-{sid}.meta.json"
+            )
+            if meta is not None:
+                updated = _with_entry(
+                    updated,
+                    replace(entry, tool_use_id=meta["toolUseId"], tool_use_id_pending=False),
+                )
+            elif not entry.tool_use_id_pending:
+                updated = _with_entry(updated, replace(entry, tool_use_id_pending=True))
+    updated = await _repair_terminal_evidence_order(
+        updated,
+        subagents_dir=subagents_dir,
+        transcript_path=transcript_path,
+        bridge_dir=bridge_dir,
+        agent_name=agent_name,
+    )
 
     # ── Drain parent task evidence ────────────────────────
     # Notifications apply by task id, then spawn tool-use id, else park.

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -10315,3 +10315,149 @@ def test_hold_approval_wait_marker_refreshes_until_released(
     settled = len(touches)
     time.sleep(0.1)
     assert len(touches) == settled, "the refresher must stop when the block exits"
+
+
+_TASK_NOTIFICATION_TEXT = (
+    "<task-notification>\n"
+    "<task-id>a815d</task-id>\n"
+    "<tool-use-id>toolu_worker_1</tool-use-id>\n"
+    "<output-file>/private/tmp/worker.out</output-file>\n"
+    "<status>completed</status>\n"
+    '<summary>Agent "Explore spec" finished</summary>\n'
+    "<result>Final verified report.</result>\n"
+    "</task-notification>"
+)
+_TASK_NOTIFICATION_TS = "2026-09-10T13:23:13.274Z"
+
+
+def _notification_entry(
+    content: Any, *, uuid: str = "task-notification-1", queued: bool = False
+) -> dict[str, Any]:
+    """Build one transcript record carrying notification markup."""
+    if queued:
+        return {
+            "type": "attachment",
+            "uuid": uuid,
+            "timestamp": _TASK_NOTIFICATION_TS,
+            "attachment": {
+                "type": "queued_command",
+                "commandMode": "task-notification",
+                "prompt": content,
+            },
+        }
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "timestamp": _TASK_NOTIFICATION_TS,
+        "message": {"role": "user", "content": content},
+    }
+
+
+def _read_notifications(tmp_path: Path, rows: list[dict[str, Any]]) -> Any:
+    """Write rows to JSONL and read them back through the offset reader."""
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    return read_transcript_items_from_offset(
+        transcript_path, 0, start_line=0, agent_name="claude-native-ui"
+    )
+
+
+@pytest.mark.parametrize("envelope", ["string", "blocks", "queued"])
+def test_offset_reader_parses_task_notification_envelopes(tmp_path: Path, envelope: str) -> None:
+    """String, list-block, and queued-command envelopes parse identically."""
+    content: Any = (
+        [{"type": "text", "text": _TASK_NOTIFICATION_TEXT}]
+        if envelope == "blocks"
+        else _TASK_NOTIFICATION_TEXT
+    )
+    result = _read_notifications(
+        tmp_path, [_notification_entry(content, queued=envelope == "queued")]
+    )
+
+    assert len(result.task_notifications) == 1
+    notification = result.task_notifications[0]
+    assert notification.task_id == "a815d"
+    assert notification.tool_use_id == "toolu_worker_1"
+    assert notification.status == "completed"
+    assert notification.result == "Final verified report."
+    assert notification.timestamp == _TASK_NOTIFICATION_TS
+    # Parsing leaves conversation items untouched: user records stay a
+    # hidden meta bubble, queued deliveries stay item-less.
+    if envelope == "queued":
+        assert result.items == []
+    else:
+        assert [item.item_type for item in result.items] == ["message"]
+        assert result.items[0].data.get("is_meta") is True
+
+
+def test_offset_reader_dedupes_and_ignores_noise(tmp_path: Path) -> None:
+    """Repeats collapse; id-less markup and queue bookkeeping drop."""
+    entry = _notification_entry(_TASK_NOTIFICATION_TEXT)
+    no_ids = (
+        "<task-notification>\n<status>completed</status>\n"
+        "<result>Done</result>\n</task-notification>"
+    )
+    no_tool_use_id = {
+        "type": "user",
+        "uuid": "agent-result-noid",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "content": "output"}],
+        },
+        "toolUseResult": {"status": "completed"},
+    }
+    bookkeeping = {
+        "type": "queue-operation",
+        "operation": "enqueue",
+        "timestamp": _TASK_NOTIFICATION_TS,
+        "content": _TASK_NOTIFICATION_TEXT,
+    }
+    result = _read_notifications(
+        tmp_path, [entry, entry, _notification_entry(no_ids), no_tool_use_id, bookkeeping]
+    )
+
+    assert len(result.task_notifications) == 1
+
+
+def test_offset_reader_notification_result_falls_back_and_caps(
+    tmp_path: Path,
+) -> None:
+    """A failed stop keeps its summary; an oversized result is capped."""
+    failed = (
+        "<task-notification>\n<task-id>a815d</task-id>\n"
+        "<tool-use-id>toolu_worker_1</tool-use-id>\n"
+        "<status>failed</status>\n"
+        '<summary>Agent "Explore spec" finished</summary>\n'
+        "</task-notification>"
+    )
+    huge = (
+        "<task-notification>\n<task-id>a815d</task-id>\n"
+        "<tool-use-id>toolu_worker_2</tool-use-id>\n"
+        "<status>completed</status>\n"
+        f"<result>{'r' * 5000}</result>\n"
+        "</task-notification>"
+    )
+    rows = [
+        _notification_entry(text, uuid=f"task-notification-{index}")
+        for index, text in enumerate([failed, huge])
+    ]
+    result = _read_notifications(tmp_path, rows)
+
+    assert len(result.task_notifications) == 2
+    assert result.task_notifications[0].result == 'Agent "Explore spec" finished'
+    assert result.task_notifications[1].result == "r" * 4000
+
+
+def test_line_reader_parses_task_notifications(tmp_path: Path) -> None:
+    """The legacy line reader surfaces the same lifecycle records."""
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text(
+        json.dumps(_notification_entry(_TASK_NOTIFICATION_TEXT)) + "\n", encoding="utf-8"
+    )
+    result = claude_native_bridge.read_transcript_items_since_with_position(
+        transcript_path, 0, agent_name="claude-native-ui"
+    )
+
+    assert len(result.task_notifications) == 1
+    assert result.task_notifications[0].task_id == "a815d"
+    assert result.task_notifications[0].timestamp == _TASK_NOTIFICATION_TS

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -10390,6 +10390,67 @@ def test_offset_reader_parses_task_notification_envelopes(tmp_path: Path, envelo
         assert result.items[0].data.get("is_meta") is True
 
 
+def _tool_result_entry(tool_use_result: Any) -> dict[str, Any]:
+    """Build a user tool_result record with a top-level toolUseResult."""
+    return {
+        "type": "user",
+        "uuid": "agent-result-1",
+        "timestamp": _TASK_NOTIFICATION_TS,
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_agent_1",
+                    "content": "Final agent output",
+                }
+            ],
+        },
+        "toolUseResult": tool_use_result,
+    }
+
+
+@pytest.mark.parametrize(
+    ("tool_use_result", "task_id"),
+    [
+        ({"status": "completed", "agentId": "a15bfb83"}, "a15bfb83"),
+        ({"status": "completed"}, None),
+    ],
+)
+def test_offset_reader_parses_terminal_agent_tool_result(
+    tmp_path: Path, tool_use_result: Any, task_id: str | None
+) -> None:
+    """A foreground Agent result with terminal toolUseResult is evidence."""
+    result = _read_notifications(tmp_path, [_tool_result_entry(tool_use_result)])
+
+    assert len(result.task_notifications) == 1
+    notification = result.task_notifications[0]
+    assert notification.task_id == task_id
+    assert notification.tool_use_id == "toolu_agent_1"
+    assert notification.status == "completed"
+    assert notification.result == "Final agent output"
+    assert notification.timestamp == _TASK_NOTIFICATION_TS
+    assert [item.item_type for item in result.items] == ["function_call_output"]
+
+
+@pytest.mark.parametrize(
+    "tool_use_result",
+    [
+        {"status": "async_launched", "agentId": "a15bfb83"},
+        {"status": "running"},
+        {"stdout": "ok", "stderr": "", "interrupted": False},
+        "Error: Exit code 1",
+    ],
+)
+def test_offset_reader_ignores_nonterminal_tool_result(
+    tmp_path: Path, tool_use_result: Any
+) -> None:
+    """Launch, running, and non-Agent tool results are not lifecycle edges."""
+    result = _read_notifications(tmp_path, [_tool_result_entry(tool_use_result)])
+
+    assert result.task_notifications == ()
+
+
 def test_offset_reader_dedupes_and_ignores_noise(tmp_path: Path) -> None:
     """Repeats collapse; id-less markup and queue bookkeeping drop."""
     entry = _notification_entry(_TASK_NOTIFICATION_TEXT)
@@ -10461,3 +10522,25 @@ def test_line_reader_parses_task_notifications(tmp_path: Path) -> None:
     assert len(result.task_notifications) == 1
     assert result.task_notifications[0].task_id == "a815d"
     assert result.task_notifications[0].timestamp == _TASK_NOTIFICATION_TS
+
+
+def test_offset_reader_surfaces_coordinator_resume(tmp_path: Path) -> None:
+    """A coordinator resume record surfaces as one flagged user message."""
+    entry = {
+        "type": "user",
+        "isMeta": True,
+        "uuid": "resume-1",
+        "timestamp": _TASK_NOTIFICATION_TS,
+        "origin": {"kind": "coordinator"},
+        "message": {"role": "user", "content": "The coordinator sent a message: Keep going."},
+    }
+    result = _read_notifications(tmp_path, [entry])
+
+    assert len(result.items) == 1
+    item = result.items[0]
+    assert item.is_coordinator_resume is True
+    assert item.data == {
+        "role": "user",
+        "content": [{"type": "input_text", "text": "The coordinator sent a message: Keep going."}],
+    }
+    assert result.record_items[0].timestamp == _TASK_NOTIFICATION_TS

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -10327,6 +10327,8 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
 
 
 _RESUME_TS = "2026-09-10T13:23:13.274Z"
+_EVIDENCE_TS = "2026-09-10T13:22:05.710Z"
+_COORD_TEXT = "The coordinator sent a message while you were working: Keep going."
 
 
 def _terminal_row(
@@ -10639,6 +10641,32 @@ async def test_quiescence_edge_for_ungated_children(
     assert events == [event]
 
 
+def _child_row(uuid: str, text: str, ts: str, kind: str = "prompt") -> dict[str, Any]:
+    """Build one child row; kind selects the prompt/resume/assistant/meta shape."""
+    row: dict[str, Any] = {
+        "isSidechain": True,
+        "type": "assistant" if kind == "assistant" else "user",
+        "uuid": uuid,
+        "timestamp": ts,
+    }
+    if kind == "assistant":
+        row["message"] = {"role": "assistant", "content": [{"type": "text", "text": text}]}
+    else:
+        row["message"] = {"role": "user", "content": text}
+    if kind in ("resume", "meta"):
+        row["isMeta"] = True
+    if kind == "resume":
+        row["origin"] = {"kind": "coordinator"}
+    return row
+
+
+def _append_child_rows(child_jsonl: Path, rows: list[dict[str, Any]]) -> None:
+    """Append decoded rows to a child transcript."""
+    with child_jsonl.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
 def test_record_timestamp_ordering() -> None:
     """Record timestamps order by instant, never by raw string."""
     newer = "2026-09-10T13:23:13.274Z"
@@ -10649,3 +10677,71 @@ def test_record_timestamp_ordering() -> None:
     assert not forwarder._record_timestamp_is_newer(older, "2026-09-10T13:22:05.710000Z")
     assert not forwarder._record_timestamp_is_newer("not-a-timestamp", older)
     assert not forwarder._record_timestamp_is_newer(None, older)
+
+
+async def test_terminal_child_reopens_on_coordinator_resume(tmp_path: Path) -> None:
+    """A newer coordinator prompt reopens a child; new evidence closes it."""
+    transcript_path = tmp_path / "session.jsonl"
+    child_jsonl = _seed_worker(transcript_path, "a-worker", "toolu_A")
+    events: list[dict[str, Any]] = []
+    rows = [_terminal_row("a-worker", "toolu_A", "completed", "first done", _EVIDENCE_TS)]
+    state = await _tick_subagents(tmp_path, rows, events)
+    assert [e["status"] for e in events] == ["idle"]
+    _append_child_rows(
+        child_jsonl, [_child_row("resume-1", _COORD_TEXT, _RESUME_TS, kind="resume")]
+    )
+    state = await _tick_subagents(tmp_path, [], events, state)
+    assert [e["status"] for e in events] == ["idle", "running"]
+    assert events[1] == {"status": "running"}
+    assert state.subagents["a-worker"].terminal_status is None
+    assert state.subagents["a-worker"].last_status == "running"
+    rows = [
+        _terminal_row("a-worker", "toolu_C2", "completed", "second done", "2026-09-10T13:24:00Z")
+    ]
+    state = await _tick_subagents(tmp_path, rows, events, state)
+    assert [e["status"] for e in events] == ["idle", "running", "idle"]
+    assert events[2] == {"status": "idle", "output": "second done"}
+    assert state.subagents["a-worker"].terminal_status == "completed"
+
+
+async def test_terminal_child_ignores_non_resume_records(tmp_path: Path) -> None:
+    """Assistant output, meta bubbles, and stale prompts never reopen a child."""
+    transcript_path = tmp_path / "session.jsonl"
+    child_jsonl = _seed_worker(transcript_path, "a-worker", "toolu_A")
+    events: list[dict[str, Any]] = []
+    rows = [_terminal_row("a-worker", "toolu_A", "completed", "first done", _EVIDENCE_TS)]
+    state = await _tick_subagents(tmp_path, rows, events)
+    _append_child_rows(
+        child_jsonl,
+        [
+            _child_row("a1", "still thinking", _RESUME_TS, kind="assistant"),
+            _child_row("m1", "cli scaffolding", _RESUME_TS, kind="meta"),
+            _child_row("r1", _COORD_TEXT, "not-a-timestamp", kind="resume"),
+            _child_row("p1", "original spawn prompt", "2026-09-10T13:21:00.000Z"),
+        ],
+    )
+    state = await _tick_subagents(tmp_path, [], events, state)
+
+    assert [e["status"] for e in events] == ["idle"]
+    assert state.subagents["a-worker"].terminal_status == "completed"
+
+
+async def test_reopened_running_post_retries_after_failure(tmp_path: Path) -> None:
+    """A reopened child's failed running POST is retried on the next tick."""
+    transcript_path = tmp_path / "session.jsonl"
+    child_jsonl = _seed_worker(transcript_path, "a-worker", "toolu_A")
+    events: list[dict[str, Any]] = []
+    rows = [_terminal_row("a-worker", "toolu_A", "completed", "first done", _EVIDENCE_TS)]
+    state = await _tick_subagents(tmp_path, rows, events)
+    _append_child_rows(
+        child_jsonl, [_child_row("resume-1", _COORD_TEXT, _RESUME_TS, kind="resume")]
+    )
+    state = await _tick_subagents(tmp_path, [], events, state, fail_status_times=1)
+
+    assert [e["status"] for e in events] == ["idle"]
+    assert state.subagents["a-worker"].terminal_status is None
+    assert state.subagents["a-worker"].last_status is None
+    assert state.subagents["a-worker"].status_reconcile_pending is True
+    state = await _tick_subagents(tmp_path, [], events, state)
+
+    assert [e["status"] for e in events] == ["idle", "running"]

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -10323,3 +10323,15 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings, "the deadline trip must be loudly logged, never silent"
     # The warning's traceback names the stalled await for next-time forensics.
     assert stall_warnings[0].exc_info is not None
+
+
+def test_record_timestamp_ordering() -> None:
+    """Record timestamps order by instant, never by raw string."""
+    newer = "2026-09-10T13:23:13.274Z"
+    older = "2026-09-10T13:22:05.710Z"
+    assert forwarder._record_timestamp_is_newer(newer, older)
+    assert not forwarder._record_timestamp_is_newer(older, newer)
+    assert not forwarder._record_timestamp_is_newer("2026-09-10T13:22:05.710000Z", older)
+    assert not forwarder._record_timestamp_is_newer(older, "2026-09-10T13:22:05.710000Z")
+    assert not forwarder._record_timestamp_is_newer("not-a-timestamp", older)
+    assert not forwarder._record_timestamp_is_newer(None, older)

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -28,6 +28,7 @@ import omnigent.harnesses.claude_native.forwarder as forwarder
 from omnigent.harnesses.claude_native.bridge import (
     BRIDGE_ID_LABEL_KEY,
     ClaudeMessageDelta,
+    ClaudeTaskNotification,
     ClaudeTranscriptItem,
     TranscriptReadResult,
     TranscriptRecordItems,
@@ -10323,6 +10324,62 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings, "the deadline trip must be loudly logged, never silent"
     # The warning's traceback names the stalled await for next-time forensics.
     assert stall_warnings[0].exc_info is not None
+
+
+def _evidence(
+    task_id: str | None = None, tool_use_id: str | None = None, result: str = "r"
+) -> ClaudeTaskNotification:
+    """Build parsed terminal evidence without touching the transcript."""
+    return ClaudeTaskNotification(
+        task_id=task_id,
+        tool_use_id=tool_use_id,
+        status="completed",
+        result=result,
+        timestamp="2026-09-10T13:23:13.274Z",
+    )
+
+
+def test_apply_terminal_notification_match_order_and_parking() -> None:
+    """Evidence applies by task id, then tool-use id, else parks newer-wins."""
+    state = forwarder.SubagentForwardState(
+        subagents={
+            "a-worker": forwarder.SubagentEntry(
+                subagent_id="a-worker",
+                child_conversation_id="conv_a-worker",
+                tool_use_id="toolu_A",
+            )
+        }
+    )
+    empty = forwarder.SubagentForwardState(subagents={})
+
+    by_task = forwarder._apply_terminal_notification(state, _evidence("a-worker", "toolu_x"))
+    by_tool = forwarder._apply_terminal_notification(state, _evidence("unknown", "toolu_A"))
+    parked = forwarder._apply_terminal_notification(empty, _evidence("late", "toolu_C"))
+    newer = replace(_evidence("late", "toolu_C", "new"), timestamp="2026-09-10T13:24:00.000Z")
+    parked = forwarder._apply_terminal_notification(parked, newer)
+    stale = forwarder._apply_terminal_notification(parked, _evidence("late", "toolu_C", "old"))
+
+    assert by_task.subagents["a-worker"].terminal_status == "completed"
+    assert by_tool.subagents["a-worker"].terminal_status == "completed"
+    assert parked.pending_terminal_notifications == {
+        "late": ("completed", "new", "2026-09-10T13:24:00.000Z")
+    }
+    assert stale.pending_terminal_notifications == parked.pending_terminal_notifications
+
+
+def test_subagent_state_loads_old_format_rows(tmp_path: Path) -> None:
+    """State files written before the terminal fields still load."""
+    bridge_dir = tmp_path / "bridge"
+    bridge_dir.mkdir(parents=True, exist_ok=True)
+    row = {"subagents": {"a-worker": {"child_conversation_id": "conv_child"}}}
+    (bridge_dir / "subagent_forwarder.json").write_text(json.dumps(row), encoding="utf-8")
+
+    state = forwarder._read_subagent_forward_state(bridge_dir)
+
+    assert state.subagents["a-worker"].tool_use_id is None
+    assert state.subagents["a-worker"].terminal_status is None
+    assert state.parent_byte_offset == 0
+    assert state.pending_terminal_notifications == {}
 
 
 def test_record_timestamp_ordering() -> None:

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -10326,6 +10326,121 @@ async def test_forward_loop_deadline_unsticks_a_stalled_iteration(
     assert stall_warnings[0].exc_info is not None
 
 
+_RESUME_TS = "2026-09-10T13:23:13.274Z"
+
+
+def _terminal_row(
+    task_id: str,
+    tool_use_id: str,
+    status: str,
+    result: str | None = "notified result",
+    timestamp: str = _RESUME_TS,
+) -> dict[str, Any]:
+    """Build a parent user row carrying one terminal notification."""
+    result_tag = f"<result>{result}</result>\n" if result is not None else ""
+    return {
+        "type": "user",
+        "timestamp": timestamp,
+        "message": {
+            "role": "user",
+            "content": (
+                "<task-notification>\n"
+                f"<task-id>{task_id}</task-id>\n"
+                f"<tool-use-id>{tool_use_id}</tool-use-id>\n"
+                f"<status>{status}</status>\n{result_tag}</task-notification>"
+            ),
+        },
+    }
+
+
+def _seed_worker(
+    transcript_path: Path,
+    subagent_id: str,
+    tool_use_id: str,
+    spawn_transcript_path: Path | None = None,
+) -> Path:
+    """Seed one Explore child on disk reusing the shared spawn helper."""
+    return _seed_subagent_on_disk(
+        transcript_path=transcript_path,
+        subagent_id=subagent_id,
+        agent_type="Explore",
+        description="Trace the auth flow",
+        tool_use_id=tool_use_id,
+        spawn_transcript_path=spawn_transcript_path,
+    )
+
+
+async def _tick_subagents(
+    tmp_path: Path,
+    parent_rows: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+    state: forwarder.SubagentForwardState | None = None,
+    *,
+    fail_status_times: int = 0,
+) -> forwarder.SubagentForwardState:
+    """Append parent rows and run one sub-agent tick against a mock server."""
+    state = state or forwarder.SubagentForwardState(subagents={})
+    transcript_path = tmp_path / "session.jsonl"
+    if parent_rows:
+        with transcript_path.open("a", encoding="utf-8") as handle:
+            handle.writelines(json.dumps(row) + "\n" for row in parent_rows)
+    attempts = {"status": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if isinstance(body, list):
+            return httpx.Response(202, json=[{"item_id": f"item-{i}"} for i, _ in enumerate(body)])
+        if body.get("type") == "external_subagent_start":
+            sid = body["data"]["subagent_id"]
+            return httpx.Response(202, json={"queued": False, "child_session_id": f"conv_{sid}"})
+        if body.get("type") == "external_session_status":
+            attempts["status"] += 1
+            if attempts["status"] <= fail_status_times:
+                return httpx.Response(500, json={})
+            events.append(body["data"])
+        return httpx.Response(202, json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        return await forwarder._forward_available_subagents(
+            client=client,
+            parent_session_id="conv_parent",
+            bridge_dir=tmp_path / "bridge",
+            transcript_path=transcript_path,
+            state=state,
+            agent_name="claude-native-ui",
+            start_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            item_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+            status_retry_tracker=forwarder._PostRetryTracker(base_delay_s=0.0),
+        )
+
+
+@pytest.mark.parametrize(
+    ("status", "post_status", "output", "result_text"),
+    [
+        ("completed", "idle", "notified result", "notified result"),
+        ("failed", "failed", "notified result", "notified result"),
+        ("stopped", "failed", "notified result", "notified result"),
+        ("killed", "failed", forwarder._SUBAGENT_FAILED_NO_RESULT_OUTPUT, None),
+    ],
+)
+async def test_subagent_terminal_notification_posts_by_task_id(
+    tmp_path: Path, status: str, post_status: str, output: str, result_text: str | None
+) -> None:
+    """A notification takes a child terminal even with a new tool-use id."""
+    transcript_path = tmp_path / "session.jsonl"
+    _seed_worker(transcript_path, "a-worker", "toolu_A")
+    events: list[dict[str, Any]] = []
+    rows = [_terminal_row("a-worker", "toolu_B", status, result_text)]
+    state = await _tick_subagents(tmp_path, rows, events)
+
+    assert events == [{"status": post_status, "output": output}]
+    assert state.subagents["a-worker"].tool_use_id == "toolu_A"
+    assert state.subagents["a-worker"].terminal_status == status
+    assert state.pending_terminal_notifications == {}
+
+
 def _evidence(
     task_id: str | None = None, tool_use_id: str | None = None, result: str = "r"
 ) -> ClaudeTaskNotification:
@@ -10367,6 +10482,27 @@ def test_apply_terminal_notification_match_order_and_parking() -> None:
     assert stale.pending_terminal_notifications == parked.pending_terminal_notifications
 
 
+async def test_subagent_terminal_notification_parks_until_registration(
+    tmp_path: Path,
+) -> None:
+    """Evidence for an unknown child parks, then drains on registration."""
+    transcript_path = tmp_path / "session.jsonl"
+    (transcript_path.parent / "session" / "subagents").mkdir(parents=True, exist_ok=True)
+    events: list[dict[str, Any]] = []
+    rows = [_terminal_row("late-child", "toolu_C", "completed")]
+    state = await _tick_subagents(tmp_path, rows, events)
+
+    assert events == []
+    parked = state.pending_terminal_notifications
+    assert parked == {"late-child": ("completed", "notified result", "2026-09-10T13:23:13.274Z")}
+    _seed_worker(transcript_path, "late-child", "toolu_C")
+    state = await _tick_subagents(tmp_path, [], events, state)
+
+    assert events == [{"status": "idle", "output": "notified result"}]
+    assert state.pending_terminal_notifications == {}
+    assert state.subagents["late-child"].terminal_status == "completed"
+
+
 def test_subagent_state_loads_old_format_rows(tmp_path: Path) -> None:
     """State files written before the terminal fields still load."""
     bridge_dir = tmp_path / "bridge"
@@ -10380,6 +10516,127 @@ def test_subagent_state_loads_old_format_rows(tmp_path: Path) -> None:
     assert state.subagents["a-worker"].terminal_status is None
     assert state.parent_byte_offset == 0
     assert state.pending_terminal_notifications == {}
+
+
+async def test_subagent_terminal_status_post_retries_after_failure(
+    tmp_path: Path,
+) -> None:
+    """A failed terminal POST is retried on the next tick, exactly once."""
+    transcript_path = tmp_path / "session.jsonl"
+    _seed_worker(transcript_path, "a-worker", "toolu_A")
+    events: list[dict[str, Any]] = []
+    rows = [_terminal_row("a-worker", "toolu_A", "completed")]
+    state = await _tick_subagents(tmp_path, rows, events, fail_status_times=99)
+
+    assert events == []
+    assert state.subagents["a-worker"].last_status is None
+    state = await _tick_subagents(tmp_path, [], events, state)
+
+    assert events == [{"status": "idle", "output": "notified result"}]
+    assert state.subagents["a-worker"].last_status == "idle"
+
+
+async def test_subagent_registration_stores_tool_use_id_for_nested(
+    tmp_path: Path,
+) -> None:
+    """Nested children register with spawn ids under their live parent."""
+    transcript_path = tmp_path / "session.jsonl"
+    root_jsonl = _seed_worker(transcript_path, "root-child", "toolu_root")
+    _seed_worker(transcript_path, "nested-child", "toolu_nested", spawn_transcript_path=root_jsonl)
+    state = await _tick_subagents(tmp_path, [], [])
+
+    assert state.subagents["root-child"].tool_use_id == "toolu_root"
+    assert state.subagents["nested-child"].tool_use_id == "toolu_nested"
+
+
+def _child_text_row(uuid: str, text: str) -> dict[str, Any]:
+    """Build one assistant text row for a child transcript."""
+    return {
+        "isSidechain": True,
+        "type": "assistant",
+        "uuid": uuid,
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _backdate_all(state: forwarder.SubagentForwardState) -> forwarder.SubagentForwardState:
+    """Move every entry's activity timestamp into the quiet past."""
+    old = time.time() - 60.0
+    return replace(
+        state,
+        subagents={
+            sid: replace(entry, last_activity_ts=old) for sid, entry in state.subagents.items()
+        },
+    )
+
+
+async def test_root_child_stays_running_until_evidence(tmp_path: Path) -> None:
+    """A quiet root child posts nothing until its Task evidence arrives."""
+    transcript_path = tmp_path / "session.jsonl"
+    child_jsonl = _seed_worker(transcript_path, "a-worker", "toolu_A")
+    child_jsonl.write_text(json.dumps(_child_text_row("r1", "work")) + "\n", encoding="utf-8")
+    events: list[dict[str, Any]] = []
+    state = await _tick_subagents(tmp_path, [], events)
+    assert [e["status"] for e in events] == ["running"]
+    state = await _tick_subagents(tmp_path, [], events, _backdate_all(state))
+    assert [e["status"] for e in events] == ["running"]
+    rows = [_terminal_row("a-worker", "toolu_B", "completed")]
+    state = await _tick_subagents(tmp_path, rows, events, state)
+    assert [e["status"] for e in events] == ["running", "idle"]
+    state = await _tick_subagents(tmp_path, [], events, state)
+    assert [e["status"] for e in events] == ["running", "idle"]
+    assert state.subagents["a-worker"].last_status == "idle"
+
+
+async def test_nested_child_keeps_quiescence_idle(tmp_path: Path) -> None:
+    """A quiet nested child still goes idle without evidence."""
+    transcript_path = tmp_path / "session.jsonl"
+    root_jsonl = _seed_worker(transcript_path, "root-child", "toolu_root")
+    nested_jsonl = _seed_worker(transcript_path, "nested-child", "toolu_nested", root_jsonl)
+    nested_jsonl.write_text(json.dumps(_child_text_row("n1", "work")) + "\n", encoding="utf-8")
+    first: list[dict[str, Any]] = []
+    state = await _tick_subagents(tmp_path, [], first)
+    assert [e["status"] for e in first].count("running") == 2
+    events: list[dict[str, Any]] = []
+    state = await _tick_subagents(tmp_path, [], events, _backdate_all(state))
+
+    assert events == [{"status": "idle"}]
+
+
+@pytest.mark.parametrize(
+    ("delivery_error", "tool_use_id", "event"),
+    [
+        (
+            forwarder._SUBAGENT_DROPPED_ITEM_REASON,
+            "toolu_A",
+            {"status": "failed", "output": forwarder._SUBAGENT_DROPPED_ITEM_REASON},
+        ),
+        (None, None, {"status": "idle"}),
+    ],
+)
+async def test_quiescence_edge_for_ungated_children(
+    tmp_path: Path, delivery_error: str | None, tool_use_id: str | None, event: dict[str, Any]
+) -> None:
+    """Delivery errors and id-less entries keep today's quiescence edge."""
+    transcript_path = tmp_path / "session.jsonl"
+    child_jsonl = _seed_worker(transcript_path, "a-worker", "toolu_A")
+    child_jsonl.write_text(json.dumps(_child_text_row("r1", "work")) + "\n", encoding="utf-8")
+    state = forwarder.SubagentForwardState(
+        subagents={
+            "a-worker": forwarder.SubagentEntry(
+                subagent_id="a-worker",
+                child_conversation_id="conv_a-worker",
+                tool_use_id=tool_use_id,
+                byte_offset=child_jsonl.stat().st_size,
+                last_activity_ts=time.time() - 60.0,
+                delivery_error=delivery_error,
+            )
+        }
+    )
+    events: list[dict[str, Any]] = []
+    await _tick_subagents(tmp_path, [], events, state)
+
+    assert events == [event]
 
 
 def test_record_timestamp_ordering() -> None:

--- a/tests/test_claude_native_terminal_lifecycle.py
+++ b/tests/test_claude_native_terminal_lifecycle.py
@@ -1,0 +1,159 @@
+"""Lifecycle regressions across transcript order, retries and Host upgrades."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from omnigent.harnesses.claude_native import forwarder as f
+
+pytestmark = pytest.mark.asyncio
+T1, T2, T3 = ("2026-09-10T13:22:05.710Z", "2026-09-10T13:23:13.274Z", "2026-09-10T13:24:00Z")
+
+
+def _append(path: Path, *rows: dict) -> None:
+    with path.open("a", encoding="utf-8") as stream:
+        stream.writelines(json.dumps(row) + "\n" for row in rows)
+
+
+def _terminal(*, task="worker", tool="tool_spawn", timestamp=T1, output="first done") -> dict:
+    tool_tag = f"<tool-use-id>{tool}</tool-use-id>" if tool else ""
+    return {
+        "type": "user",
+        "timestamp": timestamp,
+        "message": {
+            "role": "user",
+            "content": (
+                f"<task-notification><task-id>{task}</task-id>{tool_tag}"
+                f"<status>completed</status><result>{output}</result></task-notification>"
+            ),
+        },
+    }
+
+
+class _Scene:
+    def __init__(self, path: Path):
+        self.parent = path / "parent.jsonl"
+        self.child = path / "parent/subagents/agent-worker.jsonl"
+        self.child.parent.mkdir(parents=True)
+        self.bridge = path / "bridge"
+        self.events: list[dict] = []
+        self.state = f.SubagentForwardState(subagents={})
+        _append(
+            self.parent,
+            {
+                "type": "assistant",
+                "uuid": "spawn",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tool_spawn",
+                            "name": "Agent",
+                            "input": {"description": "Lifecycle test"},
+                        }
+                    ],
+                },
+            },
+        )
+
+    def register(self):
+        self.child.touch(exist_ok=True)
+        self.child.with_suffix(".meta.json").write_text(
+            json.dumps(
+                {
+                    "agentType": "Explore",
+                    "description": "Lifecycle test",
+                    "toolUseId": "tool_spawn",
+                }
+            )
+        )
+
+    def reload(self, *, legacy=False):
+        if legacy:
+            state_file = self.bridge / "subagent_forwarder.json"
+            data = json.loads(state_file.read_text())
+            data.pop("terminal_evidence_version", None)
+            data.pop("pending_terminal_tool_use_ids", None)
+            data.pop("pending_terminal_parent_offsets", None)
+            for row in data["subagents"].values():
+                row.pop("resume_observed_at", None)
+                row.pop("status_reconcile_pending", None)
+                row.pop("terminal_evidence_pending", None)
+                row.pop("tool_use_id_pending", None)
+            state_file.write_text(json.dumps(data))
+        self.state = f._read_subagent_forward_state(self.bridge)
+
+    async def tick(self, *rows, fail_status=False, fail_items=False, replayed_items=False):
+        _append(self.parent, *rows)
+
+        def handle(request):
+            body = json.loads(request.content)
+            if isinstance(body, list):
+                if fail_items:
+                    return httpx.Response(500)
+                return httpx.Response(
+                    202,
+                    json=[
+                        {"item_id": f"item-{i}", "replayed": replayed_items}
+                        for i in range(len(body))
+                    ],
+                )
+            if body["type"] == "external_subagent_start":
+                return httpx.Response(
+                    202, json={"child_session_id": "conv_worker", "existing": False}
+                )
+            if body["type"] == "external_session_status":
+                if fail_status:
+                    return httpx.Response(500)
+                self.events.append(body["data"])
+            return httpx.Response(202, json={})
+
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handle), base_url="http://test"
+        ) as client:
+            self.state = await f._forward_available_subagents(
+                client=client,
+                parent_session_id="conv_parent",
+                bridge_dir=self.bridge,
+                transcript_path=self.parent,
+                state=self.state,
+                agent_name="claude-native-ui",
+                start_retry_tracker=f._PostRetryTracker(base_delay_s=0),
+                item_retry_tracker=f._PostRetryTracker(base_delay_s=0),
+                status_retry_tracker=f._PostRetryTracker(base_delay_s=0),
+            )
+
+    def assert_completed(self, output):
+        assert self.events, "The child completion must be published to the Server"
+        assert self.events[-1]["status"] in {"completed", "idle"}
+        assert self.events[-1]["output"] == output
+        assert self.state.subagents["worker"].terminal_status == "completed"
+
+
+@pytest.mark.parametrize("legacy", [False])
+async def test_parked_terminal_retains_fallback_across_registration_and_restart(tmp_path, legacy):
+    scene = _Scene(tmp_path)
+    await scene.tick(_terminal(task="external-task"))
+    scene.reload(legacy=legacy)
+    scene.register()
+    await scene.tick()
+    scene.assert_completed("first done")
+    assert not scene.state.pending_terminal_notifications
+
+
+@pytest.mark.parametrize("parked", [False, True])
+async def test_late_old_completion_cannot_replace_newer_result(tmp_path, parked):
+    scene = _Scene(tmp_path)
+    if not parked:
+        scene.register()
+    await scene.tick(_terminal(timestamp=T3, output="second done"), _terminal())
+    if parked:
+        scene.reload()
+        scene.register()
+        await scene.tick()
+    scene.assert_completed("second done")

--- a/tests/test_claude_native_terminal_lifecycle.py
+++ b/tests/test_claude_native_terminal_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -186,7 +187,7 @@ async def test_two_completed_runs_survive_one_parent_read(tmp_path, tool):
     scene.assert_completed("second done")
 
 
-@pytest.mark.parametrize("legacy", [False])
+@pytest.mark.parametrize("legacy", [False, True])
 async def test_parked_terminal_retains_fallback_across_registration_and_restart(tmp_path, legacy):
     scene = _Scene(tmp_path)
     await scene.tick(_terminal(task="external-task"))
@@ -195,6 +196,75 @@ async def test_parked_terminal_retains_fallback_across_registration_and_restart(
     await scene.tick()
     scene.assert_completed("first done")
     assert not scene.state.pending_terminal_notifications
+
+
+@pytest.mark.parametrize("later_completion", [False, True])
+async def test_host_upgrade_heals_consumed_legacy_evidence_without_new_records(
+    tmp_path, later_completion
+):
+    scene = _Scene(tmp_path)
+    scene.register()
+    await scene.tick(_terminal())
+    _append(scene.child, _resume())
+    if later_completion:
+        _append(scene.parent, _terminal(timestamp=T3, output="second done"))
+    entry = scene.state.subagents["worker"]
+    # State written by the previous Host after it consumed the resume and,
+    # optionally, lost the later completion through its old dedupe rule.
+    entry = replace(
+        entry,
+        byte_offset=scene.child.stat().st_size,
+        terminal_status=None if later_completion else entry.terminal_status,
+        terminal_observed_at=None if later_completion else entry.terminal_observed_at,
+        last_status="running" if later_completion else entry.last_status,
+    )
+    scene.state = replace(
+        scene.state, subagents={"worker": entry}, parent_byte_offset=scene.parent.stat().st_size
+    )
+    f._write_subagent_forward_state(scene.bridge, scene.state)
+    scene.reload(legacy=True)
+    scene.events.clear()
+    await scene.tick()
+    if later_completion:
+        scene.assert_completed("second done")
+    else:
+        # A consumed cursor alone cannot distinguish a new prompt from an
+        # acknowledged historical replay. Preserve the settled state.
+        assert scene.events == []
+        assert scene.state.subagents["worker"].terminal_status == "completed"
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+async def test_foreground_resumed_agent_completion_uses_stable_task_id(tmp_path, legacy):
+    scene = _Scene(tmp_path)
+    scene.register()
+    await scene.tick(_terminal())
+    _append(scene.child, _resume())
+    await scene.tick()
+    _append(
+        scene.parent,
+        {
+            "type": "user",
+            "uuid": "foreground-result",
+            "timestamp": T3,
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tool_resume", "content": "second done"}
+                ],
+            },
+            "toolUseResult": {"status": "completed", "agentId": "worker"},
+        },
+    )
+    if legacy:
+        scene.state = replace(scene.state, parent_byte_offset=scene.parent.stat().st_size)
+        f._write_subagent_forward_state(scene.bridge, scene.state)
+        scene.reload(legacy=True)
+    scene.events.clear()
+    await scene.tick()
+    scene.assert_completed("second done")
+    if legacy and scene.events[-1]["status"] == "completed":
+        assert scene.events[-1]["replayed"] is True
 
 
 @pytest.mark.parametrize("parked", [False, True])
@@ -208,3 +278,104 @@ async def test_late_old_completion_cannot_replace_newer_result(tmp_path, parked)
         scene.register()
         await scene.tick()
     scene.assert_completed("second done")
+
+
+@pytest.mark.parametrize("dropped", [False, True])
+async def test_upgrade_never_treats_an_unaccepted_prompt_as_a_resume(tmp_path, dropped):
+    scene = _Scene(tmp_path)
+    scene.register()
+    await scene.tick(_terminal())
+    _append(scene.child, _resume())
+    if dropped:
+        entry = scene.state.subagents["worker"]
+        scene.state = replace(
+            scene.state,
+            subagents={
+                "worker": replace(
+                    entry,
+                    byte_offset=scene.child.stat().st_size,
+                    delivery_error=f._SUBAGENT_DROPPED_ITEM_REASON,
+                )
+            },
+        )
+    f._write_subagent_forward_state(scene.bridge, scene.state)
+    scene.reload(legacy=True)
+    scene.events.clear()
+    await scene.tick(fail_items=True)
+    assert scene.state.subagents["worker"].terminal_status == "completed"
+    assert scene.state.subagents["worker"].resume_observed_at is None
+    assert all(event["status"] != "running" for event in scene.events)
+
+
+async def test_missing_old_peer_does_not_block_completion_recovery(tmp_path):
+    scene = _Scene(tmp_path)
+    scene.register()
+    _append(scene.child, _resume("2026-09-10T13:20:00Z"))
+    await scene.tick()
+    _append(scene.parent, _terminal(), _terminal(task="gone", tool="gone", output="gone done"))
+    gone = f.SubagentEntry(
+        subagent_id="gone", child_conversation_id="conv_gone", byte_offset=1, last_status="running"
+    )
+    scene.state = replace(
+        scene.state,
+        subagents={**scene.state.subagents, "gone": gone},
+        parent_byte_offset=scene.parent.stat().st_size,
+    )
+    f._write_subagent_forward_state(scene.bridge, scene.state)
+    scene.reload(legacy=True)
+    scene.events.clear()
+    await scene.tick()
+    scene.assert_completed("first done")
+    assert scene.state.subagents["gone"].terminal_evidence_pending
+    scene.reload()
+    (scene.child.parent / "agent-gone.jsonl").write_text("{}\n")
+    await scene.tick()
+    assert scene.state.subagents["gone"].terminal_status == "completed"
+    assert not scene.state.subagents["gone"].terminal_evidence_pending
+
+
+async def test_upgrade_retries_late_metadata_and_preserves_historical_delivery(tmp_path):
+    scene = _Scene(tmp_path)
+    scene.register()
+    _append(scene.child, _resume("2026-09-10T13:20:00Z"))
+    await scene.tick()
+    scene.child.with_suffix(".meta.json").unlink()
+    _append(scene.parent, _terminal(task="external-task"))
+    scene.state = replace(
+        scene.state,
+        subagents={"worker": replace(scene.state.subagents["worker"], tool_use_id=None)},
+        parent_byte_offset=scene.parent.stat().st_size,
+    )
+    f._write_subagent_forward_state(scene.bridge, scene.state)
+    scene.reload(legacy=True)
+    scene.events.clear()
+    await scene.tick()
+    scene.reload()
+    scene.register()
+    await scene.tick()
+    scene.assert_completed("first done")
+    if scene.events[-1]["status"] == "completed":
+        assert scene.events[-1]["replayed"] is True
+
+
+async def test_old_delivery_error_cannot_hide_a_later_accepted_resume(tmp_path):
+    scene = _Scene(tmp_path)
+    scene.register()
+    await scene.tick(_terminal())
+    scene.state = replace(
+        scene.state,
+        subagents={
+            "worker": replace(
+                scene.state.subagents["worker"], delivery_error=f._SUBAGENT_DROPPED_ITEM_REASON
+            )
+        },
+    )
+    _append(scene.child, _resume())
+    await scene.tick()
+    assert scene.events[-1]["status"] == "running"
+    scene.reload(legacy=True)
+    scene.events.clear()
+    await scene.tick()
+    assert scene.state.subagents["worker"].terminal_status is None
+    assert scene.state.subagents["worker"].last_status == "running"
+    assert scene.events == []

--- a/tests/test_claude_native_terminal_lifecycle.py
+++ b/tests/test_claude_native_terminal_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -31,6 +32,18 @@ def _terminal(*, task="worker", tool="tool_spawn", timestamp=T1, output="first d
                 f"<status>completed</status><result>{output}</result></task-notification>"
             ),
         },
+    }
+
+
+def _resume(timestamp=T2) -> dict:
+    return {
+        "type": "user",
+        "uuid": "resume",
+        "timestamp": timestamp,
+        "isSidechain": True,
+        "isMeta": True,
+        "origin": {"kind": "coordinator"},
+        "message": {"role": "user", "content": "Continue the next part."},
     }
 
 
@@ -133,6 +146,44 @@ class _Scene:
         assert self.events[-1]["status"] in {"completed", "idle"}
         assert self.events[-1]["output"] == output
         assert self.state.subagents["worker"].terminal_status == "completed"
+
+
+async def test_resume_running_retries_after_host_restart_and_long_pause(tmp_path):
+    scene = _Scene(tmp_path)
+    scene.register()
+    await scene.tick(_terminal())
+    _append(scene.child, _resume())
+    await scene.tick(fail_status=True)
+    scene.reload()
+    with patch.object(
+        f.time, "time", return_value=scene.state.subagents["worker"].last_activity_ts + 60
+    ):
+        await scene.tick()
+    assert scene.events[-1]["status"] == "running"
+
+
+@pytest.mark.parametrize("completion_already_seen", [True, False])
+async def test_older_completion_cannot_close_an_accepted_resume(tmp_path, completion_already_seen):
+    scene = _Scene(tmp_path)
+    scene.register()
+    await scene.tick(*([_terminal()] if completion_already_seen else []))
+    _append(scene.child, _resume())
+    await scene.tick()
+    scene.reload()
+    await scene.tick(_terminal())
+    assert scene.events[-1]["status"] == "running"
+    assert scene.state.subagents["worker"].terminal_status is None
+
+
+@pytest.mark.parametrize("tool", ["tool_spawn", None])
+async def test_two_completed_runs_survive_one_parent_read(tmp_path, tool):
+    scene = _Scene(tmp_path)
+    scene.register()
+    _append(scene.child, _resume())
+    await scene.tick(
+        _terminal(tool=tool), _terminal(tool=tool, timestamp=T3, output="second done")
+    )
+    scene.assert_completed("second done")
 
 
 @pytest.mark.parametrize("legacy", [False])


### PR DESCRIPTION
## Related issue

Part of #5687.

## Summary

Claude native children can finish while their mirrored status remains running when a completion is lost during deduplication, uses a resumed tool-call ID, or arrives before registration metadata. Preserve and correlate authoritative completion evidence, keep accepted resume order durable, and repair previously consumed parent evidence after a Host upgrade.

ELI5: A helper's newest finish receipt reaches the correct task, even after a continuation or restart; an old receipt cannot finish a newer round.

```text
parent completion -> task/spawn correlation -> durable child status
accepted continuation -> running -> newer completion
upgrade -> per-child old-evidence repair -> recovered terminal status
```

Full candidate commit: `a09eb6d173b621ee2e238ad12177b07051eb32d3`; reviewed tree: `8d1f3b00ef4f385eec6b841093eef3f65a92f1e5`; baseline: `6015548599baf6bfca9b129c21e8590ece7eccc3`.

This is one complete seven-layer review stack hosted in the fork. The upstream integration PR carries the exact full stack; it is not an additional incremental review layer.

| Layer | Scope | Incremental lines |
|---|---|---:|
| [L1](https://github.com/pandalaohe/omnigent/pull/9) | parse background task terminal evidence | +264/-0 = 264 |
| [L2](https://github.com/pandalaohe/omnigent/pull/10) | parse foreground results and resume prompts | +236/-1 = 237 |
| [L3](https://github.com/pandalaohe/omnigent/pull/11) | persist ordered sub-agent terminal evidence | +265/-4 = 269 |
| [L4](https://github.com/pandalaohe/omnigent/pull/12) | deliver terminal evidence after late registration | +265/-31 = 296 |
| [L5](https://github.com/pandalaohe/omnigent/pull/13) | wait for task evidence before completing root children | +266/-1 = 267 |
| [L6](https://github.com/pandalaohe/omnigent/pull/14) | preserve accepted resume order across retries | +201/-1 = 202 |
| [L7](https://github.com/pandalaohe/omnigent/pull/15) | repair consumed terminal evidence after upgrade | +260/-1 = 261 |

## Test Plan

- Full Claude bridge/forwarder/lifecycle suite on `6015548599baf6bfca9b129c21e8590ece7eccc3`: **590 passed**.
- All seven independently materialized prefixes passed their focused tests (40, 48, 50, 53, 64, 72, 82) and canonical pre-commit, including full-project Pyrefly.
- Lifecycle regressions cover stable task IDs with new tool IDs, same-read completions, late registration, old timestamps, status POST retry after restart, consumed-cursor upgrades, missing sibling files and delayed metadata.
- Two independent review executions identified lifecycle and migration defects; each finding was corrected and rechecked with a direct regression.

```sh
python -m pytest -q tests/test_claude_native_bridge.py tests/test_claude_native_forwarder.py tests/test_claude_native_terminal_lifecycle.py
```

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Synthetic JSONL transcripts and HTTP MockTransport exercise the lifecycle path. No real account, session transcript or Host deployment is included.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The upstream wire contract is preserved: completed maps to idle; failed/stopped/killed map to failed. This is the full seven-layer candidate (1794 aggregate lines), with no extra behavior beyond the review layers. #5834 addresses the separate quiescence-badge protocol; #7088 addresses Runner acknowledgement when a parent inbox is absent; #6393 owns Codex child inventory publication. Those broader contracts and real Host/Mac acceptance are not claimed here.

## Changelog

Claude native sub-agent completion stays associated with the correct task across resumes, late notifications and Host upgrades.
