### PR TITLE
perf(web): trim AppShell re-renders during streaming

### DIFF
--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -426,7 +426,12 @@ export function AppShell() {
   const agentTerminal = useMemo(() => findAgentTerminal(terminals), [terminals]);
 
   const debugMode = useDebugMode();
-  const { data: conversationsData, isLoading: conversationsLoading } = useConversations("", true);
+  // Restrict the observer to the fields AppShell actually reads: the 30s
+  // refetchInterval otherwise re-renders this whole shell on every background
+  // `isFetching`/`dataUpdatedAt` flap even when the list is unchanged.
+  const { data: conversationsData, isLoading: conversationsLoading } = useConversations("", true, {
+    notifyOnChangeProps: ["data", "isLoading"],
+  });
   const optimisticConversationTitle = useOptimisticTitle(conversationId ?? "");
   // Surface sessions needing attention as OS notifications + a dock badge.
   // Mounted here (inside the Router) so it can navigate on click and knows
@@ -494,7 +499,10 @@ export function AppShell() {
   // snapshot carries ``omnigent.ui``/``omnigent.wrapper`` — without
   // this merge an added claude-native agent loses its terminal-first
   // toggle. Snapshot wins on conflict; spreading undefined is a no-op.
-  const sessionLabels = { ...activeConv?.labels, ...activeSession?.labels };
+  const sessionLabels = useMemo(
+    () => ({ ...activeConv?.labels, ...activeSession?.labels }),
+    [activeConv?.labels, activeSession?.labels],
+  );
   const terminalFirst = sessionLabels["omnigent.ui"] === "terminal";
   const isClaudeNative = sessionLabels["omnigent.wrapper"] === "claude-code-native-ui";
   // Native-CLI wrapper of either family. Keys harness behavior gates


### PR DESCRIPTION
## Related issue

<!-- Refactor / chore: no issue required. -->

Closes #

## Summary

AppShell re-executes its entire render body on every chatStore streaming tick — it subscribes to `status`, which churns per SSE frame. Two cheap, behaviour-preserving cuts to that hot path:

- **Memoize `sessionLabels`** (`AppShell.tsx`): the `{ ...activeConv?.labels, ...activeSession?.labels }` spread — which gates the terminal-first / claude-native JSX branches — was rebuilt on every render. Now `useMemo`'d on its two inputs.
- **Scope the `useConversations` observer** to `notifyOnChangeProps: ["data", "isLoading"]`, the only fields AppShell reads from that call. Its 30s `refetchInterval` otherwise re-renders the whole shell on every background `isFetching`/`dataUpdatedAt` flap even when the list is unchanged.

`WorkspacePanel` is already `memo`'d (and `liveness` is identity-stabilized), so this shields nothing new in its subtree — it cuts AppShell's *own* render frequency while a session is streaming. No behaviour change.

Found while investigating slow rapid conversation-switching with the WorkspacePanel open. Static profiling showed the data layer and switch path (`switchTo` keeps outgoing streams live, transcript virtualized, panels memo'd) are already well-optimized; these two were the remaining cheap wins in the shell's render frequency.

## Test Plan

- `cd web && npx vitest run src/shell/AppShell.test.tsx` — 126 tests pass.
- `npx tsc --noEmit` — clean for AppShell.
- Manual: switch between conversations while an agent streams; the shell behaves identically (terminal-first detection, conversation list, workspace panel all unchanged), with fewer background re-renders.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change

No visual change: this only reduces how often the shell re-renders. See Test Plan.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

No new tests: both changes are pure render-frequency optimizations with no behavioural surface. The existing `AppShell.test.tsx` suite (126 tests, covering terminal-first detection, conversation list wiring, workspace-panel gating — all of which read `sessionLabels` and `conversationsData`) passes unchanged, confirming the memoization and observer-scoping don't alter what AppShell computes or renders. Manually verified switching during an active stream is visually identical.

## Changelog

Reduce unnecessary re-renders of the chat shell while a session is streaming

This pull request and its description were written by Isaac.