### PR TITLE
fix(homebrew): preserve source-build mirrors across releases

### DIFF
--- a/.github/scripts/homebrew/omnigent.rb.template
+++ b/.github/scripts/homebrew/omnigent.rb.template
@@ -51,6 +51,11 @@ class Omnigent < Formula
 __RESOURCES__
 
   def install
+    if Homebrew::EnvConfig.non_default_variable?(:HOMEBREW_PIP_INDEX_URL) &&
+       (pip_index_url = Homebrew::EnvConfig.pip_index_url.presence)
+      ENV["PIP_INDEX_URL"] = pip_index_url
+    end
+
     venv = virtualenv_create(libexec, "python3.14")
 
     # jiter, tiktoken and watchfiles are the only Rust builds left. Their
@@ -58,6 +63,18 @@ __RESOURCES__
     # names to the Cellar path during relocation (macOS only; the flag breaks
     # Linux ld). Everything else compiled is a prebuilt wheel.
     ENV.append_to_rustflags "-C link-args=-Wl,-headerpad_max_install_names" if OS.mac?
+
+    if (cargo_index = ENV.fetch("HOMEBREW_CARGO_INDEX_URL", nil).presence)
+      (buildpath/".cargo").mkpath
+      (buildpath/".cargo/config.toml").write <<~TOML
+        [source.crates-io]
+        replace-with = "mirror"
+
+        [source.mirror]
+        registry = "sparse+#{cargo_index}"
+      TOML
+      ENV["CARGO_HOME"] = buildpath/".cargo"
+    end
 
     # Pure-Python resources are sdists Homebrew builds in place. Every other
     # compiled extension is pinned to an upstream wheel (WHEEL_REQUIRED /

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ Or with [Homebrew](https://github.com/omnigent-ai/homebrew-tap):
 brew install omnigent-ai/tap/omnigent
 ```
 
+For source builds on networks that require package mirrors, replace these example
+URLs with your mirrors:
+
+```bash
+HOMEBREW_PIP_INDEX_URL='https://pypi.example.com/simple' \
+HOMEBREW_CARGO_INDEX_URL='https://cargo.example.com/index/' \
+  brew install --build-from-source omnigent-ai/tap/omnigent
+```
+
+The PyPI setting also routes pip's isolated build dependencies through the mirror.
+The Cargo setting takes a sparse registry index URL ending in `/`, without the
+`sparse+` prefix. Both overrides are optional and do not affect prebuilt-bottle
+installs.
+
 Or install straight from the repo:
 
 ```bash

--- a/tests/github/test_homebrew_generate_formula.py
+++ b/tests/github/test_homebrew_generate_formula.py
@@ -1,4 +1,4 @@
-"""Regression tests for the Homebrew formula generator's handling of pillow.
+"""Regression tests for Homebrew's Pillow resources and source-build mirrors.
 
 `brew install omnigent-ai/tap/omnigent` fails on macOS with "error building
 wheel for pillow": the generated formula ships pillow as an sdist resource, so
@@ -14,6 +14,9 @@ resolution mocked to a closure containing pillow, and assert on the rendered
 formula: the pillow resource must reference wheel files, never the sdist.
 They fail while the bug is live and pass once the generator stops emitting
 pillow's sdist.
+
+The rendered install method must also retain opt-in mirror setup so release
+regeneration cannot revert source-build fixes.
 """
 
 from __future__ import annotations
@@ -21,6 +24,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from textwrap import dedent
 
 _SCRIPT_DIR = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "homebrew"
 _SCRIPT = _SCRIPT_DIR / "generate_formula.py"
@@ -175,3 +179,55 @@ def test_pick_macos_wheels_finds_pillow_cp314_wheels() -> None:
     )
     for arch in arches:
         assert wheels[arch][0].endswith(".whl")
+
+
+def _install_stanza(formula: str) -> str:
+    return dedent(formula.split("  def install\n", 1)[1].split("\n  end", 1)[0])
+
+
+def test_generated_formula_forwards_pip_mirror_before_creating_virtualenv(monkeypatch) -> None:
+    install = _install_stanza(_generate_formula_with_pillow(monkeypatch))
+    setup = dedent(
+        """\
+        if Homebrew::EnvConfig.non_default_variable?(:HOMEBREW_PIP_INDEX_URL) &&
+           (pip_index_url = Homebrew::EnvConfig.pip_index_url.presence)
+          ENV["PIP_INDEX_URL"] = pip_index_url
+        end
+        """
+    ).strip()
+
+    assert setup in install
+    assert install.index(setup) < install.index('venv = virtualenv_create(libexec, "python3.14")')
+
+
+def test_generated_formula_configures_cargo_mirror_before_resources(monkeypatch) -> None:
+    install = _install_stanza(_generate_formula_with_pillow(monkeypatch))
+    setup = dedent(
+        """\
+        if (cargo_index = ENV.fetch("HOMEBREW_CARGO_INDEX_URL", nil).presence)
+          (buildpath/".cargo").mkpath
+          (buildpath/".cargo/config.toml").write <<~TOML
+            [source.crates-io]
+            replace-with = "mirror"
+
+            [source.mirror]
+            registry = "sparse+#{cargo_index}"
+          TOML
+          ENV["CARGO_HOME"] = buildpath/".cargo"
+        end
+        """
+    ).strip()
+
+    assert setup in install
+    assert install.index(setup) < install.index("venv.pip_install sdists")
+
+
+def test_build_host_mirror_urls_are_not_baked_into_generated_formula(monkeypatch) -> None:
+    monkeypatch.delenv("HOMEBREW_PIP_INDEX_URL", raising=False)
+    monkeypatch.delenv("HOMEBREW_CARGO_INDEX_URL", raising=False)
+    original = _generate_formula_with_pillow(monkeypatch)
+
+    monkeypatch.setenv("HOMEBREW_PIP_INDEX_URL", "https://pypi.example.com/simple")
+    monkeypatch.setenv("HOMEBREW_CARGO_INDEX_URL", "https://cargo.example.com/index/")
+
+    assert _generate_formula_with_pillow(monkeypatch) == original


### PR DESCRIPTION
## Related issue

Related to omnigent-ai/homebrew-tap#25 and omnigent-ai/homebrew-tap#27.

Companion to @vb-dbrks's fixes in omnigent-ai/homebrew-tap#26 and omnigent-ai/homebrew-tap#29. Those PRs deliver the changes to the live tap; this PR preserves them during future formula generation, so it intentionally does not auto-close the delivery issues.

## Summary

- Tap-only mirror fixes disappear when the release workflow regenerates `Formula/omnigent.rb`. Put both fixes in the canonical upstream template.
- Forward a configured `HOMEBREW_PIP_INDEX_URL` to pip's isolated build environment, and configure Cargo source replacement when `HOMEBREW_CARGO_INDEX_URL` is set. Default and bottle installs stay unchanged.
- Add three generation regression tests and document the mirror URL requirements.

**ELI5:** Fixing the printed recipe is temporary if the next print uses the old master. This updates the master recipe too.

```text
Upstream formula template (this PR)
                |
       Release regeneration
                |
Tap formula retains PyPI + Cargo mirror support
```

## Test Plan

- `.venv/bin/python -m pytest tests/github -q` — 98 passed on a clean branch based on current `main`.
- Pre-commit checks passed for all three changed files.
- Generated formula passed Homebrew's Ruby syntax and style checks.
- Localhost smoke checks exercised the generated mirror setup: unset/empty/default guards, pip's isolated backend request reaching the configured mirror, and Cargo fetching and checksum-verifying a test crate. The pip fixture intentionally returned 404; this was a routing check, not a successful package build.
- Before the template fix, both mirror-persistence regression tests failed; after it, all six Homebrew generator tests pass.

**Quick reviewer verification:** run `.venv/bin/python -m pytest tests/github/test_homebrew_generate_formula.py -q`. These tests regenerate the formula without external package-index access and check that both guarded setup blocks survive before resource installation, without baking in the generation host's mirror URLs.

**End-to-end acceptance, after the companion tap PRs land:** on a clean test Mac, replace the example URLs with your package mirrors and run:

```bash
HOMEBREW_PIP_INDEX_URL='https://pypi.example.com/simple' \
HOMEBREW_CARGO_INDEX_URL='https://cargo.example.com/index/' \
  brew install --build-from-source omnigent-ai/tap/omnigent
brew test omnigent-ai/tap/omnigent
```

The Cargo URL must be a sparse index root ending in `/`, without a `sparse+` prefix.

## Demo

N/A — no UI change; non-visual evidence is in Test Plan.

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Permanent tests cover generated output, setup ordering, optional guards, and absence of baked-in mirror URLs. Ad-hoc checks used real Homebrew Ruby, pip build isolation, and Cargo with local HTTP fixtures. A full Omnigent source rebuild was not rerun; the end-to-end acceptance steps above remain for delivery verification.

## Changelog

Homebrew source builds can use configured PyPI and Cargo mirrors, with support preserved across release updates.
