### PR TITLE
fix(web): keep offline hosts selected in the new-session composer

### DIFF
--- a/tests/e2e_ui/start_session/test_start_session.py
+++ b/tests/e2e_ui/start_session/test_start_session.py
@@ -52,6 +52,7 @@ import threading
 from collections.abc import Coroutine
 from typing import Any
 
+import pytest
 from playwright.async_api import Request, Route, async_playwright, expect
 
 from tests.e2e_ui.start_session.helpers import (
@@ -1286,6 +1287,98 @@ async def _drive_remembers_last_picked_host(base_url: str, session_id: str) -> N
             )
             chip = page.get_by_test_id("new-chat-landing-host-chip")
             await expect(chip).to_have_attribute("aria-label", re.compile(beta_name))
+        finally:
+            await browser.close()
+
+
+@pytest.mark.parametrize("managed", [False, True], ids=["connected-host", "managed-sandbox"])
+def test_start_session_keeps_offline_host_selected(
+    seeded_session: tuple[str, str], managed: bool
+) -> None:
+    """An offline last pick stays selected and blocks sending until an explicit switch."""
+    base_url, session_id = seeded_session
+    _run_in_fresh_loop(_drive_keeps_offline_host_selected(base_url, session_id, managed))
+
+
+async def _drive_keeps_offline_host_selected(
+    base_url: str, session_id: str, managed: bool
+) -> None:
+    alpha_id, _alpha_name = _HOST_ALPHA
+    beta_id, beta_name = _HOST_BETA
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch()
+        page = await browser.new_page()
+        hosts = json.loads(_two_hosts_body())
+        try:
+            create_bodies: list[dict[str, Any]] = []
+            await _register_common_routes(
+                page, created_session_id=session_id, create_bodies=create_bodies
+            )
+
+            async def handle_hosts(route: Route) -> None:
+                await route.fulfill(json=hosts)
+
+            async def handle_info(route: Route) -> None:
+                await route.fulfill(
+                    status=200, content_type="application/json", body=_managed_info_body()
+                )
+
+            async def handle_agent_scan(route: Route) -> None:
+                await route.fulfill(json={"data": []})
+
+            await page.route("**/v1/hosts", handle_hosts)
+            await page.route(re.compile(r"/v1/sessions\?.*kind=any"), handle_agent_scan)
+            if managed:
+                await page.route("**/v1/info", handle_info)
+            await page.add_init_script(
+                f"""window.localStorage.setItem(
+                    "omnigent:recent-workspaces",
+                    JSON.stringify({{
+                        "{alpha_id}": ["/work/repo"],
+                        "{beta_id}": ["/work/repo"]
+                    }})
+                );"""
+            )
+
+            await page.goto(f"{base_url}/")
+            chip = page.get_by_test_id("new-chat-landing-host-chip")
+            await chip.click()
+            await page.get_by_test_id(f"new-chat-landing-host-{beta_id}").click()
+            await expect(chip).to_have_attribute("aria-label", f"Host: {beta_name}, Online")
+
+            # Reload without the in-memory draft after the chosen host disconnects.
+            hosts["hosts"][1]["status"] = "offline"
+            await page.reload()
+            await expect(chip).to_have_attribute("aria-label", f"Host: {beta_name}, Offline")
+            prompt = page.get_by_test_id("new-chat-landing-input")
+            await prompt.fill("Work on this repository")
+            await expect(page.get_by_test_id("new-chat-landing-workspace-chip")).to_have_attribute(
+                "aria-label", "Working directory: /work/repo"
+            )
+            submit = page.get_by_test_id("new-chat-landing-submit")
+            await expect(submit).to_be_disabled()
+            await prompt.press("Enter")
+            await chip.click()
+            await expect(
+                page.get_by_test_id(f"new-chat-landing-host-{beta_id}")
+            ).to_have_attribute("data-active", "true")
+            assert create_bodies == []
+
+            # Only an explicit destination change permits creation elsewhere.
+            replacement = (
+                "new-chat-landing-sandbox-option"
+                if managed
+                else f"new-chat-landing-host-{alpha_id}"
+            )
+            await page.get_by_test_id(replacement).click()
+            await expect(submit).to_be_enabled()
+            await submit.click()
+            await _wait_until(lambda: len(create_bodies) == 1)
+            if managed:
+                assert create_bodies[0]["host_type"] == "managed"
+                assert "host_id" not in create_bodies[0]
+            else:
+                assert create_bodies[0]["host_id"] == alpha_id
         finally:
             await browser.close()
 

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1528,6 +1528,68 @@ describe("NewChatLandingScreen", () => {
     );
   });
 
