### PR TITLE
fix(claude-native): follow CLAUDE_CONFIG_DIR instead of ~/.claude

### DIFF
--- a/omnigent/claude_paths.py
+++ b/omnigent/claude_paths.py
@@ -1,0 +1,34 @@
+"""Where the Claude CLI keeps its per-user files.
+
+``CLAUDE_CONFIG_DIR`` selects a Claude profile. Anything Omnigent reads or writes
+on Claude's behalf has to follow the same choice, or it lands in the wrong profile.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _configured_dir() -> Path | None:
+    configured = os.environ.get("CLAUDE_CONFIG_DIR")
+    return Path(configured).expanduser() if configured else None
+
+
+def claude_config_dir() -> Path:
+    """Return Claude's config dir: ``$CLAUDE_CONFIG_DIR`` when set, else ``~/.claude``.
+
+    :returns: The directory holding ``settings.json``, ``projects/`` and ``sessions/``.
+    """
+    return _configured_dir() or Path.home() / ".claude"
+
+
+def claude_json_path() -> Path:
+    """Return Claude's user-scope config file.
+
+    It lives inside ``$CLAUDE_CONFIG_DIR`` when that is set, and otherwise in the
+    home directory beside ``~/.claude`` rather than inside it.
+
+    :returns: ``$CLAUDE_CONFIG_DIR/.claude.json`` or ``~/.claude.json``.
+    """
+    return (_configured_dir() or Path.home()) / ".claude.json"

--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -56,6 +56,7 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib import request
 
 from omnigent._platform import is_wsl, stable_user_id
+from omnigent.claude_paths import claude_config_dir, claude_json_path
 from omnigent.harnesses.claude_native.message_display_hook import MESSAGE_DELTAS_FILE
 from omnigent.harnesses.claude_native.status import CONTEXT_RAW_FILE
 from omnigent.harnesses.kiro_native.bridge import bridge_root as kiro_bridge_root
@@ -141,7 +142,6 @@ _TOOL_RELAY_ENV_FILE = "tool_relay.env"
 _TMUX_FILE = "tmux.json"
 _PERMISSION_HOOK_FILE = "permission_hook.json"
 _CONTEXT_FILE = "context.json"
-_USER_CLAUDE_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 _MCP_SERVER_NAME = "omnigent"
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 # Tools-changed: harness POSTs to the bridge MCP server's localhost
@@ -1508,7 +1508,7 @@ def ensure_claude_workspace_trusted(workspace: Path) -> None:
 
     Claude Code blocks on two TUI prompts the first time it launches in
     a new context: a global onboarding flow (theme / login) gated by the
-    top-level ``hasCompletedOnboarding`` key in ``~/.claude.json``, and a
+    top-level ``hasCompletedOnboarding`` key in Claude's ``.claude.json``, and a
     per-directory "Do you trust the files in this folder?" dialog gated
     by ``projects["<abs cwd>"].hasTrustDialogAccepted``. Neither fires a
     ``PermissionRequest`` hook, so on a host-spawned (web-UI-driven)
@@ -1518,7 +1518,7 @@ def ensure_claude_workspace_trusted(workspace: Path) -> None:
     therefore untrusted — directory on every session.
 
     Seed both gating keys idempotently so the launch never blocks. Only
-    those two keys are written; all other ``~/.claude.json`` state (the
+    those two keys are written; all other ``.claude.json`` state (the
     user's own onboarding choices, project history, MCP config, OAuth
     account) is preserved, and the file is left untouched when both keys
     are already set. This deliberately does NOT skip per-tool permission
@@ -1537,14 +1537,14 @@ def ensure_claude_workspace_trusted(workspace: Path) -> None:
         ``Path("/home/user/repo-worktrees/feature-x")``. Resolved to an
         absolute path to match Claude's ``projects`` key convention.
     :returns: None.
-    :raises ValueError: If an existing ``~/.claude.json`` (or its
+    :raises ValueError: If an existing ``.claude.json`` (or its
         ``projects`` map / target project entry) is not a JSON object.
         Surfaced rather than silently overwritten so a corrupt or
         unexpected user config is never clobbered (fail loud).
-    :raises json.JSONDecodeError: If an existing ``~/.claude.json`` is
+    :raises json.JSONDecodeError: If an existing ``.claude.json`` is
         not valid JSON, for the same reason.
     """
