### PR TITLE
fix: recover runner authentication after delayed login

### DIFF
--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -29,6 +29,7 @@ from omnigent._platform import IS_WINDOWS, normalize_interactive_shells
 from omnigent.debug_logging import runner_primary_session_id
 from omnigent.inner import _proc
 from omnigent.runner.transports.ws_tunnel.serve import RUNNER_TUNNEL_REJECTION_PREFIX
+from omnigent.util.threaded_auth import ThreadedAuth
 from omnigent.version import VERSION
 
 if TYPE_CHECKING:
@@ -46,6 +47,7 @@ _RUNNER_VERSION = VERSION
 _RUNNER_CONFIG_HOME_ENV_VAR = "OMNIGENT_CONFIG_HOME"
 _DEFAULT_RUNNER_IDLE_TIMEOUT_S = 60 * 60
 _RUNNER_IDLE_MONITOR_MAX_POLL_INTERVAL_S = 60.0
+_AUTH_DISCOVERY_RETRY_INTERVAL_S = 5.0
 # The runner offloads short native-CLI/IPC ops via asyncio.to_thread. Python's
 # default executor sizes to min(32, cpu+4) threads, which on a many-core host
 # inflates RSS (thread stacks + glibc arenas) for little benefit. Cap it small.
@@ -283,7 +285,7 @@ async def _run_inactivity_monitor(
         await asyncio.sleep(min(poll_interval_s, idle_timeout_s - elapsed_s))
 
 
-class _RunnerDatabricksAuth(httpx.Auth):
+class _RunnerDatabricksAuth(ThreadedAuth):
     """httpx Auth that mints a fresh Databricks OAuth token per request.
 
     Used by the runner's HTTP client for callbacks to the Omnigent server
@@ -471,7 +473,7 @@ class _InitialAuthTokenFactory:
         self._last_initial_token: str = token  # retained for managed-mint proxy auth
         self._server_url = server_url
         self._fallback_factory: Callable[[], str | None] | None = None
-        self._fallback_resolved = False
+        self._retry_discovery_at = 0.0
         self._no_credential_logged = False
         self._lock = threading.Lock()
 
@@ -487,13 +489,14 @@ class _InitialAuthTokenFactory:
         """
         if self._initial_token is not None:
             return self._initial_token
-        if not self._fallback_resolved:
+        if self._fallback_factory is None:
+            if time.monotonic() < self._retry_discovery_at:
+                return None
             self._fallback_factory = _make_auth_token_factory(
                 self._server_url,
                 _allow_initial_token=False,
                 _proxy_bearer=self._last_initial_token,
             )
-            self._fallback_resolved = True
         token = self._fallback_factory() if self._fallback_factory is not None else None
         # Managed mint cannot renew itself when its proxy bearer expires —
         # the injected host bearer before a first mint, or the minted JWT
@@ -506,15 +509,17 @@ class _InitialAuthTokenFactory:
                 _allow_delegated_mint=False,
             )
             token = self._fallback_factory() if self._fallback_factory is not None else None
-        if self._fallback_factory is None and not self._no_credential_logged:
-            # This state is terminal for the process, so say it once
-            # rather than on every subsequent callback.
-            self._no_credential_logged = True
-            _logger.error(
-                "host bootstrap bearer expired and no SDK/OIDC credential is available "
-                "to renew it; run `databricks auth login` to re-authenticate",
-                extra={"session_id": runner_primary_session_id()},
-            )
+        if self._fallback_factory is None:
+            self._retry_discovery_at = time.monotonic() + _AUTH_DISCOVERY_RETRY_INTERVAL_S
+            if not self._no_credential_logged:
+                self._no_credential_logged = True
+                _logger.error(
+                    "host bootstrap bearer expired and no SDK/OIDC credential is available "
+                    "to renew it; run `databricks auth login` to re-authenticate",
+                    extra={"session_id": runner_primary_session_id()},
+                )
+        elif token:
+            self._no_credential_logged = False
         return token
 
     @property
@@ -555,10 +560,11 @@ class _InitialAuthTokenFactory:
                 reset()
 
     def invalidate(self) -> bool:
-        """Discard the host bearer so the next call resolves local auth."""
+        """Invalidate the host bearer or the resolved fallback credential."""
         with self._lock:
             if self._initial_token is None:
