### PR TITLE
fix(cli): keep executor.model when the harness override is a no-op

### DIFF
--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3361,13 +3361,23 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
     if overrides.model is not None:
         executor_block["model"] = overrides.model
     if overrides.harness is not None:
+        prior_harness = _spec_declared_harness(raw, executor_block)
         _apply_harness_override_to_executor(raw, executor_block, overrides.harness)
         # A harness-only override drops any prior model pin so the new
         # harness resolves its provider default — e.g. ``omnigent run
         # examples/polly --harness pi`` must not keep Polly's Claude-only
         # a Claude-only ``executor.model``. An explicit ``--model``
         # (applied above) wins and is left alone.
-        if overrides.model is None:
+        #
+        # Exception (#5101): when the override resolves to the harness the
+        # spec already pins, it is a no-op — e.g. the harness filled from
+        # ``harness.default`` in the global config on ``omnigent run
+        # <agent>`` with no ``--harness`` flag. Dropping the model there
+        # silently discards a pin the user set for exactly this harness.
+        overrides_a_different_harness = prior_harness != (
+            canonicalize_harness(overrides.harness) or overrides.harness
+        )
+        if overrides.model is None and overrides_a_different_harness:
             executor_block.pop("model", None)
             llm_block = raw.get("llm")
             if isinstance(llm_block, dict):