-    config_path = Path.home() / ".claude.json"
+    config_path = claude_json_path()
     if config_path.exists():
         data = json.loads(config_path.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
@@ -6603,6 +6603,11 @@ def read_claude_status_model(bridge_dir: Path) -> str | None:
     return model if isinstance(model, str) and model else None
 
 
+def _user_claude_settings_path() -> Path:
+    """Return the user's Claude Code ``settings.json`` for the active profile."""
+    return claude_config_dir() / "settings.json"
+
+
 def read_user_status_line_command() -> str | None:
     """
     Return the user's globally-configured statusLine shell command, if any.
@@ -6613,11 +6618,11 @@ def read_user_status_line_command() -> str | None:
     to whatever they had configured globally.
 
     :returns: The command string from
-        ``~/.claude/settings.json``'s ``statusLine.command``, or
+        the user's ``settings.json``'s ``statusLine.command``, or
         ``None`` when no global statusLine is configured / readable.
     """
     try:
-        raw = _USER_CLAUDE_SETTINGS_PATH.read_text(encoding="utf-8")
+        raw = _user_claude_settings_path().read_text(encoding="utf-8")
     except OSError:
         return None
     try:
@@ -6639,14 +6644,14 @@ def read_user_effort_level() -> str | None:
     """
     Return the user's configured Claude Code effort level, if any.
 
-    Read client-side from ``effortLevel`` in ``~/.claude/settings.json`` —
+    Read client-side from ``effortLevel`` in the user's ``settings.json`` —
     the level the wrapped ``claude`` actually runs at (we pass no ``--effort``).
 
     :returns: A recognized effort, e.g. ``"medium"``; ``None`` when unset,
         unreadable, or not a valid Claude effort (fail-soft, never blocks launch).
     """
     try:
-        raw = _USER_CLAUDE_SETTINGS_PATH.read_text(encoding="utf-8")
+        raw = _user_claude_settings_path().read_text(encoding="utf-8")
     except OSError:
         return None
     try:

--- a/omnigent/harnesses/claude_native/main.py
+++ b/omnigent/harnesses/claude_native/main.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import uuid
 
+from omnigent.claude_paths import claude_config_dir
 from omnigent.llms.adapters._content import redact_binary_payloads
 from omnigent.runtime.tool_result_replay import (
     blocks_from_parsed_list,
@@ -265,7 +266,6 @@ _SESSION_LABELS = {
     "omnigent.ui": "terminal",
     _WRAPPER_LABEL_KEY: _WRAPPER_LABEL_VALUE,
 }
-_CLAUDE_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 # Test override for the managed-settings chain. ``None`` means "use the ambient
 # detector's chain" — the single canonical definition (``ambient`` owns both the
 # path list and the parser). Binding a *copy* here would create a second source
@@ -2288,7 +2288,7 @@ def _redirect_claude_transcript_to_current_project(
     if source is None:
         raise click.ClickException(
             f"Claude transcript {external_session_id!r} was not found under "
-            f"{_CLAUDE_PROJECTS_DIR}."
+            f"{_claude_projects_dir()}."
         )
     target_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     tmp = target.with_suffix(".jsonl.tmp")
@@ -2531,6 +2531,11 @@ def _clone_claude_transcript(
     return target
 
 
+def _claude_projects_dir() -> Path:
+    """Return the directory Claude Code writes session transcripts under."""
+    return claude_config_dir() / "projects"
+
+
 def _find_claude_transcript(
     external_session_id: str, *, exclude: Path | None = None
 ) -> Path | None:
@@ -2545,12 +2550,13 @@ def _find_claude_transcript(
     """
     if not _CLAUDE_SESSION_ID_RE.fullmatch(external_session_id):
         return None
-    if not _CLAUDE_PROJECTS_DIR.is_dir():
+    projects_dir = _claude_projects_dir()
+    if not projects_dir.is_dir():
         return None
     matches: list[Path] = []
     filename = f"{external_session_id}.jsonl"
     excluded = exclude.resolve() if exclude is not None else None
-    for project_dir in _CLAUDE_PROJECTS_DIR.iterdir():
+    for project_dir in projects_dir.iterdir():
         if not project_dir.is_dir():
             continue
         candidate = project_dir / filename
@@ -2566,14 +2572,14 @@ def _claude_project_dir_for_cwd(cwd: Path) -> Path:
     """
     Return Claude's project transcript directory for *cwd*.
 
-    Claude Code stores transcripts under
-    ``~/.claude/projects/<sanitized-cwd>/``. The observed sanitizer
+    Claude Code stores transcripts under ``projects/<sanitized-cwd>/`` in
+    its config dir. The observed sanitizer
     replaces non-alphanumeric path characters with ``-``.
 
     :param cwd: Absolute cwd, e.g. ``Path("/home/me/repo")``.
     :returns: Claude project transcript directory.
     """
-    return _CLAUDE_PROJECTS_DIR / _sanitize_claude_project_name(str(cwd))
+    return _claude_projects_dir() / _sanitize_claude_project_name(str(cwd))
 
 
 def _sanitize_claude_project_name(path: str) -> str:

--- a/omnigent/harnesses/claude_native/status_file.py
+++ b/omnigent/harnesses/claude_native/status_file.py
@@ -28,11 +28,12 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+
+from omnigent.claude_paths import claude_config_dir
 
 _logger = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ def sessions_dir(config_dir: Path | None = None) -> Path:
     """Return Claude Code's ``sessions`` directory.
 
     Mirrors Claude's own resolution: ``CLAUDE_CONFIG_DIR`` when set,
-    otherwise ``~/.claude`` — matching :mod:`omnigent.session_import.local`.
+    otherwise ``~/.claude``.
 
     :param config_dir: Explicit Claude config dir override (tests). When
         ``None`` the environment / home default is used.
@@ -109,9 +110,7 @@ def sessions_dir(config_dir: Path | None = None) -> Path:
     """
     if config_dir is not None:
         return config_dir / "sessions"
-    configured = os.environ.get("CLAUDE_CONFIG_DIR")
-    home = Path(configured).expanduser() if configured else Path.home() / ".claude"
-    return home / "sessions"
+    return claude_config_dir() / "sessions"
 
 
 def _read_json_file(path: Path) -> dict[str, object] | None:

--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -584,6 +584,10 @@ _RUNNER_ENV_ALLOWLIST: frozenset[str] = frozenset(
         # which turns off MCP tool search and loads every tool schema eagerly.
         "CLAUDE_CODE_USE_GATEWAY",
         "ENABLE_TOOL_SEARCH",
+        # Claude Code's profile selector: a directory path, not a secret, same class
+        # as KUBECONFIG. Without it a background host's claude-native panes run on
+        # the default ~/.claude profile instead of the one the user selected.
+        "CLAUDE_CONFIG_DIR",
         # Kubernetes config path. A filesystem path (typically
         # ``~/.kube/config``), not a bearer secret — the file *contains*
         # cluster certs/tokens but the env var is just a path string,

--- a/omnigent/inner/claude_sdk_executor.py
+++ b/omnigent/inner/claude_sdk_executor.py
@@ -43,6 +43,7 @@ from types import ModuleType
 from typing import Any, NamedTuple, Protocol, TypeAlias, cast
 
 from omnigent._platform import resolve_cli_binary, stable_user_id
+from omnigent.claude_paths import claude_config_dir, claude_json_path
 from omnigent.cli_invocation import cli_invocation
 from omnigent.databricks_ai_gateway import is_databricks_ai_gateway_url
 from omnigent.inner import _proc
@@ -1261,11 +1262,12 @@ def _parse_optional_int(value: str | None) -> int | None:
 def _claude_internal_write_roots() -> list[pathlib.Path]:
     """Writable roots the Claude CLI needs for its own local session state."""
 
+    claude_dir = claude_config_dir()
     roots = [
-        pathlib.Path.home() / ".claude" / "backups",
-        pathlib.Path.home() / ".claude" / "plugins",
-        pathlib.Path.home() / ".claude" / "session-env",
-        pathlib.Path.home() / ".claude" / "sessions",
+        claude_dir / "backups",
+        claude_dir / "plugins",
+        claude_dir / "session-env",
+        claude_dir / "sessions",
         pathlib.Path.home() / ".npm" / "_logs",
         pathlib.Path(tempfile.gettempdir()) / f"claude-{stable_user_id()}",
     ]
@@ -1278,10 +1280,7 @@ def _claude_internal_write_files() -> list[pathlib.Path]:
     """Exact files the Claude CLI updates outside its writable roots."""
 
     # .credentials.json holds the Claude CLI's OAuth token on Linux.
-    candidates = [
-        pathlib.Path.home() / ".claude.json",
-        pathlib.Path.home() / ".claude" / ".credentials.json",
-    ]
+    candidates = [claude_json_path(), claude_config_dir() / ".credentials.json"]
     return [path for path in candidates if path.exists()]
 
 

--- a/omnigent/install_ledger.py
+++ b/omnigent/install_ledger.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import NotRequired, TypedDict, cast
 
+from omnigent.claude_paths import claude_json_path
 from omnigent.util.json_types import JsonObject as _JsonObject
 
 SCHEMA_VERSION = 1
@@ -462,7 +463,7 @@ def observed_external_configs(*, deep: bool) -> list[ExternalConfigEntry]:
     candidates = [
         (cwd / ".cursor" / "mcp.json", "mcpServers.omnigent", "json"),
         (cwd / ".kiro" / "settings" / "mcp.json", "mcpServers.omnigent", "json"),
-        (Path.home() / ".claude.json", "mcpServers.omnigent", "json"),
+        (claude_json_path(), "mcpServers.omnigent", "json"),
         (Path.home() / ".codex" / "config.toml", "mcp_servers.omnigent", "toml"),
     ]
     entries: list[ExternalConfigEntry] = []

--- a/omnigent/session_import/local.py
+++ b/omnigent/session_import/local.py
@@ -12,6 +12,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import get_args
 
+from omnigent.claude_paths import claude_config_dir
 from omnigent.entities import NewConversationItem, parse_item_data
 from omnigent.harnesses.claude_native.bridge import (
     ClaudeTranscriptItem,
@@ -207,9 +208,7 @@ def _recent_local_sessions_with_recency(
 ) -> list[tuple[str, float]]:
     """List recent ``(session_id, recency)`` pairs for one local harness, newest first."""
     if source == "claude":
-        configured_home = os.environ.get("CLAUDE_CONFIG_DIR")
-        home = Path(configured_home).expanduser() if configured_home else Path.home() / ".claude"
-        root = home / "projects"
+        root = claude_config_dir() / "projects"
         candidates = [
             (path, path.stem)
             for path in root.rglob("*.jsonl")
@@ -421,9 +420,7 @@ def load_claude_session(
     claude_home: Path | None = None,
 ) -> LocalSessionImport:
     """Load one Claude Code parent session from its local JSONL transcript."""
-    configured_home = os.environ.get("CLAUDE_CONFIG_DIR")
-    home = claude_home or (Path(configured_home).expanduser() if configured_home else None)
-    root = (home or Path.home() / ".claude") / "projects"
+    root = (claude_home or claude_config_dir()) / "projects"
     transcript_path = _find_transcript(root, session_id)
     if transcript_path is None:
         raise SessionImportNotFoundError(f"Claude Code session {session_id!r} was not found")

--- a/tests/cli/test_host_daemon_env.py
+++ b/tests/cli/test_host_daemon_env.py
@@ -307,3 +307,46 @@ def test_runner_env_preserves_claude_telemetry_opt_in() -> None:
     # Then
     assert env.get("OTEL_METRICS_EXPORTER") == "otlp"
     assert env.get("CLAUDE_CODE_ENABLE_TELEMETRY") == "1"
+
+
+@pytest.mark.parametrize("server_url", [None, _REMOTE_SERVER_URL])
+def test_host_daemon_env_preserves_claude_config_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    server_url: str | None,
+) -> None:
+    """Claude's profile selector survives the CLI→daemon strip in both modes.
+
+    Without it the detached daemon's claude-native panes run on the default
+    ``~/.claude`` profile instead of the one the user selected.
+    """
+    # Given
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/profiles/work")
+
+    # When
+    env = _build_host_daemon_env(server_url=server_url)
+
+    # Then
+    assert env.get("CLAUDE_CONFIG_DIR") == "/profiles/work"
+
+
+def test_runner_env_preserves_claude_config_dir() -> None:
+    """Claude's profile selector survives the daemon→runner strip.
+
+    The runner env is what the claude-native pane inherits, so a drop here puts
+    the session on the default profile.
+    """
+    # Given
+    base_env = {"PATH": "/usr/bin", "CLAUDE_CONFIG_DIR": "/profiles/work"}
+
+    # When
+    env = _build_runner_env(
+        base_env,
+        server_url=_REMOTE_SERVER_URL,
+        runner_id="runner_claude_profile",
+        binding_token="binding-claude-profile",
+        workspace="/tmp/workspace",
+        parent_pid=12345,
+    )
+
+    # Then
+    assert env.get("CLAUDE_CONFIG_DIR") == "/profiles/work"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,6 +353,19 @@ def _isolate_claude_native_state(
 
 
 @pytest.fixture(autouse=True)
+def _isolate_claude_config_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep a developer's ``CLAUDE_CONFIG_DIR`` out of tests.
+
+    Omnigent resolves Claude's home from it, which would bypass the tmp ``$HOME``
+    tests use to redirect ``~/.claude``. Tests that need a profile set it themselves.
+
+    :param monkeypatch: Pytest monkeypatch fixture; restores the env at teardown.
+    :returns: None.
+    """
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_codex_native_state(
     tmp_path_factory: pytest.TempPathFactory,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/e2e/test_claude_native_config_dir_e2e.py
+++ b/tests/e2e/test_claude_native_config_dir_e2e.py
@@ -1,0 +1,462 @@
+"""E2E regression test: claude-native must honor ``CLAUDE_CONFIG_DIR``.
+
+Reproduces the user-reported bug: a user keeps a second, logged-in Claude
+Code profile under ``CLAUDE_CONFIG_DIR`` (e.g. a work account), exports it,
+and starts ``omni host`` from that shell. When they then start a Claude Code
+(claude-native) session from the web UI, the session silently runs on the
+**default** ``~/.claude`` profile instead:
+
+* the host->runner environment strip (``_RUNNER_ENV_ALLOWLIST`` in
+  ``omnigent/host/connect.py``, and the CLI->daemon allowlist in
+  ``omnigent/cli.py``) drops ``CLAUDE_CONFIG_DIR``, so the pane's ``claude``
+  process launches without it and uses the default ``~/.claude`` account;
+* workspace trust / onboarding pre-accept is seeded into ``~/.claude.json``
+  (``ensure_claude_workspace_trusted`` hard-codes ``Path.home()``) instead of
+  ``$CLAUDE_CONFIG_DIR/.claude.json``, so the exported profile never sees the
+  folder as trusted;
+* the per-session ``--settings`` file chains the user's ``statusLine`` from
+  the hard-coded ``~/.claude/settings.json`` (``_USER_CLAUDE_SETTINGS_PATH``)
+  instead of the exported profile's ``settings.json``.
+
+This test drives the REAL user journey end to end: a real ``omnigent
+server`` subprocess, a real host daemon subprocess started with
+``CLAUDE_CONFIG_DIR`` exported (exactly the reporter's shell), a real runner
+spawned by that host, and a claude-native session created the web-UI way
+(built-in ``claude-native-ui`` agent + ``host_id`` + workspace) whose
+terminal the runner auto-creates.
+
+The Claude CLI itself is replaced with a tiny stub that records the
+environment and argv of every invocation and parks, so the test needs no
+Claude login. Everything upstream of the stub — the daemon/runner env
+construction, the trust-file write, and the settings composition — is the
+product's own behavior.
+
+Desired behavior (asserted): the pane's ``claude`` receives the exported
+``CLAUDE_CONFIG_DIR``, workspace trust lands in
+``$CLAUDE_CONFIG_DIR/.claude.json``, and the per-session settings chain the
+exported profile's ``statusLine``. On the buggy build the pane's env has no
+``CLAUDE_CONFIG_DIR``, trust lands in ``~/.claude.json``, and the settings
+chain the default profile's ``statusLine`` — so this test FAILS with all
+observed values in the failure message.
+
+Run::
+
+    .venv/bin/python -m pytest \\
+        tests/e2e/test_claude_native_config_dir_e2e.py -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# CI shells can carry an egress proxy in the environment; every HTTP call in
+# this test targets 127.0.0.1, so bypass proxy autodetection entirely.
+_http = httpx.Client(trust_env=False)
+
+# The runner imports ``omnigent_client`` / ``omnigent_ui_sdk``; in a worktree
+# they resolve from sdks/, in an installed venv from site-packages.
+_PYTHONPATH = os.pathsep.join(
+    [
+        str(_REPO_ROOT),
+        str(_REPO_ROOT / "sdks" / "python-client"),
+        str(_REPO_ROOT / "sdks" / "ui"),
+        os.environ.get("PYTHONPATH", ""),
+    ]
+)
+
+_HEALTH_TIMEOUT_S = 120.0
+_HOST_ONLINE_TIMEOUT_S = 90.0
+# Terminal auto-create includes host auth probes (which park against the
+# stub until their internal timeout), bridge prep + tmux boot; generous.
+_PANE_TIMEOUT_S = 300.0
+_POLL_S = 1.0
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("tmux") is None,
+    reason="claude-native terminals run inside tmux; tmux not installed",
+)
+
+
+def _find_free_port() -> int:
+    """Grab an ephemeral port for the spawned server."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _localhost_env(extra: dict[str, str]) -> dict[str, str]:
+    """Subprocess env with worktree imports and no proxy in the way.
+
+    :param extra: Overrides/additions applied after the base env.
+    :returns: Environment mapping for ``subprocess.Popen``.
+    """
+    env = {
+        **os.environ,
+        "PYTHONPATH": _PYTHONPATH,
+        # CI shells often carry an egress proxy; localhost must bypass it.
+        "NO_PROXY": "127.0.0.1,localhost",
+        "no_proxy": "127.0.0.1,localhost",
+    }
+    for name in ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"):
+        env.pop(name, None)
+    env.update(extra)
+    return env
+
+
+def _terminate(proc: subprocess.Popen[bytes] | None) -> None:
+    """Best-effort SIGTERM -> SIGKILL teardown for a spawned process."""
+    if proc is None or proc.poll() is not None:
+        return
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def _wait_http_ok(url: str, deadline: float) -> None:
+    """Poll *url* until it returns 200 or *deadline* (monotonic) passes."""
+    last = "not polled"
+    while time.monotonic() < deadline:
+        try:
+            if _http.get(url, timeout=2.0).status_code == 200:
+                return
+            last = "non-200"
+        except httpx.HTTPError as exc:
+            last = f"{type(exc).__name__}: {exc}"
+        time.sleep(_POLL_S)
+    raise AssertionError(f"{url} never became healthy: {last}")
+
+
+def _write_claude_stub(stub_bin: Path, launches: Path) -> None:
+    """Install a recording ``claude`` stub, first on PATH for the daemon.
+
+    Every invocation appends one record file with the env it received and
+    its argv. ``--version`` answers the host capability probe; headless
+    ``-p`` invocations (the model-catalog probe) print ``{}`` and exit;
+    everything else parks so the tmux pane stays alive.
+
+    :param stub_bin: Directory to place the stub in (prepended to PATH).
+    :param launches: Directory the stub writes one ``launch.<pid>`` record
+        per invocation into.
+    """
+    stub = stub_bin / "claude"
+    stub.write_text(
+        "#!/bin/sh\n"
+        'case " $* " in *" --version "*) echo "2.1.236 (Claude Code)"; exit 0;; esac\n'
+        "interactive=1\n"
+        'for a in "$@"; do [ "$a" = "-p" ] && interactive=0; done\n'
+        f'REC="{launches}/launch.$$"\n'
+        "{\n"
+        '  echo "INTERACTIVE=$interactive"\n'
+        '  echo "CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR-__UNSET__}"\n'
+        '  echo "HOME=$HOME"\n'
+        '  echo "RUNNER_ID=${OMNIGENT_RUNNER_ID-__UNSET__}"\n'
+        '  echo "FIRSTARG=${1-__NONE__}"\n'
+        '  for a in "$@"; do printf \'ARG:%s\\n\' "$a"; done\n'
+        '} > "$REC"\n'
+        'if [ "$interactive" = "0" ]; then echo \'{}\'; exit 0; fi\n'
+        "exec sleep 600\n"
+    )
+    stub.chmod(0o755)
+
+
+def _parse_launch(record: Path) -> tuple[dict[str, str], list[str]]:
+    """Parse one stub launch record into (env fields, argv).
+
+    :param record: A ``launch.<pid>`` file written by the stub.
+    :returns: Mapping of the recorded env fields, and the argv list.
+    """
+    lines = record.read_text().splitlines()
+    fields = dict(
+        line.split("=", 1) for line in lines if "=" in line and not line.startswith("ARG:")
+    )
+    argv = [line[len("ARG:") :] for line in lines if line.startswith("ARG:")]
+    return fields, argv
+
+
+def _pane_launch(launches: Path) -> tuple[dict[str, str], list[str]] | None:
+    """The interactive terminal pane launch, once recorded.
+
+    Filters out the host-side probes: ``claude --version`` never records,
+    headless catalog probes record ``INTERACTIVE=0``, and ``claude auth …``
+    records ``FIRSTARG=auth``.
+
+    :param launches: The stub's record directory.
+    :returns: (env fields, argv) of the pane's ``claude``, or ``None``.
+    """
+    for record in sorted(launches.glob("launch.*")):
+        fields, argv = _parse_launch(record)
+        if fields.get("INTERACTIVE") == "1" and fields.get("FIRSTARG") != "auth":
+            return fields, argv
+    return None
+
+
+def _kill_parked_stubs(launches: Path) -> None:
+    """Kill the parked ``sleep`` processes recorded by the stub.
+
+    The stub ``exec``s sleep, so each record's filename PID is the parked
+    process itself; killing exactly those avoids touching anything else.
+
+    :param launches: The stub's record directory.
+    """
+    for record in launches.glob("launch.*"):
+        with contextlib.suppress(ValueError, ProcessLookupError, PermissionError):
+            os.kill(int(record.suffix.lstrip(".")), signal.SIGKILL)
+
+
+def test_claude_native_session_honors_claude_config_dir(tmp_path: Path) -> None:
+    """
+    A claude-native session must run on the exported ``CLAUDE_CONFIG_DIR`` profile.
+
+    Journey (the reporter's): export ``CLAUDE_CONFIG_DIR`` pointing at a
+    second, logged-in Claude profile; start the host daemon from that shell;
+    start a Claude Code session from the web UI in a folder Claude has not
+    seen before.
+
+    Expected: the pane's ``claude`` process receives the exported
+    ``CLAUDE_CONFIG_DIR``; workspace trust is seeded into
+    ``$CLAUDE_CONFIG_DIR/.claude.json``; the per-session ``--settings`` file
+    chains the exported profile's ``statusLine``. Buggy behavior: the env
+    strip drops the variable (the session runs the default ``~/.claude``
+    account), trust is written to ``~/.claude.json``, and the settings chain
+    the default profile's ``statusLine``.
+
+    :param tmp_path: Per-test temp dir (server DB, homes, stub claude).
+    """
+    home = tmp_path / "home"
+    work_profile = home / "profiles" / "work"
+    default_claude_dir = home / ".claude"
+    workspace = tmp_path / "ws" / "fresh-project"
+    stub_bin = tmp_path / "bin"
+    launches = tmp_path / "launches"
+    for directory in (
+        home,
+        work_profile,
+        default_claude_dir,
+        workspace,
+        stub_bin,
+        launches,
+        home / ".omnigent",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    # Journey step 1: a second, logged-in "work" profile under
+    # CLAUDE_CONFIG_DIR, distinguishable from the machine's default
+    # ~/.claude profile (the "personal account") by account email and by a
+    # marker statusLine in each profile's settings.json.
+    (work_profile / ".claude.json").write_text(
+        json.dumps(
+            {
+                "hasCompletedOnboarding": True,
+                "theme": "dark",
+                "lastOnboardingVersion": "2.0.0",
+                "oauthAccount": {"emailAddress": "work@example.com"},
+                "projects": {},
+            }
+        )
+    )
+    (work_profile / "settings.json").write_text(
+        json.dumps({"statusLine": {"type": "command", "command": "echo WORK-PROFILE-STATUSLINE"}})
+    )
+    (home / ".claude.json").write_text(
+        json.dumps(
+            {
+                "hasCompletedOnboarding": True,
+                "theme": "dark",
+                "lastOnboardingVersion": "2.0.0",
+                "oauthAccount": {"emailAddress": "personal@example.com"},
+                "projects": {},
+            }
+        )
+    )
+    (default_claude_dir / "settings.json").write_text(
+        json.dumps(
+            {"statusLine": {"type": "command", "command": "echo DEFAULT-PROFILE-STATUSLINE"}}
+        )
+    )
+
+    _write_claude_stub(stub_bin, launches)
+
+    host_id = uuid.uuid4().hex
+    (home / ".omnigent" / "config.yaml").write_text(
+        yaml.safe_dump({"host": {"host_id": host_id, "name": f"e2e-host-{host_id[:8]}"}})
+    )
+
+    port = _find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    daemon_log_path = tmp_path / "daemon.log"
+    server_log = (tmp_path / "server.log").open("w")
+    daemon_log = daemon_log_path.open("w")
+    server_proc: subprocess.Popen[bytes] | None = None
+    daemon_proc: subprocess.Popen[bytes] | None = None
+    try:
+        server_proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "from omnigent.cli import main; main()",
+                "server",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--database-uri",
+                f"sqlite:///{tmp_path}/chat.db",
+                "--artifact-location",
+                str(tmp_path / "artifacts"),
+            ],
+            env=_localhost_env({}),
+            cwd=str(_REPO_ROOT),
+            stdout=server_log,
+            stderr=subprocess.STDOUT,
+        )
+        _wait_http_ok(f"{base_url}/health", time.monotonic() + _HEALTH_TIMEOUT_S)
+
+        # Journey step 2: the host daemon starts from the shell that exported
+        # CLAUDE_CONFIG_DIR. The var is handed straight to the daemon, which
+        # is *more generous* than the real ``omni host`` path — the
+        # CLI->daemon env strip would already have dropped it — so a fixed
+        # daemon->runner path is sufficient for this test to pass.
+        daemon_proc = subprocess.Popen(
+            [sys.executable, "-m", "omnigent.host._daemon_entry", "--server", base_url],
+            env=_localhost_env(
+                {
+                    "HOME": str(home),
+                    "CLAUDE_CONFIG_DIR": str(work_profile),
+                    "PATH": f"{stub_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                    "OMNIGENT_PROCESS_LOG_FILE": str(daemon_log_path),
+                }
+            ),
+            cwd=str(_REPO_ROOT),
+            stdout=subprocess.DEVNULL,
+            stderr=daemon_log,
+        )
+
+        deadline = time.monotonic() + _HOST_ONLINE_TIMEOUT_S
+        online = False
+        while time.monotonic() < deadline:
+            try:
+                hosts = _http.get(f"{base_url}/v1/hosts", timeout=2.0)
+                if hosts.status_code == 200 and any(
+                    h["host_id"] == host_id and h["status"] == "online"
+                    for h in hosts.json().get("hosts", [])
+                ):
+                    online = True
+                    break
+            except httpx.HTTPError:
+                # The server/daemon is still booting; transient connection
+                # errors are expected while polling and simply retried.
+                pass
+            time.sleep(_POLL_S)
+        assert online, (
+            f"host never came online; daemon log:\n{daemon_log_path.read_text()[-3000:]}"
+        )
+
+        # Journey step 3: start a Claude Code session the web-UI way — the
+        # built-in claude-native agent + host_id + a fresh workspace. The
+        # host launches a runner, which auto-creates the Claude terminal.
+        agents = _http.get(f"{base_url}/v1/agents", timeout=10.0)
+        agents.raise_for_status()
+        agent_id = next(a["id"] for a in agents.json()["data"] if a["name"] == "claude-native-ui")
+        create = _http.post(
+            f"{base_url}/v1/sessions",
+            json={"agent_id": agent_id, "host_id": host_id, "workspace": str(workspace)},
+            timeout=_PANE_TIMEOUT_S,
+        )
+        create.raise_for_status()
+
+        # Journey step 4: wait for the pane's claude process, then observe
+        # which profile the session actually runs on.
+        deadline = time.monotonic() + _PANE_TIMEOUT_S
+        pane: tuple[dict[str, str], list[str]] | None = None
+        while time.monotonic() < deadline:
+            pane = _pane_launch(launches)
+            if pane is not None:
+                break
+            time.sleep(_POLL_S)
+        assert pane is not None, (
+            f"pane claude never launched; daemon log:\n{daemon_log_path.read_text()[-8000:]}"
+        )
+        pane_fields, pane_argv = pane
+
+        # The trust write happens around terminal bring-up; give it a short
+        # grace period to land in either profile before reading final state.
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            default_cfg = json.loads((home / ".claude.json").read_text())
+            work_cfg = json.loads((work_profile / ".claude.json").read_text())
+            if str(workspace) in default_cfg.get("projects", {}) or str(workspace) in work_cfg.get(
+                "projects", {}
+            ):
+                break
+            time.sleep(_POLL_S)
+
+        settings_marker = "no --settings flag on the pane launch"
+        if "--settings" in pane_argv:
+            settings_path = Path(pane_argv[pane_argv.index("--settings") + 1])
+            if settings_path.exists():
+                settings_text = settings_path.read_text()
+                if "WORK-PROFILE-STATUSLINE" in settings_text:
+                    settings_marker = "WORK-PROFILE-STATUSLINE"
+                elif "DEFAULT-PROFILE-STATUSLINE" in settings_text:
+                    settings_marker = "DEFAULT-PROFILE-STATUSLINE"
+                else:
+                    settings_marker = "neither profile's statusLine"
+            else:
+                settings_marker = f"--settings file missing: {settings_path}"
+
+        failures: list[str] = []
+        if pane_fields.get("CLAUDE_CONFIG_DIR") != str(work_profile):
+            failures.append(
+                "the pane's claude launched with CLAUDE_CONFIG_DIR="
+                f"{pane_fields.get('CLAUDE_CONFIG_DIR')!r} instead of the exported "
+                f"work profile {str(work_profile)!r} — the host->runner env strip "
+                "dropped it, so the session runs on the default ~/.claude account"
+            )
+        if str(workspace) not in work_cfg.get("projects", {}):
+            where = (
+                "the default ~/.claude.json"
+                if str(workspace) in default_cfg.get("projects", {})
+                else "no profile at all"
+            )
+            failures.append(
+                "workspace trust / onboarding pre-accept was not seeded into "
+                f"$CLAUDE_CONFIG_DIR/.claude.json — it went to {where}, so the "
+                "exported profile never sees the folder as trusted"
+            )
+        if settings_marker != "WORK-PROFILE-STATUSLINE":
+            failures.append(
+                "the per-session --settings file chains the user statusLine from "
+                f"the wrong profile: got {settings_marker!r}, expected the exported "
+                "profile's WORK-PROFILE-STATUSLINE (settings are read from the "
+                "hard-coded ~/.claude/settings.json)"
+            )
+        assert not failures, (
+            "claude-native ignored the exported CLAUDE_CONFIG_DIR:\n- "
+            + "\n- ".join(failures)
+            + f"\npane argv: {pane_argv}"
+        )
+    finally:
+        _terminate(daemon_proc)
+        _terminate(server_proc)
+        _kill_parked_stubs(launches)
+        server_log.close()
+        daemon_log.close()

--- a/tests/inner/test_claude_sdk_executor.py
+++ b/tests/inner/test_claude_sdk_executor.py
@@ -5649,3 +5649,42 @@ async def test_terminal_error_carries_observed_usage() -> None:
     assert usage["context_tokens"] == 100_000
     # output_tokens is unknown on an incomplete turn — reported as 0.
     assert usage["output_tokens"] == 0
+
+
+def test_claude_internal_write_roots_follow_the_configured_claude_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sandbox opens the configured profile's state dirs, not ``~/.claude``."""
+    from omnigent.inner.claude_sdk_executor import _claude_internal_write_roots
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    profile = tmp_path / "work-profile"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+
+    roots = _claude_internal_write_roots()
+
+    assert profile / "sessions" in roots
+    assert home / ".claude" / "sessions" not in roots
+
+
+def test_claude_internal_write_files_follow_the_configured_claude_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only the configured profile's config and credentials become writable."""
+    from omnigent.inner.claude_sdk_executor import _claude_internal_write_files
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    profile = tmp_path / "work-profile"
+    profile.mkdir()
+    (profile / ".claude.json").write_text("{}\n", encoding="utf-8")
+    (profile / ".credentials.json").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+
+    assert _claude_internal_write_files() == [
+        profile / ".claude.json",
+        profile / ".credentials.json",
+    ]

--- a/tests/test_claude_native.py
+++ b/tests/test_claude_native.py
@@ -2774,7 +2774,7 @@ async def test_ensure_local_claude_resume_transcript_uses_workspace_dir(
     nothing.
     """
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     workspace = Path("/work/some-repo")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -2830,7 +2830,7 @@ async def test_ensure_local_claude_resume_transcript_returns_none_when_no_record
     leave an empty ``<sid>.jsonl`` behind for a later launch to trip over.
     """
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     workspace = Path("/work/some-repo")
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -2989,7 +2989,7 @@ async def test_resume_transcript_falls_back_to_local_file_when_history_unfetchab
     resuming from it beats silently launching a blank session.
     """
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     workspace = Path("/work/some-repo")
     target_dir = projects / claude_native._sanitize_claude_project_name(str(workspace))
     target_dir.mkdir(parents=True)
@@ -3028,7 +3028,7 @@ async def test_resume_transcript_ignores_corrupt_local_file(
     failure.
     """
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     workspace = Path("/work/some-repo")
     target_dir = projects / claude_native._sanitize_claude_project_name(str(workspace))
     target_dir.mkdir(parents=True)
@@ -3062,7 +3062,7 @@ async def test_resume_transcript_ignores_binary_local_file(
     ``UnicodeDecodeError`` out of the fallback path.
     """
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     workspace = Path("/work/some-repo")
     target_dir = projects / claude_native._sanitize_claude_project_name(str(workspace))
     target_dir.mkdir(parents=True)
@@ -3097,7 +3097,7 @@ async def test_resume_transcript_ignores_local_file_on_4xx(
     local transcript exists.
     """
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     workspace = Path("/work/some-repo")
     target_dir = projects / claude_native._sanitize_claude_project_name(str(workspace))
     target_dir.mkdir(parents=True)
@@ -3125,7 +3125,7 @@ async def test_resume_transcript_raises_when_history_unfetchable_and_no_local_fi
 ) -> None:
     """No server history and no local transcript → the failure surfaces."""
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
 
     def handler(request: httpx.Request) -> httpx.Response:
         del request
@@ -3212,7 +3212,7 @@ async def test_ensure_local_claude_resume_transcript_rematerializes_image_blocks
     from omnigent.harnesses.claude_native import bridge as claude_native_bridge
 
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     bridge_dir = tmp_path / "bridge"
     monkeypatch.setattr(
         claude_native_bridge, "bridge_dir_for_conversation_id", lambda _conv: bridge_dir
@@ -3262,7 +3262,7 @@ async def test_ensure_local_claude_resume_transcript_marks_unresolvable_attachme
     from omnigent.harnesses.claude_native import bridge as claude_native_bridge
 
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     bridge_dir = tmp_path / "bridge"
     monkeypatch.setattr(
         claude_native_bridge, "bridge_dir_for_conversation_id", lambda _conv: bridge_dir
@@ -3307,7 +3307,7 @@ async def test_ensure_local_claude_resume_transcript_survives_malformed_file_met
     from omnigent.harnesses.claude_native import bridge as claude_native_bridge
 
     projects = tmp_path / "projects"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     bridge_dir = tmp_path / "bridge"
     monkeypatch.setattr(
         claude_native_bridge, "bridge_dir_for_conversation_id", lambda _conv: bridge_dir
@@ -5127,7 +5127,7 @@ async def test_resolve_cold_resume_args_injects_external_session_id(
     :param tmp_path: Temporary directory used to isolate Claude
         project state from the developer's real ``~/.claude`` tree.
     """
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: tmp_path / "projects")
     client = await _httpx_client_with_canned_response(
         _conversation_response_body(
             labels={"omnigent.wrapper": "claude-code-native-ui"},
@@ -5160,7 +5160,7 @@ async def test_resolve_cold_resume_args_declines_resume_when_no_history(
     :param monkeypatch: Pytest monkeypatch fixture.
     :param tmp_path: Temporary directory isolating Claude project state.
     """
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: tmp_path / "projects")
     client = await _httpx_client_with_canned_response(
         _conversation_response_body(
             labels={"omnigent.wrapper": "claude-code-native-ui"},
@@ -5263,7 +5263,7 @@ async def test_resolve_cold_resume_args_bootstraps_missing_local_claude_transcri
         raise AssertionError(f"unexpected request {request.method} {request.url}")
 
     monkeypatch.chdir(workspace)
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         args = await claude_native._resolve_cold_resume_args(client, "conv_abc")
@@ -5387,7 +5387,7 @@ async def test_resolve_cold_resume_args_replaces_existing_local_claude_transcrip
         raise AssertionError(f"unexpected request {request.method} {request.url}")
 
     monkeypatch.chdir(workspace)
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         args = await claude_native._resolve_cold_resume_args(client, "conv_abc")
@@ -5459,7 +5459,7 @@ async def test_ensure_local_claude_resume_transcript_repairs_stale_duplicated_im
         del request
         return httpx.Response(200, json=_items_response_body([image_item]))
 
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects)
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         written = await claude_native._ensure_local_claude_resume_transcript(
@@ -6817,7 +6817,7 @@ def test_align_working_directory_redirect_moves_transcript_and_updates_state(
         "",
     ]
     source.write_text("\n".join(original_lines) + "\n", encoding="utf-8")
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
     monkeypatch.setattr(
         claude_native,
         "_fetch_external_session_id_for_redirect",
@@ -6897,7 +6897,7 @@ def test_align_working_directory_redirect_replaces_stale_target(
     target_dir.mkdir(parents=True)
     target = target_dir / f"{external_session_id}.jsonl"
     target.write_text('{"cwd":"do-not-overwrite"}\n', encoding="utf-8")
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
     monkeypatch.setattr(
         claude_native,
         "_fetch_external_session_id_for_redirect",
@@ -6972,7 +6972,7 @@ def test_align_working_directory_redirect_works_when_recorded_path_missing(
         )
         return "move"
 
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
     monkeypatch.setattr(
         claude_native,
         "_fetch_external_session_id_for_redirect",
@@ -7070,7 +7070,7 @@ def test_clone_claude_transcript_rewrites_session_and_cwd_into_clone_project_dir
         "",
     ]
     source_path.write_text("\n".join(source_lines) + "\n", encoding="utf-8")
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
 
     result = claude_native._clone_claude_transcript(
         source_external_session_id=source_uuid,
@@ -7132,7 +7132,7 @@ def test_clone_claude_transcript_returns_none_when_source_missing(
     projects_dir.mkdir(parents=True)
     clone_workspace = tmp_path / "clone"
     clone_workspace.mkdir()
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
 
     result = claude_native._clone_claude_transcript(
         source_external_session_id="00000000-0000-0000-0000-000000000000",
@@ -7241,7 +7241,7 @@ def test_clone_claude_transcript_repairs_stale_image_duplication(
     source_text = source_path.read_text(encoding="utf-8")
     assert source_text.count(b64_structured) == 2, "pre-fix wedged state"
     assert source_text.count(b64_mcp) == 2, "pre-fix wedged state"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
 
     result = claude_native._clone_claude_transcript(
         source_external_session_id=source_uuid,
@@ -7337,7 +7337,7 @@ def test_clone_claude_transcript_leaves_invalid_image_shaped_text_unchanged(
         "toolUseResult": json.dumps(fake_text),
     }
     source_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
 
     result = claude_native._clone_claude_transcript(
         source_external_session_id=source_uuid,
@@ -7698,7 +7698,7 @@ def test_clone_and_cwd_copy_paths_both_collapse_a_dropped_payload(
     source_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
     source_text = source_path.read_text(encoding="utf-8")
     assert source_text.count(payload) == 2, "pre-repair wedged state"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
 
     cloned = claude_native._clone_claude_transcript(
         source_external_session_id=source_uuid,
@@ -7744,7 +7744,7 @@ def test_clone_claude_transcript_repairs_progressive_jpeg_duplication(
     b64 = _TINY_PROGRESSIVE_JPEG_BASE64
     source_path.write_text(json.dumps(_stale_duplicated_jpeg_record(b64)) + "\n", encoding="utf-8")
     assert source_path.read_text(encoding="utf-8").count(b64) == 2, "pre-fix wedged state"
-    monkeypatch.setattr(claude_native, "_CLAUDE_PROJECTS_DIR", projects_dir)
+    monkeypatch.setattr(claude_native, "_claude_projects_dir", lambda: projects_dir)
 
     result = claude_native._clone_claude_transcript(
         source_external_session_id=source_uuid,
@@ -11329,3 +11329,30 @@ def test_resolve_native_claude_config_spec_api_key_auth_skips_connect_broker(
     dc._write_sidecar(cfg, "https://srv", "hid", "launch-tok", "https://ws.example")
 
     assert claude_native.resolve_native_claude_config(spec=spec, refresh_models=False) is None
+
+
+def test_find_claude_transcript_searches_the_configured_claude_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Transcripts are found in ``$CLAUDE_CONFIG_DIR/projects``, where Claude writes them."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    profile = tmp_path / "work-profile"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+    session_id = "02857840-6362-408f-b41f-309e396ed7c6"
+    transcript = profile / "projects" / "-work-repo" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text("{}\n", encoding="utf-8")
+
+    assert claude_native._find_claude_transcript(session_id) == transcript
+
+
+def test_claude_project_dir_for_cwd_uses_the_configured_claude_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A moved transcript lands where the configured profile's Claude will look for it."""
+    profile = tmp_path / "work-profile"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+
+    assert claude_native._claude_project_dir_for_cwd(Path("/work/repo")) == (
+        profile / "projects" / "-work-repo"
+    )

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -6637,7 +6637,7 @@ def test_read_user_status_line_command_returns_string(
         json.dumps({"statusLine": {"type": "command", "command": "bun run hud"}}),
         encoding="utf-8",
     )
-    monkeypatch.setattr(claude_native_bridge, "_USER_CLAUDE_SETTINGS_PATH", settings)
+    monkeypatch.setattr(claude_native_bridge, "_user_claude_settings_path", lambda: settings)
 
     assert claude_native_bridge.read_user_status_line_command() == "bun run hud"
 
@@ -6648,7 +6648,7 @@ def test_read_user_status_line_command_returns_none_when_unset(
     """No global statusLine → chain is omitted; wrapper prints nothing extra."""
     settings = tmp_path / "settings.json"
     settings.write_text(json.dumps({"model": "opus"}), encoding="utf-8")
-    monkeypatch.setattr(claude_native_bridge, "_USER_CLAUDE_SETTINGS_PATH", settings)
+    monkeypatch.setattr(claude_native_bridge, "_user_claude_settings_path", lambda: settings)
     assert claude_native_bridge.read_user_status_line_command() is None
 
 
@@ -6659,7 +6659,7 @@ def test_read_user_effort_level_returns_configured_level(
     """A recognized ``effortLevel`` is returned, to stamp on the session row."""
     settings = tmp_path / "settings.json"
     settings.write_text(json.dumps({"effortLevel": effort}), encoding="utf-8")
-    monkeypatch.setattr(claude_native_bridge, "_USER_CLAUDE_SETTINGS_PATH", settings)
+    monkeypatch.setattr(claude_native_bridge, "_user_claude_settings_path", lambda: settings)
     assert claude_native_bridge.read_user_effort_level() == effort
 
 
@@ -6669,7 +6669,7 @@ def test_read_user_effort_level_returns_none_when_unset(
     """No ``effortLevel`` → None, so creation omits reasoning_effort entirely."""
     settings = tmp_path / "settings.json"
     settings.write_text(json.dumps({"model": "opus"}), encoding="utf-8")
-    monkeypatch.setattr(claude_native_bridge, "_USER_CLAUDE_SETTINGS_PATH", settings)
+    monkeypatch.setattr(claude_native_bridge, "_user_claude_settings_path", lambda: settings)
     assert claude_native_bridge.read_user_effort_level() is None
 
 
@@ -6679,7 +6679,7 @@ def test_read_user_effort_level_rejects_unrecognized_value(
     """An unrecognized value is treated as unset (fail-soft, so launch never 400s)."""
     settings = tmp_path / "settings.json"
     settings.write_text(json.dumps({"effortLevel": "ultra"}), encoding="utf-8")
-    monkeypatch.setattr(claude_native_bridge, "_USER_CLAUDE_SETTINGS_PATH", settings)
+    monkeypatch.setattr(claude_native_bridge, "_user_claude_settings_path", lambda: settings)
     assert claude_native_bridge.read_user_effort_level() is None
 
 
@@ -6688,7 +6688,7 @@ def test_read_user_effort_level_returns_none_when_settings_missing(
 ) -> None:
     """Missing settings.json → None; absence of config must not raise."""
     missing = tmp_path / "does-not-exist" / "settings.json"
-    monkeypatch.setattr(claude_native_bridge, "_USER_CLAUDE_SETTINGS_PATH", missing)
+    monkeypatch.setattr(claude_native_bridge, "_user_claude_settings_path", lambda: missing)
     assert claude_native_bridge.read_user_effort_level() is None
 
 
@@ -10453,3 +10453,37 @@ def test_hold_approval_wait_marker_refreshes_until_released(
     settled = len(touches)
     time.sleep(0.1)
     assert len(touches) == settled, "the refresher must stop when the block exits"
+
+
+def test_ensure_trusted_writes_into_the_configured_claude_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Trust lands in the ``.claude.json`` the configured profile's Claude reads."""
+    home_config = _redirect_home(monkeypatch, tmp_path / "home")
+    profile = tmp_path / "work-profile"
+    profile.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+
+    ensure_claude_workspace_trusted(workspace)
+
+    assert not home_config.exists()
+    data = json.loads((profile / ".claude.json").read_text(encoding="utf-8"))
+    assert data["projects"][str(workspace.resolve())]["hasTrustDialogAccepted"] is True
+
+
+def test_read_user_status_line_command_reads_the_configured_claude_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """User settings come from ``$CLAUDE_CONFIG_DIR/settings.json`` when it is set."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    profile = tmp_path / "work-profile"
+    profile.mkdir()
+    (profile / "settings.json").write_text(
+        json.dumps({"statusLine": {"type": "command", "command": "work-profile-hud"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+
+    assert claude_native_bridge.read_user_status_line_command() == "work-profile-hud"

--- a/tests/test_claude_paths.py
+++ b/tests/test_claude_paths.py
@@ -1,0 +1,69 @@
+"""Tests for resolving Claude Code's files the way the Claude CLI does."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from omnigent.claude_paths import claude_config_dir, claude_json_path
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``Path.home()`` at a temp dir.
+
+    :param tmp_path: Pytest temp dir.
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: The fake home, e.g. ``tmp_path / "home"``.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def test_claude_config_dir_defaults_to_dot_claude(home: Path) -> None:
+    """Without ``CLAUDE_CONFIG_DIR`` Claude keeps its state in ``~/.claude``."""
+    assert claude_config_dir() == home / ".claude"
+
+
+def test_claude_config_dir_follows_claude_config_dir(
+    home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A profile selected via ``CLAUDE_CONFIG_DIR`` replaces ``~/.claude`` entirely."""
+    profile = tmp_path / "work-profile"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+
+    assert claude_config_dir() == profile
+
+
+def test_claude_config_dir_expands_tilde(home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``~``-relative ``CLAUDE_CONFIG_DIR`` resolves against the user's home."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/profiles/work")
+
+    assert claude_config_dir() == home / "profiles" / "work"
+
+
+def test_claude_config_dir_treats_empty_value_as_unset(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty ``CLAUDE_CONFIG_DIR`` falls back to ``~/.claude``, as the CLI does."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "")
+
+    assert claude_config_dir() == home / ".claude"
+
+
+def test_claude_json_defaults_to_home(home: Path) -> None:
+    """The user-scope config sits beside ``~/.claude``, not inside it."""
+    assert claude_json_path() == home / ".claude.json"
+
+
+def test_claude_json_moves_into_claude_config_dir(
+    home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With ``CLAUDE_CONFIG_DIR`` set, the CLI reads ``.claude.json`` from inside it."""
+    profile = tmp_path / "work-profile"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+
+    assert claude_json_path() == profile / ".claude.json"

--- a/tests/test_install_ledger.py
+++ b/tests/test_install_ledger.py
@@ -237,3 +237,28 @@ def test_record_and_remove_launch_agent_preserves_other_entries(
     removed = install_ledger.load_ledger(install_ledger.ledger_path())
     assert removed is not None
     assert removed.entries.launch_agents == [unrelated]
+
+
+def test_deep_backfill_observes_claude_config_in_the_configured_claude_home(
+    tmp_path: Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    state = home / ".omnigent"
+    profile = tmp_path / "work-profile"
+    workspace = tmp_path / "workspace"
+    state.mkdir(parents=True)
+    profile.mkdir()
+    workspace.mkdir()
+    (state / "installation_id").write_text("install-123\n")
+    claude_config = profile / ".claude.json"
+    claude_config.write_text('{"mcpServers": {"omnigent": {"command": "python"}}}\n')
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(profile))
+    monkeypatch.chdir(workspace)
+
+    ledger = install_ledger.backfill_install_ledger(deep=True, apply=False)
+
+    assert ledger is not None
+    observed = [entry.path for entry in ledger.entries.injected_external_config]
+    assert observed == [str(claude_config)]

--- a/tests/test_routing_model_switch_guards.py
+++ b/tests/test_routing_model_switch_guards.py
@@ -58,13 +58,15 @@ def test_the_users_claude_settings_file_is_only_ever_read() -> None:
         if not isinstance(node, ast.Attribute):
             continue
         if not (
-            isinstance(node.value, ast.Name) and node.value.id == "_USER_CLAUDE_SETTINGS_PATH"
+            isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "_user_claude_settings_path"
         ):
             continue
         reads.append(node.attr)
-    # The definition itself is an assignment, not an attribute access, so every
-    # hit here is a use.
-    assert reads, "the guard found no usages at all — has the constant been renamed?"
+    # The accessor's own definition is not an attribute access, so every hit here
+    # is a use.
+    assert reads, "the guard found no usages at all — has the accessor been renamed?"
     assert set(reads) <= {"read_text", "read_bytes", "exists", "is_file"}, (
         f"non-read access to the user's settings file: {sorted(set(reads))}"
     )


### PR DESCRIPTION
## Related issue

Closes #7124

## Summary

When `omni host` runs with `CLAUDE_CONFIG_DIR` pointing at a second Claude profile, claude-native sessions still start on the default `~/.claude` profile, and Omnigent reads settings and seeds workspace trust in the wrong one. This makes Omnigent follow the profile Claude itself uses:

- Forward `CLAUDE_CONFIG_DIR` through the CLI→daemon and daemon→runner env strips, next to `KUBECONFIG` and `CLOUDSDK_CONFIG`: it is a path, not a secret.
- Add `omnigent/claude_paths.py` with `claude_config_dir()` and `claude_json_path()`, matching Claude Code's own rule (`.claude.json` lives inside `CLAUDE_CONFIG_DIR` when set, beside `~/.claude` otherwise). Use it for the settings reads, trust seeding, transcript lookup, the claude-sdk sandbox allow-list and the install ledger. The session status reader and session import already had the rule inline and now share it.

The two halves ship together on purpose. Forwarding alone would put the pane on the selected profile while trust is still seeded into `~/.claude.json`, so it would stop at the trust prompt; the path changes alone would do the reverse.

This doesn't change *whether* trust is seeded (#6594), only which profile's file it goes into.

ELI5: Claude keeps a separate home per profile. Omnigent only ever looked in the default one, and never told the Claude it launches which home to use.

```
before                                    after
host: CLAUDE_CONFIG_DIR=work              host: CLAUDE_CONFIG_DIR=work
  runner env: dropped by the strip          runner env: forwarded
    claude pane -> ~/.claude                  claude pane -> work profile
omnigent reads/writes -> ~/.claude        omnigent reads/writes -> work profile
```

## Test Plan

- Manual, on macOS: a second profile selected with `CLAUDE_CONFIG_DIR`, and `omni host` started from that environment by launchd. I started a Claude Code session from the web UI in a fresh folder, once on 0.13.0 and once on this branch, then checked the pane's `claude` process, where its transcript landed, and which `.claude.json` gained the folder's trust entry:
  - 0.13.0: no `CLAUDE_CONFIG_DIR` in the pane's environment, transcript under `~/.claude/projects/`, trust added to `~/.claude.json`.
  - this branch: the pane's environment carries `CLAUDE_CONFIG_DIR`, the transcript lands under the profile's `projects/`, trust is added to the profile's `.claude.json`, and `~/.claude.json` is left alone. The session answered normally.

- Unit tests for the resolver and for every call site with `CLAUDE_CONFIG_DIR` set (transcript lookup, trust seeding, settings read, sandbox write roots and files, install ledger, both env strips). Each failed before the change.
- `tests/conftest.py` now clears `CLAUDE_CONFIG_DIR` by default, so a developer's own profile can't slip past the tmp-`HOME` isolation the existing tests rely on.
- The full `pytest` suite, plus `ruff check`, `ruff format --check`, `pyrefly check` and `pre-commit run` on the changed files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The manual check is the before/after web UI run in Test Plan. The env forwarding and the path changes only prove themselves together, so it was the way to confirm that a real background host's pane and Omnigent now agree on the profile.

## Changelog

Claude Code sessions now use the profile selected with `CLAUDE_CONFIG_DIR` instead of always using `~/.claude`.

## Issues

Resolves [OMNI-7254](https://linear.app/omnigent/issue/OMNI-7254/bug-claude-native-ignores-claude-config-dir-sessions-start-on-the)