-                return False
+                invalidate = getattr(self._fallback_factory, "invalidate", None)
+                return bool(invalidate()) if callable(invalidate) else False
             self._initial_token = None
             _logger.info(
                 "host bootstrap bearer rejected; resolving runner-local auth",

--- a/omnigent/runner/_entry.py
+++ b/omnigent/runner/_entry.py
@@ -1014,6 +1014,22 @@ class _ManagedMintTokenFactory:
             self.declined = False
             self.declined_by_server_error = False
 
+    def invalidate(self) -> bool:
+        """Discard the cached JWT so the next call re-mints.
+
+        Called when the server rejects the minted credential mid-session
+        (e.g. a signing-key rotation revoked it); without this the cache
+        still looks valid locally and is re-sent on every retry.
+
+        :returns: ``True`` when a cached token was discarded.
+        """
+        with self._lock:
+            if self._cached_token is None:
+                return False
+            self._cached_token = None
+            self._cached_expires_at = 0.0
+            return True
+
     def _still_valid_cached_token(self, now: float) -> str | None:
         """Return the cached token if it hasn't expired outright.
 

--- a/omnigent/runner/transports/ws_tunnel/serve.py
+++ b/omnigent/runner/transports/ws_tunnel/serve.py
@@ -440,13 +440,7 @@ async def serve_tunnel(
             redirect_url = _websocket_auth_redirect_url(exc)
             if redirect_url is not None:
                 login_redirect_streak += 1
-                _reset_server_error_decline(auth_token_factory)
-                if _invalidate_auth_token_factory(auth_token_factory):
-                    auth_token = await _handle_refreshable_auth_failure(
-                        auth_token_factory, 302, exc
-                    )
-                    delay_s = _INITIAL_RECONNECT_DELAY_S
-                    continue
+                await asyncio.to_thread(_prepare_auth_retry, auth_token_factory)
                 # The websockets library auto-followed a redirect away
                 # from our ws:// endpoint to an http(s):// URL —
                 # typically the Databricks App login page. On a runner
@@ -511,8 +505,7 @@ async def serve_tunnel(
                     # so we don't call the factory directly here. Also clear a
                     # 5xx-latched mint decline: the rejection proves the server
                     # requires auth, so the next refresh must re-mint.
-                    _reset_server_error_decline(auth_token_factory)
-                    _invalidate_auth_token_factory(auth_token_factory)
+                    await asyncio.to_thread(_prepare_auth_retry, auth_token_factory)
                     retry_reason = f"HTTP {http_status}; retrying with refreshed token"
                     if ever_connected:
                         # Escalate the backoff rather than resetting it: a rejection
@@ -603,6 +596,19 @@ async def serve_tunnel(
             delay_s = min(delay_s * 2, _MAX_RECONNECT_DELAY_S)
 
 
+def _prepare_auth_retry(factory: Callable[[], str | None] | None) -> None:
+    """Reset rejected credentials without making transient failures fatal."""
+    try:
+        _reset_server_error_decline(factory)
+        _invalidate_auth_token_factory(factory)
+    except (ValueError, OSError, ImportError):
+        _logger.warning(
+            "auth token invalidation failed; retrying credential lookup",
+            exc_info=True,
+            extra={"session_id": runner_primary_session_id()},
+        )
+
+
 def _invalidate_auth_token_factory(factory: Callable[[], str | None] | None) -> bool:
     """Invalidate a host-bootstrap bearer when the factory supports it.
 
@@ -664,48 +670,6 @@ async def _refresh_auth_token(
             extra={"session_id": runner_primary_session_id()},
         )
     return current_token
-
-
-async def _handle_refreshable_auth_failure(
-    factory: Callable[[], str | None] | None,
-    http_status: int,
-    exc: WebSocketException,
-) -> str | None:
-    """
-    Attempt a token refresh after an HTTP 302 login-page redirect.
-
-    If the factory produces a new token, returns it so the caller
-    can retry immediately. If no factory is available or the refresh
-    fails, raises a fatal ``RuntimeError``.
-
-    :param factory: Sync callable returning a fresh token.
-    :param http_status: The HTTP status that triggered this call,
-        e.g. ``302`` for a login-page redirect.
-    :param exc: The original ``WebSocketException``.
-    :returns: A refreshed token string.
-    :raises RuntimeError: When no factory is available or refresh
-        fails.
-    """
-    if factory is not None:
-        try:
-            fresh = await asyncio.to_thread(factory)
-            if fresh is not None:
-                _logger.info(
-                    "auth token refreshed after HTTP %d; retrying",
-                    http_status,
-                    extra={"session_id": runner_primary_session_id()},
-                )
-                return fresh
-        except (ValueError, OSError, ImportError):
-            _logger.warning(
-                "auth token refresh failed after HTTP %d",
-                http_status,
-                exc_info=True,
-                extra={"session_id": runner_primary_session_id()},
-            )
-    raise RuntimeError(
-        f"{RUNNER_TUNNEL_REJECTION_PREFIX}(HTTP {http_status}); check remote server authentication"
-    ) from exc
 
 
 def _websocket_http_status(exc: BaseException) -> int | None:

--- a/omnigent/util/threaded_auth.py
+++ b/omnigent/util/threaded_auth.py
@@ -1,0 +1,45 @@
+"""Adapt blocking HTTP authentication providers for asynchronous clients."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import AsyncGenerator
+
+import httpx
+
+
+class ThreadedAuth(httpx.Auth):
+    """Run each synchronous auth-flow step outside the caller's event loop."""
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Preserve HTTPX body/retry semantics while offloading credential work."""
+        if self.requires_request_body:
+            await request.aread()
+        flow = self.auth_flow(request)
+        lock = threading.Lock()
+
+        def advance(response: httpx.Response | None) -> httpx.Request | None:
+            with lock:
+                try:
+                    return next(flow) if response is None else flow.send(response)
+                except StopIteration:
+                    return None
+
+        def close() -> None:
+            # Cancellation doesn't stop an in-flight worker. Serialize cleanup
+            # with that worker so we never close an executing generator.
+            with lock:
+                flow.close()
+
+        try:
+            next_request = await asyncio.to_thread(advance, None)
+            while next_request is not None:
+                response = yield next_request
+                if self.requires_response_body:
+                    await response.aread()
+                next_request = await asyncio.to_thread(advance, response)
+        finally:
+            await asyncio.to_thread(close)

--- a/tests/e2e/test_runner_auth_delayed_relogin.py
+++ b/tests/e2e/test_runner_auth_delayed_relogin.py
@@ -1,0 +1,578 @@
+"""E2E regression tests: runner authentication must recover after a delayed re-login.
+
+Reported journey: a previously connected runner's
+credentials expire, the server starts rejecting its bearer (HTTP 401/403 or a
+Databricks Apps OAuth login redirect), and the user's re-login takes several
+minutes. The runner must survive that window and recover on its own once
+credentials return — instead it bricks until process restart. Synchronous
+credential providers also execute on the asyncio event loop during HTTP
+authentication.
+
+Four facets, each driven through the runner's real outbound auth code over
+real sockets (no transports are stubbed), with synthetic credential providers
+and a local server standing in for the Databricks Apps front door — the same
+controlled setup the report used:
+
+1. ``_InitialAuthTokenFactory``: after the bootstrap bearer is invalidated
+   while credential discovery returns ``None`` (login still in progress), a
+   later successful login must be rediscovered (a short, bounded rediscovery
+   backoff is fine; requiring a process restart is not). The wrapper
+   permanently caches the missing fallback factory and returns ``None``
+   forever.
+2. ``serve_tunnel``: an ESTABLISHED tunnel whose reconnect bounces to the
+   OAuth login page while renewal is unavailable must keep retrying and
+   reconnect once login completes. The immediate-refresh path raises a fatal
+   ``RuntimeError`` instead, killing the tunnel task.
+3. ``_RunnerDatabricksAuth`` on ``httpx.AsyncClient``: the synchronous
+   credential provider must not execute on the running event loop (it can
+   shell out to the Databricks CLI or block on HTTP for seconds).
+4. After the bootstrap fallback resolves to the managed-mint provider, a
+   server rejection of the minted credential must reach that provider
+   (invalidate + re-mint). ``_InitialAuthTokenFactory.invalidate()`` returns
+   ``False`` without forwarding, so every retry re-sends the same rejected
+   token and callbacks 401 forever.
+
+Every assertion states the EXPECTED (fixed) behaviour, so each test fails on
+the live bug and passes once the fix lands. No real credentials are touched:
+the ``_isolated_credentials`` fixture scrubs Databricks/runner auth state into
+a temp directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import http
+import json
+import threading
+import time
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import httpx
+import pytest
+from websockets.asyncio.server import serve
+
+import omnigent.runner._entry as runner_entry
+from omnigent.runner._entry import (
+    _InitialAuthTokenFactory,
+    _RunnerDatabricksAuth,
+)
+from omnigent.runner.identity import (
+    RUNNER_DELEGATED_AUTH_ENV_VAR,
+    RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR,
+)
+from omnigent.runner.transports.ws_tunnel.serve import serve_tunnel
+from tests._helpers.live_server import find_free_port
+
+_BOOTSTRAP_BEARER = "expired-host-bootstrap-bearer"
+_FRESH_OIDC_TOKEN = "fresh-oidc-token-after-relogin"
+_OAUTH_LOGIN_URL = (
+    "https://workspace.example.invalid/oidc/oauth2/v2.0/authorize"
+    "?redirect_uri=https%3A%2F%2Fworkspace.example.invalid%2F.auth%2Fcallback"
+)
+
+
+@pytest.fixture()
+def isolated_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Isolate every credential-discovery source into a temp directory.
+
+    Scrubs ambient Databricks and runner-auth environment variables, points
+    the Omnigent token store (``auth_tokens.json``) at a temp state dir, and
+    points the Databricks SDK at an empty config file — so credential
+    discovery genuinely returns ``None`` until a test writes a stored token
+    (simulating the user completing ``omnigent login`` minutes later).
+
+    :param tmp_path: pytest-provided temp directory.
+    :param monkeypatch: pytest monkeypatch fixture.
+    :yields: The isolated Omnigent state directory holding
+        ``auth_tokens.json``.
+    """
+    state_dir = tmp_path / "omnigent-state"
+    state_dir.mkdir()
+    monkeypatch.setenv("OMNIGENT_DATA_DIR", str(state_dir))
+    import os as _os
+
+    for name in list(_os.environ):
+        if name.startswith("DATABRICKS_"):
+            monkeypatch.delenv(name, raising=False)
+    empty_cfg = tmp_path / "empty-databrickscfg"
+    empty_cfg.write_text("")
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(empty_cfg))
+    for name in (
+        "RUNNER_SERVER_URL",
+        "OMNIGENT_RUNNER_INITIAL_AUTH_TOKEN",
+        "OMNIGENT_RUNNER_DELEGATED_AUTH",
+        "OMNIGENT_RUNNEL_TUNNEL_BINDING_TOKEN",
+        "OMNIGENT_RUNNER_TUNNEL_BINDING_TOKEN",
+        "OMNIGENT_RUNNER_SLICE_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    # The runner-process singleton must not shadow per-test factories.
+    monkeypatch.setattr(runner_entry, "_runner_auth_factory", None)
+    yield state_dir
+
+
+def _write_stored_oidc_token(state_dir: Path, server_url: str, token: str) -> None:
+    """Simulate the user completing ``omnigent login`` for *server_url*.
+
+    Writes a valid stored OIDC session token (1 h of remaining life) into the
+    isolated ``auth_tokens.json`` — exactly what a completed login leaves on
+    disk for credential discovery to find.
+
+    :param state_dir: The isolated Omnigent state directory.
+    :param server_url: Server URL the token is stored under.
+    :param token: The session token string to store.
+    :returns: None.
+    """
+    (state_dir / "auth_tokens.json").write_text(
+        json.dumps({server_url.rstrip("/"): {"token": token, "expires_at": time.time() + 3600}})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Facet 1 — bootstrap invalidation must not permanently cache a missing
+# credential fallback (delayed login is never rediscovered).
+# ---------------------------------------------------------------------------
+
+
+def test_delayed_relogin_is_rediscovered_after_bootstrap_invalidation(
+    isolated_credentials: Path,
+) -> None:
+    """A login completed minutes after invalidation must be rediscovered.
+
+    Journey: the host-bootstrapped runner's bearer expires and the server
+    rejects it (the auth flow invalidates the bootstrap bearer); credential
+    discovery finds nothing because the user's re-login is still in progress;
+    the user completes ``omnigent login`` a few minutes later. The factory
+    must then return the fresh credential — pre-fix it permanently cached the
+    missing fallback and returns ``None`` forever, bricking the runner until
+    process restart.
+
+    :param isolated_credentials: Isolated Omnigent state directory fixture.
+    :returns: None.
+    """
+    server_url = "http://127.0.0.1:59999"
+    factory = _InitialAuthTokenFactory(_BOOTSTRAP_BEARER, server_url)
+    assert factory() == _BOOTSTRAP_BEARER
+
+    # The server rejected the bootstrap bearer (as _RunnerDatabricksAuth /
+    # serve_tunnel do on 401 or an OAuth login redirect).
+    assert factory.invalidate() is True
+
+    # Login has not completed yet: no credential is correct at this instant.
+    assert factory() is None
+
+    # Minutes later the user's re-login completes and leaves a stored token.
+    _write_stored_oidc_token(isolated_credentials, server_url, _FRESH_OIDC_TOKEN)
+
+    # Rediscovery may sit behind a short bounded backoff (discovery can
+    # shell out to the Databricks CLI, so hammering it on every callback
+    # would be wrong) — but it must happen without a process restart. Poll
+    # briefly; on the live bug the missing fallback is cached forever and
+    # this still returns ``None`` at the deadline.
+    deadline = time.monotonic() + 15
+    token = factory()
+    while token != _FRESH_OIDC_TOKEN and time.monotonic() < deadline:
+        time.sleep(0.25)
+        token = factory()
+    assert token == _FRESH_OIDC_TOKEN, (
+        "credential rediscovery after a delayed re-login returned "
+        f"{token!r} instead of the fresh stored token (waited 15s): "
+        "_InitialAuthTokenFactory permanently cached the missing fallback "
+        "factory it resolved while login was still in progress, so the "
+        "runner never recovers without a process restart"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Facet 2 — an established tunnel must survive a login redirect while renewal
+# is unavailable, and reconnect once login completes.
+# ---------------------------------------------------------------------------
+
+
+class _DelayedLoginCredentials:
+    """Well-behaved synthetic credential provider with a delayed re-login.
+
+    Mirrors the ``_InitialAuthTokenFactory`` interface: returns the host
+    bootstrap bearer until :meth:`invalidate`, then ``None`` while the user's
+    login is in progress, then a fresh token once ``login_complete`` is set.
+    Being well-behaved isolates the tunnel-loop facet from the facet-1
+    caching bug.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with the bootstrap bearer still valid."""
+        self._bootstrap: str | None = _BOOTSTRAP_BEARER
+        self.login_complete = False
+
+    def __call__(self) -> str | None:
+        """Return the current credential, or ``None`` while login is pending.
+
+        :returns: The bootstrap bearer, the fresh post-login token, or
+            ``None`` while re-login is still in progress.
+        """
+        if self._bootstrap is not None:
+            return self._bootstrap
+        return _FRESH_OIDC_TOKEN if self.login_complete else None
+
+    def invalidate(self) -> bool:
+        """Discard the bootstrap bearer after a server rejection.
+
+        :returns: ``True`` when the bootstrap bearer was discarded.
+        """
+        if self._bootstrap is None:
+            return False
+        self._bootstrap = None
+        return True
+
+
+async def test_established_tunnel_survives_login_redirect_and_reconnects() -> None:
+    """An established tunnel must retry through a delayed re-login window.
+
+    Journey: the runner's tunnel connects and serves (proving credentials);
+    the server recycles the connection; the bearer has expired, so every
+    reconnect upgrade bounces to the Databricks Apps OAuth login page while
+    renewal is unavailable (the user's re-login takes minutes); the login
+    then completes. The tunnel loop must keep retrying with backoff and
+    reconnect on its own — pre-fix the immediate-refresh path raises a fatal
+    ``RuntimeError`` on the first redirect, killing the tunnel task, so the
+    runner never reconnects no matter when login completes.
+
+    :returns: None.
+    """
+    creds = _DelayedLoginCredentials()
+    upgrade_attempts = 0
+    accepted = 0
+    first_connected = asyncio.Event()
+    reconnected_after_login = asyncio.Event()
+    login_complete_server_side = False
+
+    def process_request(connection: object, request: object) -> object | None:
+        """Accept the first upgrade; bounce later ones to the OAuth login page.
+
+        :param connection: The server-side WebSocket connection.
+        :param request: The HTTP upgrade request.
+        :returns: ``None`` to accept, or a 302 login redirect response.
+        """
+        nonlocal upgrade_attempts
+        upgrade_attempts += 1
+        if upgrade_attempts == 1:
+            return None
+        auth = request.headers.get("Authorization", "")  # type: ignore[attr-defined]
+        if login_complete_server_side and auth == f"Bearer {_FRESH_OIDC_TOKEN}":
+            return None
+        response = connection.respond(http.HTTPStatus.FOUND, "")  # type: ignore[attr-defined]
+        response.headers["Location"] = _OAUTH_LOGIN_URL
+        return response
+
+    async def handler(connection: object) -> None:
+        """Serve one accepted tunnel connection, then recycle it.
+
+        :param connection: The server-side WebSocket connection.
+        :returns: None.
+        """
+        nonlocal accepted
+        accepted += 1
+        if accepted == 1:
+            first_connected.set()
+        else:
+            reconnected_after_login.set()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(connection.recv(), timeout=5)  # type: ignore[attr-defined]
+        with contextlib.suppress(Exception):
+            await connection.close(1000)  # type: ignore[attr-defined]
+
+    async def _noop_app(scope: object, receive: object, send: object) -> None:
+        """Minimal ASGI app; the fake server never dispatches requests.
+
+        :param scope: ASGI scope.
+        :param receive: ASGI receive callable.
+        :param send: ASGI send callable.
+        :returns: None.
+        """
+        del scope, receive, send
+
+    port = find_free_port()
+    async with serve(handler, "127.0.0.1", port, process_request=process_request):
+        tunnel_task = asyncio.create_task(
+            serve_tunnel(
+                _noop_app,
+                server_url=f"http://127.0.0.1:{port}",
+                runner_id="runner_delayed_relogin_e2e",
+                runner_version="0.0.0-e2e",
+                auth_token_factory=creds,
+            )
+        )
+        try:
+            await asyncio.wait_for(first_connected.wait(), timeout=15)
+
+            # Let the tunnel take several redirect-rejected reconnect attempts
+            # while renewal is unavailable (login still in progress). Pre-fix
+            # the task dies fatally on the first redirect instead.
+            deadline = time.monotonic() + 25
+            while upgrade_attempts < 4 and not tunnel_task.done() and time.monotonic() < deadline:
+                await asyncio.sleep(0.1)
+
+            if tunnel_task.done():
+                exc = tunnel_task.exception()
+                pytest.fail(
+                    "established tunnel died fatally instead of retrying "
+                    f"through the delayed re-login window: {exc!r}. Expected "
+                    "it to keep reconnecting with backoff and recover once "
+                    "login completes."
+                )
+
+            # The user's re-login completes; the server accepts the fresh
+            # bearer again. The tunnel must reconnect on its own.
+            creds.login_complete = True
+            login_complete_server_side = True
+
+            reconnect_waiter = asyncio.create_task(reconnected_after_login.wait())
+            done, _pending = await asyncio.wait(
+                {tunnel_task, reconnect_waiter},
+                timeout=30,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if tunnel_task in done:
+                exc = tunnel_task.exception()
+                pytest.fail(
+                    f"tunnel task died after login completed instead of reconnecting: {exc!r}"
+                )
+            reconnect_waiter.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await reconnect_waiter
+            assert reconnected_after_login.is_set(), (
+                "tunnel did not reconnect within 30s of the delayed re-login "
+                "completing; established tunnels must survive a failed or "
+                "delayed login and reconnect when credentials return"
+            )
+        finally:
+            tunnel_task.cancel()
+            await asyncio.gather(tunnel_task, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# Facet 3 — the synchronous credential provider must not execute on the
+# running event loop during async HTTP authentication.
+# ---------------------------------------------------------------------------
+
+
+class _Ok200Handler(BaseHTTPRequestHandler):
+    """Answer 200 OK to every GET, standing in for an Omnigent endpoint."""
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress default request logging.
+
+        :param format: printf-style format string.
+        :param args: Format arguments.
+        :returns: None.
+        """
+        del format, args
+
+    def do_GET(self) -> None:
+        """Respond 200 to any GET.
+
+        :returns: None.
+        """
+        body = b"{}"
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture()
+def ok_server() -> Iterator[str]:
+    """Spin up a local HTTP server that answers 200 to every GET.
+
+    :yields: The base URL of the server.
+    """
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Ok200Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_sync_credential_provider_runs_off_the_event_loop(ok_server: str) -> None:
+    """The credential provider must run in a worker thread, not on the loop.
+
+    ``_RunnerDatabricksAuth``'s provider can shell out to the Databricks CLI
+    (~0.5 s) or block on an HTTP mint. Executed on the running event loop it
+    stalls every other coroutine (heartbeats, stream relays) and breaks
+    providers that require a worker thread. The provider here records where
+    it executed; pre-fix it observes a running event loop.
+
+    :param ok_server: Base URL of the local 200-OK server fixture.
+    :returns: None.
+    """
+    execution_contexts: list[str] = []
+
+    def provider() -> str:
+        """Record whether this call executes on the event loop.
+
+        :returns: A synthetic bearer token.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            execution_contexts.append("worker-thread")
+        else:
+            execution_contexts.append("event-loop")
+        return "synthetic-bearer"
+
+    async def drive() -> None:
+        """Make one authenticated request through the real async client.
+
+        :returns: None.
+        """
+        auth = _RunnerDatabricksAuth(provider, server_url=ok_server)
+        async with httpx.AsyncClient(auth=auth) as client:
+            response = await client.get(f"{ok_server}/v1/sessions/s/agent/contents")
+            assert response.status_code == 200
+
+    asyncio.run(drive())
+
+    assert execution_contexts, "credential provider was never invoked"
+    assert all(ctx == "worker-thread" for ctx in execution_contexts), (
+        "synchronous credential provider executed on the running asyncio "
+        f"event loop (observed contexts: {execution_contexts}); it must run "
+        "in a worker thread so blocking lookup/refresh cannot stall the "
+        "runner's event loop or break providers that require a thread"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Facet 4 — after the bootstrap fallback resolves, a rejected credential must
+# reach the resolved provider (invalidate + re-mint), not be re-sent forever.
+# ---------------------------------------------------------------------------
+
+
+class _MintAndResourceHandler(BaseHTTPRequestHandler):
+    """Local server: managed-mint endpoint plus a bearer-checked resource.
+
+    ``POST …/token`` mints ``minted-<n>`` (incrementing). ``GET`` of any
+    other path rejects the expired bootstrap bearer and the first minted
+    token with 401 (both revoked server-side), and accepts any later mint —
+    so recovery only needs the client to actually re-mint.
+    """
+
+    mint_count = 0
+    lock = threading.Lock()
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Suppress default request logging.
+
+        :param format: printf-style format string.
+        :param args: Format arguments.
+        :returns: None.
+        """
+        del format, args
+
+    def do_POST(self) -> None:
+        """Mint the next owner token.
+
+        :returns: None.
+        """
+        cls = type(self)
+        with cls.lock:
+            cls.mint_count += 1
+            token = f"minted-{cls.mint_count}"
+        body = json.dumps({"token": token, "expires_at": time.time() + 3600}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        """Serve the resource, rejecting revoked bearers with 401.
+
+        :returns: None.
+        """
+        bearer = self.headers.get("Authorization", "")
+        revoked = {f"Bearer {_BOOTSTRAP_BEARER}", "Bearer minted-1"}
+        if bearer in revoked or not bearer.startswith("Bearer minted-"):
+            body = b"unauthorized"
+            self.send_response(401)
+        else:
+            body = b"{}"
+            self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.fixture()
+def mint_server() -> Iterator[str]:
+    """Spin up the mint + resource server.
+
+    :yields: The base URL of the server.
+    """
+    _MintAndResourceHandler.mint_count = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _MintAndResourceHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_rejection_after_bootstrap_fallback_reaches_the_resolved_provider(
+    isolated_credentials: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mint_server: str,
+) -> None:
+    """A rejected minted credential must be invalidated and re-minted.
+
+    Journey: the host-bootstrapped runner's bearer expires; the first
+    callback 401s, the bootstrap bearer is invalidated, and the fallback
+    resolves to the managed-mint provider (``minted-1``). The server later
+    revokes that credential too (e.g. a signing-key rotation) and 401s it.
+    The next callback must reach the resolved provider — invalidate its
+    cache and re-mint — and succeed. Pre-fix
+    ``_InitialAuthTokenFactory.invalidate()`` returns ``False`` without
+    forwarding to the provider, so every retry re-sends the same revoked
+    token and the runner's callbacks 401 forever.
+
+    :param isolated_credentials: Isolated Omnigent state directory fixture.
+    :param monkeypatch: pytest monkeypatch fixture.
+    :param mint_server: Base URL of the mint + resource server fixture.
+    :returns: None.
+    """
+    del isolated_credentials
+    monkeypatch.setenv(RUNNER_DELEGATED_AUTH_ENV_VAR, "1")
+    monkeypatch.setenv(RUNNER_TUNNEL_BINDING_TOKEN_ENV_VAR, "delayed-relogin-e2e-binding-token")
+
+    factory = _InitialAuthTokenFactory(_BOOTSTRAP_BEARER, mint_server)
+    auth = _RunnerDatabricksAuth(factory, server_url=mint_server)
+    resource_url = f"{mint_server}/v1/sessions/s/agent/contents"
+
+    with httpx.Client(auth=auth) as client:
+        # Callback 1: bootstrap bearer 401s -> invalidated -> fallback
+        # resolves and mints minted-1 -> the retry discovers minted-1 is
+        # ALSO revoked (rotation happened while the runner was cut off).
+        first = client.get(resource_url)
+        assert first.status_code == 401
+
+        # Callback 2: the rejection must reach the resolved mint provider so
+        # it re-mints a fresh credential the server accepts.
+        second = client.get(resource_url)
+
+    assert second.status_code == 200, (
+        f"runner callback still fails (HTTP {second.status_code}) after its "
+        "minted credential was revoked, even though re-minting would "
+        "succeed: invalidate() on the bootstrap wrapper never reaches the "
+        "resolved managed-mint provider, so every retry re-sends the same "
+        "rejected token and the runner is bricked until restart "
+        f"(mints performed: {_MintAndResourceHandler.mint_count})"
+    )

--- a/tests/runner/test_auth_recovery.py
+++ b/tests/runner/test_auth_recovery.py
@@ -94,3 +94,29 @@ def test_bootstrap_factory_invalidates_fallback_credential(
     assert factory() == "expired-fallback"
     assert factory.invalidate()
     assert factory() == "renewed"
+
+
+def test_managed_mint_invalidate_discards_cached_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A server-revoked minted JWT must be discarded and re-minted, not re-sent."""
+    minted: list[str] = []
+
+    def mint(*args: object, **kwargs: object) -> tuple[str, float]:
+        minted.append(f"minted-{len(minted) + 1}")
+        return minted[-1], 9e9
+
+    monkeypatch.setattr(_entry, "_mint_managed_owner_token", mint)
+    factory = _entry._ManagedMintTokenFactory(
+        "https://example.invalid/v1/runners/r/token",
+        "https://example.invalid",
+        "test-binding-token",
+    )
+    assert factory() == "minted-1"
+    assert factory() == "minted-1"  # cached until expiry
+    # The server rejected minted-1 (e.g. signing-key rotation): the resolved
+    # provider must drop its cache so the retry presents a fresh credential.
+    assert factory.invalidate() is True
+    assert factory() == "minted-2"
+    assert factory.invalidate() is True
+    assert factory.invalidate() is False  # nothing cached to discard

--- a/tests/runner/test_auth_recovery.py
+++ b/tests/runner/test_auth_recovery.py
@@ -1,0 +1,96 @@
+"""Credential recovery must survive asynchronous calls and delayed re-login."""
+
+from __future__ import annotations
+
+import asyncio
+from itertools import pairwise
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from omnigent.runner import _entry
+
+
+@pytest.mark.parametrize("status", [401, 403, 302])
+async def test_async_runner_auth_refreshes_outside_event_loop(
+    monkeypatch: pytest.MonkeyPatch, status: int
+) -> None:
+    """HTTP callbacks and the native policy relay can use synchronous providers."""
+    monkeypatch.setattr("omnigent.cli_auth.databricks_request_headers", lambda *a, **k: {})
+    tokens = iter(["expired", "renewed"])
+    sent: list[str] = []
+
+    def token() -> str:
+        with pytest.raises(RuntimeError, match="no running event loop"):
+            asyncio.get_running_loop()
+        return next(tokens)
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        sent.append(request.headers["Authorization"])
+        if sent[-1] == "Bearer renewed":
+            return httpx.Response(200)
+        return httpx.Response(status, headers={"Location": "/oidc/authorize"})
+
+    async with httpx.AsyncClient(
+        auth=_entry._RunnerDatabricksAuth(token), transport=httpx.MockTransport(respond)
+    ) as client:
+        response = await client.post("https://example.invalid/policies/evaluate")
+    assert response.status_code == 200
+    assert sent == ["Bearer expired", "Bearer renewed"]
+
+
+@pytest.mark.parametrize("login_succeeds", [False, True])
+def test_bootstrap_factory_retries_missing_credentials_after_long_outage(
+    monkeypatch: pytest.MonkeyPatch, login_succeeds: bool
+) -> None:
+    """Ten minutes of missing credentials neither spin nor latch failure forever."""
+    now = 0.0
+    attempts: list[float] = []
+    available = False
+
+    def discover(*args: object, **kwargs: object):
+        attempts.append(now)
+        return (lambda: "renewed") if available else None
+
+    monkeypatch.setattr(_entry, "time", SimpleNamespace(monotonic=lambda: now))
+    monkeypatch.setattr(_entry, "_make_auth_token_factory", discover)
+    factory = _entry._InitialAuthTokenFactory("expired", "https://example.invalid")
+    assert factory.invalidate()
+    for second in range(600):
+        now = float(second)
+        assert factory() is None
+    assert 1 < len(attempts) <= 120
+    assert all(b - a >= 5 for a, b in pairwise(attempts))
+    available = login_succeeds
+    now = 660.0
+    assert factory() == ("renewed" if login_succeeds else None)
+    if login_succeeds:
+        count = len(attempts)
+        now += 60
+        assert factory() == "renewed"
+        assert len(attempts) == count
+
+
+def test_bootstrap_factory_invalidates_fallback_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second rejected credential refreshes the already-resolved provider."""
+
+    class Provider:
+        refreshed = False
+
+        def __call__(self) -> str:
+            return "renewed" if self.refreshed else "expired-fallback"
+
+        def invalidate(self) -> bool:
+            self.refreshed = True
+            return True
+
+    provider = Provider()
+    monkeypatch.setattr(_entry, "_make_auth_token_factory", lambda *a, **k: provider)
+    factory = _entry._InitialAuthTokenFactory("bootstrap", "https://example.invalid")
+    factory.invalidate()
+    assert factory() == "expired-fallback"
+    assert factory.invalidate()
+    assert factory() == "renewed"

--- a/tests/runner/transports/ws_tunnel/test_auth_recovery.py
+++ b/tests/runner/transports/ws_tunnel/test_auth_recovery.py
@@ -1,0 +1,132 @@
+"""A connected tunnel survives a long credential outage until re-login."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from websockets.datastructures import Headers
+from websockets.exceptions import InvalidStatus, InvalidURI
+from websockets.http11 import Response
+
+from omnigent.runner import _entry
+from omnigent.runner.transports.ws_tunnel import serve as serve_module
+
+
+@pytest.mark.parametrize("status", [401, 403, 302])
+@pytest.mark.parametrize("login_succeeds", [False, True])
+async def test_connected_tunnel_survives_delayed_or_failed_relogin(
+    monkeypatch: pytest.MonkeyPatch, status: int, login_succeeds: bool
+) -> None:
+    """Simulate ten minutes of rejections without killing a connected runner."""
+    now = 0.0
+    attempts = 0
+    recovered = False
+    sleeps: list[float] = []
+    shutdown = asyncio.Event()
+
+    def discover(*args: object, **kwargs: object):
+        return (lambda: "renewed") if login_succeeds and now >= 600 else None
+
+    async def serve_once(app: Any, **kwargs: Any) -> None:
+        nonlocal attempts, recovered
+        attempts += 1
+        if attempts == 1:
+            kwargs["on_connected"]()
+            return
+        if kwargs["auth_token"] == "renewed":
+            kwargs["on_connected"]()
+            recovered = True
+            shutdown.set()
+            return
+        if status == 302:
+            raise InvalidURI("https://example.invalid/oidc/authorize", "scheme isn't ws or wss")
+        raise InvalidStatus(Response(status, "Unauthorized", Headers(), b""))
+
+    async def sleep(delay: float) -> None:
+        nonlocal now
+        sleeps.append(delay)
+        now += delay
+        if now >= 660:
+            shutdown.set()
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(_entry, "time", SimpleNamespace(monotonic=lambda: now))
+    monkeypatch.setattr(_entry, "_make_auth_token_factory", discover)
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", serve_once)
+    monkeypatch.setattr(
+        serve_module, "asyncio", SimpleNamespace(**(vars(asyncio) | {"sleep": sleep}))
+    )
+    monkeypatch.setattr(serve_module.random, "uniform", lambda *args: 0.0)
+    factory = _entry._InitialAuthTokenFactory("bootstrap", "https://example.invalid")
+    await serve_module.serve_tunnel(
+        serve_once,
+        server_url="https://example.invalid",
+        runner_id="synthetic-runner",
+        runner_version="0.1.0",
+        auth_token="bootstrap",
+        auth_token_factory=factory,
+        shutdown_event=shutdown,
+    )
+    assert recovered is login_succeeds
+    assert now >= 600
+    assert attempts > 3
+    assert max(sleeps) <= 10
+
+
+@pytest.mark.parametrize("status", [401, 403, 302])
+@pytest.mark.parametrize("refresh_fails", [False, True])
+async def test_rejection_invalidates_off_loop_and_tolerates_refresh_failure(
+    monkeypatch: pytest.MonkeyPatch, status: int, refresh_fails: bool
+) -> None:
+    shutdown = asyncio.Event()
+    attempts = 0
+
+    class Provider:
+        invalidations = 0
+
+        def __call__(self) -> str:
+            return "renewed" if self.invalidations else "expired"
+
+        def invalidate(self) -> bool:
+            with pytest.raises(RuntimeError, match="no running event loop"):
+                asyncio.get_running_loop()
+            self.invalidations += 1
+            if refresh_fails:
+                raise OSError("temporary credential provider failure")
+            return True
+
+    provider = Provider()
+
+    async def serve_once(app: Any, **kwargs: Any) -> None:
+        nonlocal attempts
+        attempts += 1
+        if kwargs["auth_token"] == "renewed":
+            shutdown.set()
+            return
+        if status == 302:
+            raise InvalidURI("https://example.invalid/oidc/authorize", "scheme isn't ws or wss")
+        raise InvalidStatus(Response(status, "Unauthorized", Headers(), b""))
+
+    async def sleep(delay: float) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(serve_module, "_serve_tunnel_once", serve_once)
+    monkeypatch.setattr(
+        serve_module, "asyncio", SimpleNamespace(**(vars(asyncio) | {"sleep": sleep}))
+    )
+    await asyncio.wait_for(
+        serve_module.serve_tunnel(
+            serve_once,
+            server_url="https://example.invalid",
+            runner_id="synthetic-runner",
+            runner_version="0.1.0",
+            auth_token_factory=provider,
+            shutdown_event=shutdown,
+        ),
+        timeout=5,
+    )
+    assert attempts == 2
+    assert provider.invalidations == 1

--- a/tests/util/test_threaded_auth.py
+++ b/tests/util/test_threaded_auth.py
@@ -1,0 +1,73 @@
+"""Async transport and cancellation behavior of blocking auth providers."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import AsyncIterator, Generator
+from contextlib import suppress
+
+import httpx
+
+from omnigent.util.threaded_auth import ThreadedAuth
+
+
+async def test_async_streaming_bodies_remain_available_to_auth() -> None:
+    """Body-dependent auth sees buffered request and response streams on retry."""
+
+    class BodyAuth(ThreadedAuth):
+        requires_request_body = True
+        requires_response_body = True
+
+        def auth_flow(
+            self, request: httpx.Request
+        ) -> Generator[httpx.Request, httpx.Response, None]:
+            assert request.content == b"request"
+            response = yield request
+            assert response.content == b"response"
+
+    class Body(httpx.AsyncByteStream):
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            yield b"response"
+
+    async def body() -> AsyncIterator[bytes]:
+        yield b"request"
+
+    async with httpx.AsyncClient(
+        auth=BodyAuth(),
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, stream=Body())),
+    ) as client:
+        response = await client.post("https://example.invalid", content=body())
+    assert response.status_code == 200
+
+
+async def test_cancellation_waits_for_provider_cleanup_without_blocking_loop() -> None:
+    """Cancellation cannot close a generator while its credential lookup runs."""
+    started = asyncio.Event()
+    release = threading.Event()
+    closed = threading.Event()
+    loop = asyncio.get_running_loop()
+
+    class BlockingAuth(ThreadedAuth):
+        def auth_flow(
+            self, request: httpx.Request
+        ) -> Generator[httpx.Request, httpx.Response, None]:
+            try:
+                loop.call_soon_threadsafe(started.set)
+                assert release.wait(timeout=5)
+                yield request
+            finally:
+                closed.set()
+
+    flow = BlockingAuth().async_auth_flow(httpx.Request("GET", "https://example.invalid"))
+    task = asyncio.create_task(anext(flow))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=3)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not closed.is_set()
+    finally:
+        release.set()
+    with suppress(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=3)
+    assert closed.is_set()


### PR DESCRIPTION
## Related issue

Closes #7199

## Summary

A runner that has already connected can stop recovering when login takes several minutes. Keep retrying missing credential discovery, forward later invalidations to the resolved provider, and let login redirects use the normal reconnect backoff. Run blocking HTTP authentication and WebSocket credential invalidation in worker threads.

In plain terms: the runner waits for credentials to become usable again and resumes without a restart.

```mermaid
flowchart LR
  A[Credential rejected] --> B[Invalidate in worker]
  B --> C[Reconnect backoff]
  C --> D[Rediscover or refresh]
  D --> E{Credentials usable?}
  E -->|Yes| F[Resume connection]
  E -->|No| C
```

The existing initial-authentication failure threshold remains in place for runners that have never connected.

## Test Plan

- 70 relevant tests passed: async HTTP retry for 401/403/login redirects, ten-minute delayed or failed login with a virtual clock, fallback invalidation, transient invalidation failures, request/response streaming, cancellation cleanup, and existing runner/tunnel regressions.
- `pre-commit run` passed; Pyrefly reported zero errors.
- Tests use synthetic credentials and mock upstream transport. No live credentials were changed.

Reproduce locally: `uv run --extra all pytest tests/runner/test_auth_recovery.py tests/runner/transports/ws_tunnel/test_auth_recovery.py tests/util/test_threaded_auth.py`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The virtual-clock tests cover both successful and unsuccessful login after ten minutes. Real host/runner startup is outside these tests.

## Changelog

Connected runners recover after delayed re-login without requiring a restart.

## Issues

Resolves [OMNI-7323](https://linear.app/omnigent/issue/OMNI-7323/runner-authentication-does-not-recover-after-a-delayed-re-login)