@@ -3430,6 +3440,30 @@ def _apply_harness_override_to_executor(
         config = {}
         executor_block["config"] = config
     config["harness"] = canonical
+
+
+def _spec_declared_harness(raw: _YamlMapping, executor_block: _YamlMapping) -> str | None:
+    """
+    Read the harness the spec already pins, in canonical form.
+
+    Mirrors the read side of :func:`_apply_harness_override_to_executor`:
+    the flat ``executor.harness`` key for single-file omnigent YAMLs and
+    ``executor.config.harness`` for ``spec_version`` bundles.
+
+    :param raw: Parsed top-level YAML mapping (format discriminator via
+        ``spec_version``).
+    :param executor_block: The ``executor:`` mapping inside *raw*.
+    :returns: The canonical harness id, or ``None`` when the spec
+        declares no harness.
+    """
+    if "spec_version" not in raw:
+        harness = executor_block.get("harness")
+    else:
+        config = executor_block.get("config")
+        harness = config.get("harness") if isinstance(config, dict) else None
+    if not isinstance(harness, str) or not harness.strip():
+        return None
+    return canonicalize_harness(harness.strip()) or harness.strip()
 
 
 def _validate_agent_spec(agent_path: Path) -> None:

--- a/omnigent/chat.py
+++ b/omnigent/chat.py
@@ -3369,7 +3369,7 @@ def _apply_overrides_to_raw(raw: _YamlMapping, overrides: ChatOverrides) -> None
         # a Claude-only ``executor.model``. An explicit ``--model``
         # (applied above) wins and is left alone.
         #
-        # Exception (#5101): when the override resolves to the harness the
+        # Exception: when the override resolves to the harness the
         # spec already pins, it is a no-op — e.g. the harness filled from
         # ``harness.default`` in the global config on ``omnigent run
         # <agent>`` with no ``--harness`` flag. Dropping the model there

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2028,6 +2028,57 @@ def test_apply_overrides_harness_only_clears_pinned_model() -> None:
     assert executor.get("model") is None
 
 
+def test_apply_overrides_same_harness_keeps_pinned_model() -> None:
+    """
+    A harness override that matches the spec's own harness keeps the model.
+
+    #5101: ``omnigent run <agent>`` without ``--harness`` fills the
+    harness from ``harness.default`` in the global config. When that
+    default equals the harness the spec already pins, the "drop the
+    model" rule must not fire — the pin was written for exactly this
+    harness, and dropping it made the run fail with an error telling
+    the user to set ``executor.model``.
+    """
+    raw: dict[str, object] = {
+        "spec_version": 1,
+        "name": "my-agent",
+        "prompt": "repro",
+        "executor": {
+            "type": "omnigent",
+            "model": "my-model-id",
+            "config": {"harness": "pi"},
+        },
+    }
+
+    _apply_overrides_to_raw(raw, ChatOverrides(harness="pi"))
+
+    executor = raw["executor"]
+    assert isinstance(executor, dict)
+    assert executor["config"]["harness"] == "pi"
+    assert executor["model"] == "my-model-id"
+
+
+def test_apply_overrides_flat_same_harness_keeps_pinned_model() -> None:
+    """
+    Same-harness no-op override keeps the model for single-file YAMLs too.
+
+    The flat ``executor.harness`` read side must match the write side so
+    canonical aliases (e.g. ``claude`` vs ``claude-sdk``) count as the
+    same harness.
+    """
+    raw: dict[str, object] = {
+        "name": "single_file",
+        "prompt": "hi",
+        "executor": {"harness": "claude-sdk", "model": "sonnet"},
+    }
+
+    _apply_overrides_to_raw(raw, ChatOverrides(harness="claude"))
+
+    executor = raw["executor"]
+    assert isinstance(executor, dict)
+    assert executor["model"] == "sonnet"
+
+
 def test_apply_overrides_rejects_harness_for_non_omnigent_executor_type() -> None:
     """
     A spec_version bundle with a non-omnigent ``executor.type`` fails

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2032,8 +2032,8 @@ def test_apply_overrides_same_harness_keeps_pinned_model() -> None:
     """
     A harness override that matches the spec's own harness keeps the model.
 
-    #5101: ``omnigent run <agent>`` without ``--harness`` fills the
-    harness from ``harness.default`` in the global config. When that
+    ``omnigent run <agent>`` without ``--harness`` fills the harness
+    from ``harness.default`` in the global config. When that
     default equals the harness the spec already pins, the "drop the
     model" rule must not fire — the pin was written for exactly this
     harness, and dropping it made the run fail with an error telling

--- a/tests/e2e/test_run_preserves_spec_model_under_config_harness_default.py
+++ b/tests/e2e/test_run_preserves_spec_model_under_config_harness_default.py
@@ -1,0 +1,262 @@
+"""``omnigent run <agent>`` must not drop the spec's ``executor.model``.
+
+When the effective config carries a harness default (``harness: pi``) and
+``omnigent run <agent-dir>`` is invoked **without** ``--harness``, the CLI
+fills the harness override from config and the override-materialization
+path then pops ``executor.model`` from the rewritten bundle. The spec's
+pinned model never reaches the provider wire: with a gateway provider that
+declares only an ``openai`` family and no ``models.default``, turn setup
+either fails loud with::
+
+    No default model resolved for provider family 'openai': ... Set
+    'executor.model' in the agent YAML or a provider 'models.default' ...
+
+(although the agent YAML *does* set ``executor.model``), or — when catalog
+discovery can resolve a family default — silently runs on that default
+instead of the pinned model.
+
+The test drives the real user journey end-to-end: seed an isolated config
+home with the harness default and the gateway provider (pointed at the
+mock LLM gateway), author an agent spec that pins ``executor.model``, run
+the actual ``python -m omnigent run <agent-dir> -p 'say hi'`` subprocess
+with no ``--harness`` flag, and require the journey to complete with the
+spec's model reaching the gateway wire. Before the fix the spec model
+never reaches the gateway ledger; after the fix the turn completes and the
+captured chat-completions request carries the spec model.
+
+No real LLM is needed — the provider's ``base_url`` targets the mock
+gateway (``tests/server/integration/mock_llm_server.py``), which records
+every request body::
+
+    .venv/bin/python -m pytest \\
+        tests/e2e/test_run_preserves_spec_model_under_config_harness_default.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import httpx
+import yaml
+
+# Worktree root: tests/e2e/<this file> -> parents[2]. Threaded onto the CLI
+# subprocess's PYTHONPATH so it (and the daemon/server/runner it spawns)
+# import THIS worktree's code, not the editable install in a shared .venv.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Unique, greppable model id so the gateway ledger assertion cannot match
+# a request issued by anything but this spec.
+_SPEC_MODEL = "e2e-spec-pinned-model"
+_PROVIDER = "e2e-model-pin-gateway"
+# Full local-stack budget: `omnigent run` boots a host daemon + local
+# server + runner before the turn executes.
+_RUN_TIMEOUT_S = 300
+
+
+def _seed_config_home(config_home: Path, gateway_base_url: str) -> None:
+    """Write the effective config that arms the bug.
+
+    Two load-bearing properties:
+
+    - ``harness: pi`` — a config-level harness *default*. ``omnigent run``
+      fills the harness override from it when ``--harness`` is omitted,
+      which is what the drop path mistakes for an explicit flag.
+    - the provider declares only an ``openai`` family and **no**
+      ``models.default`` — so once the spec model is dropped, nothing in
+      the seeded config can resolve a model and the drop shows up either
+      as a loud turn-setup failure or as a foreign catalog-default model
+      on the gateway wire (never as the pinned model).
+
+    :param config_home: Directory used as ``OMNIGENT_CONFIG_HOME``.
+    :param gateway_base_url: OpenAI-wire base URL of the mock gateway,
+        e.g. ``"http://127.0.0.1:51234/v1"``.
+    """
+    config_home.mkdir(parents=True, exist_ok=True)
+    (config_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "harness": "pi",
+                "providers": {
+                    _PROVIDER: {
+                        "kind": "gateway",
+                        "openai": {
+                            # A literal ref resolves to itself — no env
+                            # propagation into the daemon/runner needed.
+                            "api_key_ref": "dummy-key-model-pin",
+                            "base_url": gateway_base_url,
+                            "wire_api": "chat",
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _seed_agent_dir(agent_dir: Path) -> None:
+    """Write the agent bundle whose ``executor.model`` must survive.
+
+    Mirrors the reported spec shape: ``executor.model`` pinned explicitly,
+    provider auth pointing at the gateway, ``executor.config.harness``
+    matching the config default (the drop fires on the override being
+    *present*, not on it differing from the spec).
+
+    :param agent_dir: Directory to create the bundle in.
+    """
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "spec_version": 1,
+                "name": "model-pin-agent",
+                "description": "regression agent for the spec-model drop",
+                "executor": {
+                    "type": "omnigent",
+                    "model": _SPEC_MODEL,
+                    "auth": {"type": "provider", "name": _PROVIDER},
+                    "config": {"harness": "pi"},
+                },
+                "prompt": "You are a terse test agent.\n",
+                "os_env": {
+                    "type": "caller_process",
+                    "cwd": ".",
+                    "sandbox": {"type": "none"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _gateway_request_models(mock_url: str) -> list[str]:
+    """Model ids of every request the mock gateway captured.
+
+    :param mock_url: Mock gateway base URL.
+    :returns: ``model`` field of each captured request body, in order.
+    """
+    resp = httpx.get(f"{mock_url}/mock/requests", timeout=10.0)
+    resp.raise_for_status()
+    return [r.get("model") for r in resp.json()["requests"] if isinstance(r, dict)]
+
+
+def test_run_preserves_spec_model_under_config_harness_default(
+    tmp_path: Path, isolated_mock_llm_server_url: str
+) -> None:
+    """The spec's ``executor.model`` reaches the harness without ``--harness``.
+
+    Journey (the reporter's, verbatim): config with a harness default and
+    a gateway provider (openai family only, no ``models.default``) → agent
+    spec pinning ``executor.model`` → ``omnigent run <agent-dir> -p ...``
+    with no ``--harness`` flag. The run must not die at turn setup with
+    ``No default model resolved`` (the field it asks for is set), and the
+    request that reaches the gateway must carry the spec's model.
+    """
+    mock_url = isolated_mock_llm_server_url
+    # Queue responses keyed by the spec model (the routing key is the
+    # request's own ``model`` field, so a hit is itself evidence the spec
+    # model survived), plus a fallback so an unexpected extra call cannot
+    # starve the turn.
+    httpx.post(
+        f"{mock_url}/mock/configure",
+        json={"key": _SPEC_MODEL, "responses": [{"text": "hi from mock"}] * 3},
+        timeout=10.0,
+    ).raise_for_status()
+    httpx.post(
+        f"{mock_url}/mock/set_fallback",
+        json={"key": _SPEC_MODEL, "response": {"text": "hi from mock"}},
+        timeout=10.0,
+    ).raise_for_status()
+
+    config_home = tmp_path / "confighome"
+    _seed_config_home(config_home, f"{mock_url}/v1")
+    agent_dir = tmp_path / "agent"
+    _seed_agent_dir(agent_dir)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    # Nest the run's data dir under the session's throwaway
+    # OMNIGENT_DATA_DIR (tests/conftest.py) so the session-end process
+    # reaper can attribute any subprocess that survives a hard kill.
+    session_data_root = Path(os.environ.get("OMNIGENT_DATA_DIR") or tmp_path)
+    data_dir = session_data_root / f"model-pin-{uuid.uuid4().hex[:8]}"
+
+    # The subprocess runs with cwd=tmp_path, where a shared venv's editable
+    # install would win module resolution and silently test someone else's
+    # checkout. Point it at this worktree instead (same pattern as
+    # tests/e2e/_native_resume_helpers.cli_env). No trailing separator: an
+    # empty PYTHONPATH element means cwd, re-introducing the shadowing.
+    inherited_pythonpath = os.environ.get("PYTHONPATH")
+    pythonpath = (
+        f"{_REPO_ROOT}{os.pathsep}{inherited_pythonpath}"
+        if inherited_pythonpath
+        else str(_REPO_ROOT)
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "OMNIGENT_CONFIG_HOME": str(config_home),
+            "OMNIGENT_DATA_DIR": str(data_dir),
+            "PYTHONPATH": pythonpath,
+        }
+    )
+    # An ambient model override would re-inject a model after the drop and
+    # mask the bug (see _apply_overrides_to_raw's OMNIGENT_MODEL fallback).
+    env.pop("OMNIGENT_MODEL", None)
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "omnigent",
+                "run",
+                str(agent_dir),
+                "-p",
+                "say hi",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=tmp_path,
+            timeout=_RUN_TIMEOUT_S,
+        )
+    finally:
+        # Tear down the host daemon + detached local server this run
+        # booted for its isolated data dir.
+        subprocess.run(
+            [sys.executable, "-m", "omnigent", "stop"],
+            capture_output=True,
+            env=env,
+            cwd=tmp_path,
+            timeout=120,
+        )
+
+    combined = result.stdout + result.stderr
+
+    # The bug's loud shape: turn setup demands the very field the agent
+    # YAML already sets.
+    assert "No default model resolved" not in combined, (
+        "`omnigent run` (no --harness, config harness default set) dropped "
+        f"the spec's executor.model={_SPEC_MODEL!r} at bundle write and "
+        f"failed turn setup:\n{combined}"
+    )
+    assert result.returncode == 0, (
+        "`omnigent run <agent> -p` exited non-zero although the agent spec "
+        f"pins executor.model={_SPEC_MODEL!r} (exit {result.returncode}):\n"
+        f"{combined}"
+    )
+    # The bug's silent shape: a catalog/provider default reaches the wire
+    # instead of the pin. The spec model must be what actually reached the
+    # gateway — highest precedence, ahead of provider/catalog defaults.
+    models = _gateway_request_models(mock_url)
+    assert _SPEC_MODEL in models, (
+        "no request carrying the spec's executor.model reached the gateway "
+        f"(captured request models: {models!r}):\n{combined}"
+    )


### PR DESCRIPTION
## Related issue

Closes #5101

Related tracking: [OMNI-4228](https://linear.app/omnigent/issue/OMNI-4228/executormodel-in-an-agent-spec-is-dropped-when-the-bundle-configyaml).

## Summary

### Problem

An agent can pin both `executor.config.harness: pi` and `executor.model: my-model-id`, yet `omnigent run <agent>` can discard that model before the harness sees it. The CLI fills the missing `--harness` flag from the global harness default. When that default is also `pi`, the bundle writer previously treated it as a harness change and removed the model anyway.

The run then uses a provider/catalog default, or fails with “No default model resolved” and asks the user to set the field they already set. Configuring a provider default works around the error but prevents the agent's own model choice from taking effect.

In plain English: choosing the same engine again should keep the model you already chose. If you have not chosen a model in the agent, the environment can still supply one.

### Candidate fixes

| Approach | Tradeoff |
| --- | --- |
| Track whether the harness came from the flag or global config | Requires carrying that distinction through the CLI and materialization paths; an explicit repeat of the same harness still needs a defined policy. |
| Compare the requested harness with the spec's harness | Handles both config defaults and explicit repeats at the point where the model is changed. This PR uses this approach. |
| Keep the spec model for every harness override | Can carry an incompatible model into a different harness. |

### Behavior in this PR

- Read the existing harness from either flat `executor.harness` or bundle `executor.config.harness`, and compare canonical names so aliases such as `claude` and `claude-sdk` match.
- Preserve `executor.model` and legacy `llm.model` when the override selects the same harness.
- When no explicit `--model` is supplied, remove old spec models only for a different harness, then apply `OMNIGENT_MODEL` if no model remains.
- Keep explicit `--model` as the highest-priority choice.

The environment fallback runs independently of whether a model was removed. This avoids losing `OMNIGENT_MODEL` when a same-harness override applies to a spec that has no model.

```mermaid
flowchart TD
    A[Apply harness override] --> B{Explicit --model?}
    B -->|Yes| C[Use CLI model]
    B -->|No| D{Same canonical harness?}
    D -->|Yes| E[Keep spec model if present]
    D -->|No| F[Remove old spec models]
    E --> G{Model missing?}
    F --> G
    G -->|Yes| H[Use OMNIGENT_MODEL if set]
    G -->|No| I[Use preserved model]
```

When the harness remains the same, precedence is `--model` → spec model → `OMNIGENT_MODEL` → existing runtime default resolution. The environment step here applies when a harness override is being materialized; this PR does not change model selection for specs run without one.

## Test Plan

### Automated coverage

- `tests/cli/test_chat.py`: **154 passed**. Includes a new 12-case matrix for flat/bundle specs, canonical harness aliases, missing models, executor/legacy model pins, and explicit CLI model precedence. Existing harness-switch tests also pass.
- Regression proof: against the original PR implementation, the two new same-harness cases without a spec model failed; the other 10 matrix cases passed.
- Full CLI subprocess tests: **2 passed**. They use a local mock gateway and check the actual requested model, once from the spec and once from `OMNIGENT_MODEL`, with a matching global harness default and no provider model default.
- Independent Click dispatch + bundle materialization checks confirm both explicit `--harness pi` and config-default `pi` preserve the environment model. A different harness still uses the environment fallback, and `--model` still wins.
- Pre-commit passed, including Ruff, Pyrefly, test-quality checks, and file hygiene.
- Merged locally with `main` at `5fc83cf25` without conflicts: **156 tests passed** (154 CLI + 2 E2E), and Pyrefly reported **0 errors**.

Run the focused checks from this checkout:

```bash
OMNIGENT_SKIP_WEB_UI=true uv sync --frozen --extra all --group dev
uv run --no-sync pytest -q tests/cli/test_chat.py
uv run --no-sync pytest -q tests/e2e/test_run_preserves_spec_model_under_config_harness_default.py
```

The E2E test needs the supported Pi CLI on `PATH` and uses a mock gateway, so it requires no real API key. The local validation used Pi 0.84.2 installed under a temporary prefix:

```bash
npm install --prefix /tmp/omnigent-pr7135-pi --no-audit --no-fund \
  @earendil-works/pi-coding-agent@0.84.2
PATH="/tmp/omnigent-pr7135-pi/node_modules/.bin:$PATH" \
  uv run --no-sync pytest -q \
  tests/e2e/test_run_preserves_spec_model_under_config_harness_default.py
```

### Manual behavior check

Using an existing Pi agent and a configured gateway from #5101:

1. Set the global harness default and the agent's `executor.config.harness` to `pi`. Set `executor.model` to a model that gateway supports; leave the provider's model default unset.
2. Run `uv run --no-sync omnigent run <agent-dir> -p "say hi"`. Confirm a response and the chosen model in the gateway request logs. Repeat with `--harness pi`; the chosen model should remain the same.
3. Remove `executor.model` from a copy of the agent and run `OMNIGENT_MODEL=<supported-model> uv run --no-sync omnigent run <agent-copy> -p "say hi"`. Confirm that environment model reaches the gateway.
4. Add `--model <another-supported-model>` to step 3. Confirm the explicit model takes priority.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A for screenshots: this is CLI model selection. The Test Plan covers observable gateway requests.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The E2E cases exercise real CLI dispatch, bundle registration, local runtime startup, and Pi requests to a mock gateway. They use isolated configuration and dummy credentials; production gateway/keychain authentication is outside this change. The manual steps above are provided for reviewers and were not run against a production gateway.

## Changelog

`omnigent run` preserves the agent's model when the harness override matches its configured harness, including when the override comes from the global default.
