### PR TITLE
fix(native): preserve bridge dirs claimed during sweep

### DIFF
--- a/omnigent/native/native_bridge_common.py
+++ b/omnigent/native/native_bridge_common.py
@@ -65,9 +65,8 @@ def prune_orphaned_dirs(
     additional eligibility predicate, such as a minimum inactivity period.
     Conservative in the dangerous direction — a reused/foreign pid reads as
     alive and is left.
-    The check-then-rmtree race (a pid reused between the liveness read and
-    the removal) is accepted: it is benign because a live session refreshes
-    its marker every turn, so only genuinely orphaned dirs reach removal.
+    Ownership is checked again immediately before removal so a runner that
+    claims the directory while an eligibility predicate runs is preserved.
     Dirs with no marker (or an unparseable one) are left untouched: they are
     either from an older version or not ours.
 
@@ -103,6 +102,12 @@ def prune_orphaned_dirs(
                 continue
             if not eligible:
                 continue
+        try:
+            current_pid = int(marker.read_text(encoding="utf-8").strip())
+        except (OSError, ValueError):
+            continue
+        if current_pid != pid or _process_alive(current_pid):
+            continue
         shutil.rmtree(entry, ignore_errors=True)
         pruned += 1
     return pruned

--- a/tests/test_native_bridge_common.py
+++ b/tests/test_native_bridge_common.py
@@ -100,6 +100,26 @@ def test_prune_retains_entry_when_eligibility_check_fails(
     assert not eligible_dir.exists()
 
 
+def test_prune_retains_entry_claimed_during_eligibility_check(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A new owner claim while retention is checked prevents deletion."""
+    root = tmp_path / "bridge-root"
+    bridge_dir = root / "reclaimed"
+    bridge_dir.mkdir(parents=True)
+    marker = bridge_dir / native_bridge_common.OWNER_PID_FILENAME
+    marker.write_text("111", encoding="utf-8")
+    monkeypatch.setattr("omnigent.inner.terminal._process_alive", lambda pid: pid == 222)
+
+    def _should_prune(_bridge_dir: Path) -> bool:
+        marker.write_text("222", encoding="utf-8")
+        return True
+
+    assert native_bridge_common.prune_orphaned_dirs(root, should_prune=_should_prune) == 0
+    assert bridge_dir.exists()
+
+
 def test_reap_invokes_prune_for_every_native_agent(monkeypatch: pytest.MonkeyPatch) -> None:
     """The dynamic sweep calls each native agent's module-level prune once."""
     agents = (


### PR DESCRIPTION
## Related issue

Follow-up to #7113 and #6904.

## Summary

- Recheck `owner.pid` immediately before pruning an orphaned native bridge directory.
- Skip deletion when a runner claimed the directory while a harness-specific retention check was running.
- Add a deterministic regression test covering the stale-owner → live-owner race exposed when the host sweep overlaps runner launches.

## Test Plan

- `uv run --group dev --extra tracing pytest -q tests/test_native_bridge_common.py tests/test_codex_native_bridge.py -k 'native_bridge_common or orphan or owner_pid or prune'` — 17 passed.
- `uv run --group dev --extra tracing pre-commit run --files omnigent/native/native_bridge_common.py tests/test_native_bridge_common.py` — passed.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The regression test changes the marker during the retention callback and verifies the reclaimed directory survives.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The shared reaper suite verifies both the new owner-change guard and unchanged dead-owner deletion; Codex retention tests verify the seven-day eligibility policy still behaves normally.

## Changelog

Native session startup no longer risks orphan cleanup deleting a bridge directory that a new runner has reclaimed.
