### PR TITLE
perf(claude-native): share one pane capture for permission-mode and /btw signals

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -4211,6 +4211,25 @@ class BtwOverlay:
     truncated: bool
 
 
+@dataclass(frozen=True)
+class PaneSignals:
+    """
+    The poll-time signals scraped from a single Claude pane capture.
+
+    Bundled so the forwarder reads the pane ONCE per poll and parses every
+    footer-derived signal from that one ``capture-pane`` subprocess, instead
+    of spawning a separate capture per signal.
+
+    :param permission_mode: The ``--permission-mode`` footer value, e.g.
+        ``"auto"``, or ``None`` when no mode footer is visible.
+    :param btw_overlay: A settled ``/btw`` side-chat overlay, or ``None``
+        when none is shown / it is still generating.
+    """
+
+    permission_mode: str | None = None
+    btw_overlay: BtwOverlay | None = None
+
+
 def _btw_overlay_from_pane(pane: str) -> BtwOverlay | None:
     """
     Parse a *completed* ``/btw`` side-chat overlay from a captured pane.
@@ -6498,6 +6517,34 @@ def read_btw_overlay(bridge_dir: Path) -> BtwOverlay | None:
     if not isinstance(socket_path, str) or not isinstance(tmux_target, str):
         return None
     return _btw_overlay_from_pane(_capture_pane(socket_path, tmux_target))
+
+
+def read_pane_signals(bridge_dir: Path) -> PaneSignals:
+    """
+    Read every poll-time footer signal from ONE Claude pane capture.
+
+    Non-blocking, best-effort, read-only. Captures the pane a single time
+    and parses both the permission-mode footer and any settled ``/btw``
+    overlay from it, so the forwarder spawns one ``capture-pane``
+    subprocess per poll rather than one per signal. Returns an empty
+    :class:`PaneSignals` when the terminal isn't up.
+
+    :param bridge_dir: Bridge directory path, e.g.
+        ``/tmp/omnigent/claude-native/<digest>``.
+    :returns: The parsed pane signals (fields ``None`` when absent).
+    """
+    payload = _read_json_file(bridge_dir / _TMUX_FILE)
+    if not isinstance(payload, dict):
+        return PaneSignals()
+    socket_path = payload.get("socket_path")
+    tmux_target = payload.get("tmux_target")
+    if not isinstance(socket_path, str) or not isinstance(tmux_target, str):
+        return PaneSignals()
+    pane = _capture_pane(socket_path, tmux_target)
+    return PaneSignals(
+        permission_mode=_permission_mode_from_pane(pane),
+        btw_overlay=_btw_overlay_from_pane(pane),
+    )
 
 
 def dismiss_btw_overlay(bridge_dir: Path) -> bool:

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -21,6 +21,7 @@ from omnigent.entities.session_resources import terminal_resource_id
 from omnigent.harnesses.claude_native.bridge import (
     BRIDGE_ID_LABEL_KEY,
     OBSERVER_HOOK_STDERR_FILE,
+    BtwOverlay,
     ClaudeHookRecord,
     ClaudeMessageDelta,
     ClaudeTranscriptItem,
@@ -29,13 +30,12 @@ from omnigent.harnesses.claude_native.bridge import (
     compute_transcript_cumulative_cost,
     read_active_session_id,
     read_bridge_id,
-    read_btw_overlay,
     read_claude_context_state,
     read_claude_session_id,
     read_hook_events_from_offset,
     read_hook_events_since_with_position,
     read_message_deltas_from_offset,
-    read_permission_mode,
+    read_pane_signals,
     read_transcript_items_from_offset,
     read_transcript_items_since_with_position,
     read_transcript_path,
@@ -113,15 +113,12 @@ def _subagent_id_from_meta_path(meta_path: Path) -> str:
 _DEFAULT_POLL_INTERVAL_S = 0.25
 _TRANSCRIPT_DISCOVERY_WARNING_S = 30.0
 _OBSERVER_HOOK_STDERR_READ_BYTES = 64 * 1024
-# Minimum spacing between permission-mode pane reads. Unlike the model mirror
-# (which reads a JSON file), this spawns a ``tmux capture-pane`` subprocess, so
-# it runs well below the poll interval; a mode switch is a human action and 2s
-# of lag is imperceptible.
-_PERMISSION_MODE_POLL_INTERVAL_S = 2.0
-# Minimum spacing between /btw overlay pane reads. Like the permission-mode
-# mirror this spawns a ``tmux capture-pane`` subprocess, and a side-chat is a
-# human action, so a ~1s cadence is ample without churning subprocesses.
-_BTW_OVERLAY_POLL_INTERVAL_S = 1.0
+# Minimum spacing between pane reads. One ``tmux capture-pane`` subprocess per
+# window feeds every footer-derived signal (permission mode + /btw overlay), so
+# the cost is one subprocess regardless of how many signals are parsed. Both
+# signals change only on a human action (shift+tab, a /btw), so 2s of lag is
+# imperceptible and keeps the subprocess rate low.
+_PANE_POLL_INTERVAL_S = 2.0
 # Bound on the per-session ring of already-relayed /btw exchange keys. The
 # overlay persists (and stacks history) across polls, so a handful of keys
 # covers a session's side chats while keeping the dedupe set small.
@@ -745,9 +742,10 @@ class _ForwardDedupeState:
     # mirrors the launch mode and any in-pane shift+tab switch, neither of
     # which the web UI can observe on its own.
     posted_permission_mode: str | None = None
-    # Monotonic deadline before which the next pane read is skipped, so the
-    # subprocess spawn runs at _PERMISSION_MODE_POLL_INTERVAL_S, not every poll.
-    permission_mode_next_read: float = 0.0
+    # Monotonic deadline before which the next pane capture is skipped, so the
+    # single ``capture-pane`` subprocess (feeding both the permission-mode and
+    # /btw signals) spawns at _PANE_POLL_INTERVAL_S, not every poll.
+    pane_next_read: float = 0.0
     # Turn-settle latch driving the scheduled-wake boundary. The Stop edge
     # records the ended turn's id as PENDING; it activates (moves to
     # ``settled_response_id``) only once a fully-consumed transcript batch
@@ -778,12 +776,11 @@ class _ForwardDedupeState:
     pending_compaction_dismiss_seq: int | None = None
     # /btw side-chat relay. The overlay is never persisted (transcript,
     # deltas and hooks are all empty for it), so it is scraped read-only from
-    # the pane. ``btw_next_read`` throttles the capture subprocess.
-    # ``posted_btw_keys`` rings the (question, answer) hashes already relayed
-    # so the persistent, history-stacking overlay isn't re-posted every poll.
-    # ``btw_pending_key`` requires the same exchange on two consecutive reads
-    # before posting, so a torn capture can't relay a partial answer.
-    btw_next_read: float = 0.0
+    # the shared pane capture. ``posted_btw_keys`` rings the (question, answer)
+    # hashes already relayed so the persistent, history-stacking overlay isn't
+    # re-posted every poll. ``btw_pending_key`` requires the same exchange on
+    # two consecutive reads before posting, so a torn capture can't relay a
+    # partial answer.
     btw_pending_key: str | None = None
     posted_btw_keys: dict[str, None] = field(default_factory=dict)
 
@@ -1355,18 +1352,12 @@ async def forward_claude_transcript_to_session(
                             bridge_dir=bridge_dir,
                             dedupe=dedupe,
                         )
-                        # Same rationale for the permission mode: a shift+tab in
-                        # the pane emits no event, so poll the footer.
-                        await _forward_permission_mode_from_pane(
-                            client=client,
-                            session_id=current_session_id,
-                            bridge_dir=bridge_dir,
-                            dedupe=dedupe,
-                        )
-                        # A /btw side-chat answers only in the pane overlay
-                        # (never the transcript/deltas/hooks), so scrape and
-                        # mirror the settled exchange into the web view.
-                        await _forward_btw_overlay_from_pane(
+                        # Footer-derived signals (permission mode, /btw overlay)
+                        # emit no event and live only in the rendered pane. One
+                        # throttled capture feeds both, so a shift+tab switch and
+                        # a settled /btw exchange both reach the web view without
+                        # spawning a capture-pane subprocess per signal.
+                        await _forward_pane_signals(
                             client=client,
                             session_id=current_session_id,
                             bridge_dir=bridge_dir,
@@ -5098,7 +5089,7 @@ async def _post_external_permission_mode_change(
     resp.raise_for_status()
 
 
-async def _forward_permission_mode_from_pane(
+async def _forward_pane_signals(
     client: httpx.AsyncClient,
     *,
     session_id: str,
@@ -5106,32 +5097,57 @@ async def _forward_permission_mode_from_pane(
     dedupe: _ForwardDedupeState,
 ) -> None:
     """