+  it.each([false, true])(
+    "restores an offline remembered host and requires an explicit switch (managed=%s)",
+    async (managedSandboxesEnabled) => {
+      localStorage.setItem("omnigent:last-host-choice", "host_2");
+      localStorage.setItem(
+        RECENT_KEY,
+        JSON.stringify({ host_1: ["/Users/corey/repo"], host_2: ["/work/repo"] }),
+      );
+      mockHosts([host("online", 1), host("offline", 2)]);
+      renderLanding({ managed_sandboxes_enabled: managedSandboxesEnabled });
+
+      const chip = screen.getByTestId("new-chat-landing-host-chip");
+      await waitFor(() => expect(chip).toHaveAccessibleName("Host: machine-2, Offline"));
+      const input = screen.getByTestId("new-chat-landing-input");
+      fireEvent.change(input, { target: { value: "Work on this repository" } });
+      expect(screen.getByTestId("new-chat-landing-workspace-chip")).toHaveAccessibleName(
+        "Working directory: /work/repo",
+      );
+      expect(screen.getByTestId("new-chat-landing-submit")).toBeDisabled();
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+      expect(authenticatedFetchMock).not.toHaveBeenCalled();
+      expect(localStorage.getItem("omnigent:last-host-choice")).toBe("host_2");
+
+      fireEvent.pointerDown(chip, { button: 0 });
+      expect(screen.getByTestId("new-chat-landing-host-host_2")).toHaveAttribute(
+        "data-active",
+        "true",
+      );
+      fireEvent.click(screen.getByTestId("new-chat-landing-host-host_1"));
+      await waitFor(() => expect(screen.getByTestId("new-chat-landing-submit")).toBeEnabled());
+      expect(localStorage.getItem("omnigent:last-host-choice")).toBe("host_1");
+    },
+  );
+
+  it.each(["offline", "missing"])(
+    "blocks creation when the selected host becomes %s and recovers when it returns",
+    async (availability) => {
+      localStorage.setItem("omnigent:last-host-choice", "host_1");
+      renderLanding();
+      const input = screen.getByTestId("new-chat-landing-input");
+      fireEvent.change(input, { target: { value: "Work on this repository" } });
+      const submit = screen.getByTestId("new-chat-landing-submit");
+      await waitFor(() => expect(submit).toBeEnabled());
+
+      mockHosts([host("online", 2), ...(availability === "offline" ? [host("offline", 1)] : [])]);
+      fireEvent.change(input, { target: { value: "Keep working on this repository" } });
+      expect(submit).toBeDisabled();
+      fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+      fireEvent.submit(screen.getByTestId("new-chat-landing-composer"));
+      expect(authenticatedFetchMock).not.toHaveBeenCalled();
+      expect(localStorage.getItem("omnigent:last-host-choice")).toBe("host_1");
+
+      mockHosts([host("online", 2), host("online", 1)]);
+      fireEvent.change(input, { target: { value: "Continue on the same host" } });
+      expect(submit).toBeEnabled();
+      expect(screen.getByTestId("new-chat-landing-host-chip")).toHaveAccessibleName(
+        "Host: machine-1, Online",
+      );
+    },
+  );
+
   it("uses a home-specific focus shadow without a resting shadow or focus border", () => {
     renderLanding();
 

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -3033,12 +3033,10 @@ export function NewChatLandingScreen() {
       }
       // Sandbox no longer offered (e.g. an OSS server) — fall through.
     } else if (lastChoice) {
-      // A persisted host pick can only be honored once the host list has
-      // loaded and shows it online. Wait for the load rather than defaulting
-      // past it — defaulting to the sandbox here would set sandboxSelected and
-      // this effect would then never re-run to restore the host.
+      // Restore offline hosts too; availability gates creation, not selection.
+      // Wait for the list so a remembered host cannot lose to a default.
       if (hostsLoading) return;
-      const stored = (hosts ?? []).find((h) => h.host_id === lastChoice && h.status === "online");
+      const stored = (hosts ?? []).find((h) => h.host_id === lastChoice);
       if (stored) {
         setSelectedHostId(stored.host_id);
         return;
@@ -4379,7 +4377,7 @@ export function NewChatLandingScreen() {
   const canSubmit =
     message.trim().length > 0 &&
     selectedAgent != null &&
-    (sandboxSelected ? sandboxRepoValid : !!selectedHostId && workspaceValid) &&
+    (sandboxSelected ? sandboxRepoValid : selectedHost?.status === "online" && workspaceValid) &&
     !creating;
 
   // Why submit is disabled, surfaced as the button's tooltip. Checked in the
@@ -4394,13 +4392,15 @@ export function NewChatLandingScreen() {
         } — remove the extras`
       : sandboxSelected && !sandboxRepoValid
         ? "Please enter a valid repository URL"
-        : !sandboxSelected && (!selectedHostId || !workspaceValid)
-          ? "Please choose a host and working directory"
-          : configuredAgentUnavailable && selectedAgent == null
-            ? "This project's configured agent is unavailable — pick an agent to continue"
-            : message.trim().length === 0
-              ? "Enter a message to get started"
-              : null;
+        : !sandboxSelected && selectedHostId && selectedHost?.status !== "online"
+          ? "Selected host is unavailable. Reconnect it or choose another host."
+          : !sandboxSelected && (!selectedHostId || !workspaceValid)
+            ? "Please choose a host and working directory"
+            : configuredAgentUnavailable && selectedAgent == null
+              ? "This project's configured agent is unavailable — pick an agent to continue"
+              : message.trim().length === 0
+                ? "Enter a message to get started"
+                : null;
 
   // Chip display labels.
   const worktreeHeader = composerWorktreeHeaderState({


### PR DESCRIPTION
## Related issue

N/A — follows up on #5598.

## Summary

An offline remembered host currently leaves the new-session picker on “Choose host.” Keep that host selected and display its offline status so users can see which machine they intended to use.

Require the selected host to be online before creating a session, including through Enter or form submission. This also blocks creation if the host disconnects or disappears while the user is drafting; reconnecting or explicitly choosing another destination restores submission.

## Test Plan

- Four new Vitest regressions pass: restoring an offline host in standalone and managed deployments, and blocking/recovering after an already-selected host goes offline or disappears. All four failed before the fix.
- Five Playwright tests pass: offline selection after reload and explicit switching to another host or a managed sandbox, plus existing remembered-host and host-list-gap coverage.
- `pnpm --dir web test src/shell/NewChatDialog.test.tsx src/shell/NewChatDialog.flow.test.tsx src/lib/hostPreferences.test.ts`: 433 passed, 2 failed. Both failures also reproduce on unchanged `main`: `renders the reference two-layer composer with one in-form control row` and `keeps compact host and working-directory controls accessibly named` expect “This machine” but receive “machine-1”.
- `pnpm --dir web build` and staged `pre-commit run` pass, including frontend lint, TypeScript, formatting, and Python test lint.
- Manual check: select a host, stop its host process, reload the new-session page, and enter a prompt. The host stays selected as offline and Start remains disabled. Reconnect or explicitly select another destination to enable Start.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Built UI with synthetic host data: the offline “Build VM” remains selected and Start is disabled, while the user can explicitly choose the online workstation or Databricks Sandbox.

Screenshot captured; attachment pending.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Browser tests cover reload persistence and the actual create request after an explicit destination switch. Unit tests additionally cover keyboard/form submission and recovery when the selected host returns. The demo was visually checked against the built frontend using synthetic API responses; no live host or sandbox was launched for the screenshot.

## Changelog

Your last selected host stays selected when offline, and new sessions wait for it to reconnect or for you to choose another destination.