-    Mirror the pane's permission-mode footer to the session label each poll.
+    Capture the Claude pane ONCE per window and relay every footer signal.
 
-    A shift+tab pressed inside the TUI produces no event Omnigent can see, so
-    without this the web picker shows a stale mode until the next UI-driven
-    switch. Polling the footer is the only signal available: Claude Code emits
-    nothing on a mode change, and hook payloads only arrive on tool use.
-
-    The launch mode is posted too, not just later switches: a session started
-    in manual mode carries no ``--permission-mode`` arg and no mode label, so
-    with nothing posted the web picker has no mode to render and hides itself.
-    Best-effort and idempotent — the server ignores a mode equal to the stored
-    label, an unchanged mode or unreadable pane is a no-op, and a failed POST
-    is retried next poll.
+    Neither the permission mode nor a ``/btw`` side-chat is observable to
+    Omnigent through the transcript, deltas, or hooks — both live only in the
+    rendered pane. Rather than each spawning its own ``tmux capture-pane``
+    subprocess, this reads the pane a single time (throttled to
+    :data:`_PANE_POLL_INTERVAL_S`) and hands the one snapshot to each relay,
+    so the always-on cost is one subprocess per window regardless of how many
+    signals are parsed.
 
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
     :param bridge_dir: Native Claude bridge directory.
     :param dedupe: Shared per-session dedupe state; mutated in place.
     """
-    # Throttled: this spawns a tmux subprocess, unlike the file-backed model
-    # mirror that shares this poll loop.
     now = time.monotonic()
-    if now < dedupe.permission_mode_next_read:
+    if now < dedupe.pane_next_read:
         return
-    dedupe.permission_mode_next_read = now + _PERMISSION_MODE_POLL_INTERVAL_S
-    mode = await asyncio.to_thread(read_permission_mode, bridge_dir)
+    dedupe.pane_next_read = now + _PANE_POLL_INTERVAL_S
+    signals = await asyncio.to_thread(read_pane_signals, bridge_dir)
+    await _relay_permission_mode(
+        client, session_id=session_id, mode=signals.permission_mode, dedupe=dedupe
+    )
+    await _relay_btw_overlay(
+        client, session_id=session_id, overlay=signals.btw_overlay, dedupe=dedupe
+    )
+
+
+async def _relay_permission_mode(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    mode: str | None,
+    dedupe: _ForwardDedupeState,
+) -> None:
+    """
+    Mirror the pane's permission-mode footer to the session label.
+
+    A shift+tab pressed inside the TUI produces no event Omnigent can see, so
+    without this the web picker shows a stale mode until the next UI-driven
+    switch. The launch mode is posted too, not just later switches: a session
+    started in manual mode carries no ``--permission-mode`` arg and no mode
+    label, so with nothing posted the web picker has no mode to render and
+    hides itself. Best-effort and idempotent — an unchanged or unreadable
+    (``None``) mode is a no-op, and a failed POST is retried next poll.
+
+    :param client: Omnigent HTTP client.
+    :param session_id: Omnigent session/conversation id.
+    :param mode: The permission-mode footer parsed from the pane, or ``None``.
+    :param dedupe: Shared per-session dedupe state; mutated in place.
+    """
     if mode is None or mode == dedupe.posted_permission_mode:
         return
     try:
@@ -5152,11 +5168,11 @@ async def _forward_permission_mode_from_pane(
     dedupe.posted_permission_mode = mode
 
 
-async def _forward_btw_overlay_from_pane(
+async def _relay_btw_overlay(
     client: httpx.AsyncClient,
     *,
     session_id: str,
-    bridge_dir: Path,
+    overlay: BtwOverlay | None,
     dedupe: _ForwardDedupeState,
 ) -> None:
     """
@@ -5164,13 +5180,12 @@ async def _forward_btw_overlay_from_pane(
 
     ``/btw`` answers live only in the in-TUI overlay — never in the
     transcript, the message-deltas file, or a hook — so the transcript
-    forwarder relays nothing. This scrapes the settled overlay (read-only,
-    no keystrokes → no race with the executor's pane writes) and posts it as
-    a single TRANSIENT ``external_btw_sidechat`` event: the web UI shows the
-    ephemeral overlay (dismissed with Escape) and nothing is written to the
-    main transcript, faithful to ``/btw``'s side-chat nature. Both entry
-    points are covered: a ``/btw`` typed in the web composer or directly in
-    the embedded terminal.
+    forwarder relays nothing. Given the settled overlay scraped from the
+    shared pane capture, this posts it as a single TRANSIENT
+    ``external_btw_sidechat`` event: the web UI shows the ephemeral overlay
+    (dismissed with Escape) and nothing is written to the main transcript,
+    faithful to ``/btw``'s side-chat nature. Both entry points are covered:
+    a ``/btw`` typed in the web composer or directly in the embedded terminal.
 
     Best-effort: a long answer the pane clipped is relayed with the
     ``truncated`` flag set (the overlay points at the terminal for the full
@@ -5180,14 +5195,10 @@ async def _forward_btw_overlay_from_pane(
 
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
-    :param bridge_dir: Native Claude bridge directory.
+    :param overlay: The settled ``/btw`` overlay parsed from the pane, or
+        ``None`` when none is shown.
     :param dedupe: Shared per-session dedupe state; mutated in place.
     """
-    now = time.monotonic()
-    if now < dedupe.btw_next_read:
-        return
-    dedupe.btw_next_read = now + _BTW_OVERLAY_POLL_INTERVAL_S
-    overlay = await asyncio.to_thread(read_btw_overlay, bridge_dir)
     if overlay is None:
         dedupe.btw_pending_key = None
         return

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -4964,7 +4964,7 @@ def _publish_btw_sidechat(
     Publish a transient ``session.btw_sidechat`` overlay to the live stream.
 
     Emitted when the claude-native forwarder scrapes a settled ``/btw``
-    side-chat from the pane (see ``_forward_btw_overlay_from_pane`` in the
+    side-chat from the pane (see ``_relay_btw_overlay`` in the
     claude-native forwarder). Broadcast-only: nothing is written to the
     conversation store, so the ephemeral exchange never lands in the main
     transcript. Live viewers render a dismissable overlay; a client that

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -7910,10 +7910,11 @@ async def test_in_pane_permission_mode_switch_reaches_the_sse_wire_end_to_end(
     event type absent from the route's payload-validation passthrough 400s
     every POST, and one absent from ``ServerStreamEvent`` fails at the SSE
     boundary — both invisible to the forwarder, which logs post failures at
-    debug level. Drives ``_forward_permission_mode_from_pane`` itself rather
-    than a hand-rolled POST, so the mirror's own logic is on the path.
+    debug level. Drives ``_forward_pane_signals`` itself rather than a
+    hand-rolled POST, so the mirror's own logic is on the path.
     """
     from omnigent.harnesses.claude_native import forwarder as fwd
+    from omnigent.harnesses.claude_native.bridge import PaneSignals
     from tests.server.helpers import start_session_stream_collector
 
     agent = await create_test_agent(client)
@@ -7922,21 +7923,21 @@ async def test_in_pane_permission_mode_switch_reaches_the_sse_wire_end_to_end(
 
     pane_mode = "default"
 
-    def _fake_read(_bridge_dir: Any) -> str | None:
-        """Serve the pane footer the forwarder would capture via tmux."""
-        return pane_mode
+    def _fake_read(_bridge_dir: Any) -> PaneSignals:
+        """Serve the pane signals the forwarder would capture via tmux."""
+        return PaneSignals(permission_mode=pane_mode)
 
     dedupe = fwd._ForwardDedupeState()
     collector = await start_session_stream_collector(session_id)
     try:
         with (
-            patch.object(fwd, "read_permission_mode", _fake_read),
-            patch.object(fwd, "_PERMISSION_MODE_POLL_INTERVAL_S", 0.0),
+            patch.object(fwd, "read_pane_signals", _fake_read),
+            patch.object(fwd, "_PANE_POLL_INTERVAL_S", 0.0),
         ):
 
             async def _poll() -> None:
-                """Run one real permission-mode mirror pass against the server."""
-                await fwd._forward_permission_mode_from_pane(
+                """Run one real pane-signal mirror pass against the server."""
+                await fwd._forward_pane_signals(
                     client=client,
                     session_id=session_id,
                     bridge_dir=Path("/tmp/omnigent/claude-native/e2e"),

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -4147,34 +4147,17 @@ async def test_forwarder_retries_model_post_after_transient_failure(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_forwarder_mirrors_in_pane_permission_mode_switch(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_relay_permission_mode_mirrors_switch_and_dedupes() -> None:
     """
     Both the launch mode and a later shift+tab reach the session label.
 
-    Claude Code emits no event on a mode change, so the pane footer is polled.
-    The launch mode is posted as well: a manual-mode session has no mode label
-    and no launch flag, so skipping it would leave the web picker with nothing
-    to render. Repeat polls of an unchanged footer stay quiet.
+    Claude Code emits no event on a mode change, so the pane footer is
+    mirrored. The launch mode is posted as well: a manual-mode session has no
+    mode label and no launch flag, so skipping it would leave the web picker
+    with nothing to render. An unchanged footer stays quiet, and a footerless
+    (``None``) read must not post a reversal.
     """
-    bridge_dir = tmp_path / "bridge"
-    pane_mode: str | None = "default"
-    reads = 0
-
-    def _fake_read(_bridge_dir: Path) -> str | None:
-        """Serve the pane's current mode, counting each capture."""
-        nonlocal reads
-        reads += 1
-        return pane_mode
-
-    monkeypatch.setattr(forwarder, "read_permission_mode", _fake_read)
-    # Reads are throttled off a monotonic deadline; zero the interval so each
-    # call in this test performs a capture instead of returning early.
-    monkeypatch.setattr(forwarder, "_PERMISSION_MODE_POLL_INTERVAL_S", 0.0)
     dedupe = forwarder._ForwardDedupeState()
-
     posts: list[dict[str, Any]] = []
 
     def _handle_request(request: httpx.Request) -> httpx.Response:
@@ -4185,61 +4168,51 @@ async def test_forwarder_mirrors_in_pane_permission_mode_switch(
     transport = httpx.MockTransport(_handle_request)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
 
-        async def _poll() -> None:
-            """Run one permission-mode mirror pass."""
-            await forwarder._forward_permission_mode_from_pane(
-                client=client,
+        async def _relay(mode: str | None) -> None:
+            """Run one permission-mode relay pass for the given pane mode."""
+            await forwarder._relay_permission_mode(
+                client,
                 session_id="conv_abc",
-                bridge_dir=bridge_dir,
+                mode=mode,
                 dedupe=dedupe,
             )
 
-        # Poll 1: the launch mode is posted, so the picker has a mode to show.
-        await _poll()
+        # The launch mode is posted, so the picker has a mode to show.
+        await _relay("default")
         assert [p["type"] for p in posts] == ["external_permission_mode_change"]
         assert posts[0]["data"] == {"permission_mode": "default"}
         assert dedupe.posted_permission_mode == "default"
 
-        # Poll 2: unchanged footer is a no-op, not a repeat POST.
-        await _poll()
+        # Unchanged footer is a no-op, not a repeat POST.
+        await _relay("default")
         assert len(posts) == 1
 
-        # Poll 3: the user presses shift+tab into auto mode.
-        pane_mode = "auto"
-        await _poll()
+        # The user presses shift+tab into auto mode.
+        await _relay("auto")
         assert posts[-1]["data"] == {"permission_mode": "auto"}
         assert dedupe.posted_permission_mode == "auto"
 
-        # Poll 4: still auto — the switch isn't re-posted every poll.
-        await _poll()
+        # Still auto — the switch isn't re-posted every poll.
+        await _relay("auto")
         assert len(posts) == 2
 
         # A footerless pane reads as unknown and must not post a reversal.
-        pane_mode = None
-        await _poll()
+        await _relay(None)
         assert len(posts) == 2
         assert dedupe.posted_permission_mode == "auto"
-    assert reads == 5
 
 
 @pytest.mark.asyncio
-async def test_forwarder_posts_manual_launch_mode_so_picker_renders(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_relay_permission_mode_posts_manual_launch_mode() -> None:
     """
     A manual-mode launch publishes a mode, keeping the picker reachable.
 
     Manual is the default, and launching into it writes no
     ``--permission-mode`` arg and no mode label, leaving the pane footer as the
-    only source. The first poll must post it: with no mode stored the web
+    only source. The first relay must post it: with no mode stored the web
     picker hides itself, and manual becomes a state no one can switch out of.
     """
-    bridge_dir = tmp_path / "bridge"
-    monkeypatch.setattr(forwarder, "read_permission_mode", lambda _bridge_dir: "default")
-    monkeypatch.setattr(forwarder, "_PERMISSION_MODE_POLL_INTERVAL_S", 0.0)
     dedupe = forwarder._ForwardDedupeState()
-
     posts: list[dict[str, Any]] = []
 
     def _handle_request(request: httpx.Request) -> httpx.Response:
@@ -4249,10 +4222,10 @@ async def test_forwarder_posts_manual_launch_mode_so_picker_renders(
 
     transport = httpx.MockTransport(_handle_request)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        await forwarder._forward_permission_mode_from_pane(
-            client=client,
+        await forwarder._relay_permission_mode(
+            client,
             session_id="conv_abc",
-            bridge_dir=bridge_dir,
+            mode="default",
             dedupe=dedupe,
         )
 
@@ -4263,10 +4236,7 @@ async def test_forwarder_posts_manual_launch_mode_so_picker_renders(
 
 
 @pytest.mark.asyncio
-async def test_forwarder_retries_permission_mode_post_after_transient_failure(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_relay_permission_mode_retries_after_transient_failure() -> None:
     """
     A failed mode POST is retried, so the switch isn't silently dropped.
 
@@ -4274,16 +4244,7 @@ async def test_forwarder_retries_permission_mode_post_after_transient_failure(
     advanced the baseline, the web picker would stay stale until the user
     switched modes again.
     """
-    pane_mode = "default"
-
-    def _fake_read(_bridge_dir: Path) -> str | None:
-        """Serve the pane's current mode."""
-        return pane_mode
-
-    monkeypatch.setattr(forwarder, "read_permission_mode", _fake_read)
-    monkeypatch.setattr(forwarder, "_PERMISSION_MODE_POLL_INTERVAL_S", 0.0)
     dedupe = forwarder._ForwardDedupeState()
-
     posts: list[dict[str, Any]] = []
     fail_modes = {"plan"}
 
@@ -4300,65 +4261,29 @@ async def test_forwarder_retries_permission_mode_post_after_transient_failure(
     transport = httpx.MockTransport(_handle_request)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
 
-        async def _poll() -> None:
-            """Run one permission-mode mirror pass."""
-            await forwarder._forward_permission_mode_from_pane(
-                client=client,
+        async def _relay(mode: str | None) -> None:
+            """Run one permission-mode relay pass for the given pane mode."""
+            await forwarder._relay_permission_mode(
+                client,
                 session_id="conv_abc",
-                bridge_dir=tmp_path / "bridge",
+                mode=mode,
                 dedupe=dedupe,
             )
 
-        await _poll()  # the launch mode lands
+        await _relay("default")  # the launch mode lands
         assert dedupe.posted_permission_mode == "default"
 
-        pane_mode = "plan"
-        await _poll()
+        await _relay("plan")
         assert len(posts) == 2
         assert dedupe.posted_permission_mode == "default"  # NOT advanced — POST failed
 
-        await _poll()
+        await _relay("plan")
         assert [p["data"] for p in posts] == [
             {"permission_mode": "default"},
             {"permission_mode": "plan"},
             {"permission_mode": "plan"},
         ]
         assert dedupe.posted_permission_mode == "plan"  # now committed
-
-
-@pytest.mark.asyncio
-async def test_forwarder_throttles_permission_mode_pane_reads(tmp_path: Path) -> None:
-    """
-    Pane reads are spaced by the throttle, not run on every poll.
-
-    Unlike the file-backed model mirror sharing this loop, each read spawns a
-    ``tmux capture-pane`` subprocess. The poll loop is far tighter than the
-    throttle, so an unthrottled read would spawn processes continuously for a
-    signal that only changes when a human presses shift+tab.
-    """
-    reads = 0
-
-    def _fake_read(_bridge_dir: Path) -> str | None:
-        """Count captures; the mode itself is irrelevant here."""
-        nonlocal reads
-        reads += 1
-        return "default"
-
-    with patch.object(forwarder, "read_permission_mode", _fake_read):
-        dedupe = forwarder._ForwardDedupeState()
-        transport = httpx.MockTransport(lambda _req: httpx.Response(202, json={}))
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-            for _ in range(5):
-                await forwarder._forward_permission_mode_from_pane(
-                    client=client,
-                    session_id="conv_abc",
-                    bridge_dir=tmp_path / "bridge",
-                    dedupe=dedupe,
-                )
-
-    # Five back-to-back polls inside one throttle window capture once.
-    assert reads == 1
-    assert dedupe.permission_mode_next_read > 0.0
 
 
 def test_validated_transcript_state_resets_legacy_byte_cursor_without_fingerprint(
@@ -10347,30 +10272,24 @@ def _btw_recording_client_calls() -> tuple[list[dict[str, Any]], httpx.MockTrans
 
 
 @pytest.mark.asyncio
-async def test_forward_btw_overlay_relays_after_stability_then_dedupes(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+async def test_relay_btw_overlay_relays_after_stability_then_dedupes() -> None:
     """
     A settled /btw overlay relays ONE transient side-chat event.
 
-    The first poll only records the exchange as pending (torn-capture
-    guard); the second poll (same exchange) posts the transient
-    ``external_btw_sidechat`` event; the third poll is deduped and posts
-    nothing.
+    The first read only records the exchange as pending (torn-capture
+    guard); the second (same exchange) posts the transient
+    ``external_btw_sidechat`` event; the third is deduped and posts nothing.
     """
     overlay = BtwOverlay(question="/btw is this ok?", answer="Yes, all good.", truncated=False)
-    monkeypatch.setattr(forwarder, "read_btw_overlay", lambda _bridge_dir: overlay)
     dedupe = forwarder._ForwardDedupeState()
     calls, transport = _btw_recording_client_calls()
 
     async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
         for _ in range(3):
-            dedupe.btw_next_read = 0.0  # bypass the per-poll throttle
-            await forwarder._forward_btw_overlay_from_pane(
+            await forwarder._relay_btw_overlay(
                 client,
                 session_id="conv1",
-                bridge_dir=tmp_path,
+                overlay=overlay,
                 dedupe=dedupe,
             )
 
@@ -10383,23 +10302,18 @@ async def test_forward_btw_overlay_relays_after_stability_then_dedupes(
 
 
 @pytest.mark.asyncio
-async def test_forward_btw_overlay_relays_truncated_flag(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+async def test_relay_btw_overlay_relays_truncated_flag() -> None:
     """A clipped overlay relays the visible answer with truncated=True."""
     overlay = BtwOverlay(question="/btw big", answer="line1\nline2", truncated=True)
-    monkeypatch.setattr(forwarder, "read_btw_overlay", lambda _bridge_dir: overlay)
     dedupe = forwarder._ForwardDedupeState()
     calls, transport = _btw_recording_client_calls()
 
     async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
         for _ in range(2):
-            dedupe.btw_next_read = 0.0
-            await forwarder._forward_btw_overlay_from_pane(
+            await forwarder._relay_btw_overlay(
                 client,
                 session_id="conv1",
-                bridge_dir=tmp_path,
+                overlay=overlay,
                 dedupe=dedupe,
             )
 
@@ -10409,24 +10323,92 @@ async def test_forward_btw_overlay_relays_truncated_flag(
 
 
 @pytest.mark.asyncio
-async def test_forward_btw_overlay_no_overlay_is_noop(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+async def test_relay_btw_overlay_no_overlay_is_noop() -> None:
     """No visible overlay posts nothing and clears any pending key."""
-    monkeypatch.setattr(forwarder, "read_btw_overlay", lambda _bridge_dir: None)
     dedupe = forwarder._ForwardDedupeState()
     dedupe.btw_pending_key = "stale"
     calls, transport = _btw_recording_client_calls()
 
     async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
-        dedupe.btw_next_read = 0.0
-        await forwarder._forward_btw_overlay_from_pane(
+        await forwarder._relay_btw_overlay(
             client,
             session_id="conv1",
-            bridge_dir=tmp_path,
+            overlay=None,
             dedupe=dedupe,
         )
 
     assert calls == []
     assert dedupe.btw_pending_key is None
+
+
+@pytest.mark.asyncio
+async def test_forward_pane_signals_captures_once_and_relays_both(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """
+    One throttled capture feeds both the permission-mode and /btw relays.
+
+    Back-to-back polls inside one throttle window capture the pane exactly
+    once (the shared-capture win), and the single snapshot's mode + settled
+    overlay both reach the wire (the overlay after its two-read stability
+    guard).
+    """
+    from omnigent.harnesses.claude_native.bridge import PaneSignals
+
+    overlay = BtwOverlay(question="/btw ok?", answer="Yes.", truncated=False)
+    reads = 0
+
+    def _fake_signals(_bridge_dir: Path) -> PaneSignals:
+        """Serve one snapshot carrying both signals, counting captures."""
+        nonlocal reads
+        reads += 1
+        return PaneSignals(permission_mode="auto", btw_overlay=overlay)
+
+    monkeypatch.setattr(forwarder, "read_pane_signals", _fake_signals)
+    monkeypatch.setattr(forwarder, "_PANE_POLL_INTERVAL_S", 0.0)
+    dedupe = forwarder._ForwardDedupeState()
+    calls, transport = _btw_recording_client_calls()
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+        for _ in range(3):
+            await forwarder._forward_pane_signals(
+                client,
+                session_id="conv1",
+                bridge_dir=tmp_path,
+                dedupe=dedupe,
+            )
+
+    types = [c["type"] for c in calls]
+    assert types.count("external_permission_mode_change") == 1
+    assert types.count("external_btw_sidechat") == 1
+    assert dedupe.posted_permission_mode == "auto"
+
+
+@pytest.mark.asyncio
+async def test_forward_pane_signals_throttles_capture(tmp_path: Path) -> None:
+    """Back-to-back polls inside one throttle window capture the pane once."""
+    from omnigent.harnesses.claude_native.bridge import PaneSignals
+
+    reads = 0
+
+    def _fake_signals(_bridge_dir: Path) -> PaneSignals:
+        """Count captures; the signals themselves are irrelevant here."""
+        nonlocal reads
+        reads += 1
+        return PaneSignals()
+
+    with patch.object(forwarder, "read_pane_signals", _fake_signals):
+        dedupe = forwarder._ForwardDedupeState()
+        transport = httpx.MockTransport(lambda _req: httpx.Response(202, json={}))
+        async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+            for _ in range(5):
+                await forwarder._forward_pane_signals(
+                    client,
+                    session_id="conv1",
+                    bridge_dir=tmp_path,
+                    dedupe=dedupe,
+                )
+
+    assert reads == 1
+    assert dedupe.pane_next_read > 0.0


### PR DESCRIPTION
## Related issue

Follow-up to #6931 (Linear OMNI-5911). That PR merged before this perf refactor was pushed to the branch, so it lands separately here.

## Summary

Follow-up to the `/btw` transient-overlay work (#6931): remove the extra always-on pane-capture the `/btw` relay added.

Before this, the `/btw` overlay poll spawned its own `tmux capture-pane` subprocess every second, on top of the permission-mode poll's own 2s capture — doubling the always-on subprocess rate per claude-native session even when `/btw` is never used.

Now the forwarder captures the pane **once per throttled window** and parses every footer-derived signal from that single snapshot:

- `bridge.py`: add `PaneSignals` + `read_pane_signals()` — one `capture-pane` → `{permission_mode, btw_overlay}`.
- `forwarder.py`: replace `_forward_permission_mode_from_pane` / `_forward_btw_overlay_from_pane` (each captured + throttled independently) with `_forward_pane_signals` (one throttled capture) delegating to pure `_relay_permission_mode` / `_relay_btw_overlay` helpers. Collapse the two `*_next_read` deadlines and the two poll intervals into one `pane_next_read` / `_PANE_POLL_INTERVAL_S` (2s).

Net: `/btw` adds **zero** extra subprocesses/network at idle; the always-on cost is one `capture-pane` every 2s per session (what permission-mode already cost). Both terminal- and web-initiated `/btw` entry points keep working — no coverage lost.

## Test Plan

- `python -m pytest tests/test_claude_native_forwarder.py tests/test_claude_native_bridge.py -q` — full modules pass (553 in the pair locally). Rewrote the permission-mode and `/btw` forwarder tests to drive the new pure relay helpers, added a shared-capture orchestrator test asserting one capture across 5 back-to-back polls, and a `_forward_pane_signals` throttle test.
- `tests/server/integration/test_sessions_endpoints.py::test_in_pane_permission_mode_switch_reaches_the_sse_wire_end_to_end` — updated to drive `_forward_pane_signals` via a mocked `read_pane_signals`; still crosses the real SSE wire. Passes.
- `ruff` clean on the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Backend-only (forwarder/bridge + tests); no web change. `/btw` behavior is functionally identical — the only observable difference is the forwarder doing one pane capture per 2s window instead of two on separate cadences.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The permission-mode and `/btw` relay logic is now unit-tested through the pure `_relay_*` helpers; the single-capture-feeds-both behavior and the throttle are covered by dedicated `_forward_pane_signals` tests; the end-to-end SSE path stays covered by the updated integration test.

## Changelog

`/btw` no longer adds a per-second pane-capture subprocess — the permission-mode and `/btw` signals now share one capture per poll window
