### PR TITLE
fix(claude-native): mirror terminal dialogs and notifications into chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,13 @@ omnigent hermes                      # Hermes Agent (Nous Research)
 omnigent pi                          # Pi
 ```
 
+Claude-native also mirrors terminal notifications and visible numbered dialogs
+into the chat as expandable notices, including tool descriptions, hook warnings,
+and the displayed choices. These notices survive a refresh but are not sent back
+to the model. Respond using the approval card when one is available, or open the
+terminal; a notice does not approve a tool. Text hidden behind a collapsed
+description or outside the terminal viewport is not captured.
+
 `omnigent agy` requires agy 1.1.13 or newer. When `GEMINI_API_KEY` is set,
 direct Gemini API authentication takes precedence over agy's saved OAuth login.
 

--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -724,6 +724,7 @@ class ClaudeHookRecord:
         each counted entry (see :func:`_normalize_background_task`), so the UI
         can name them. ``None`` for non-``Stop`` events, when the array is
         absent, or when no counted entry carried a usable field.
+    :param notification_message: Notification title and message, when present.
     """
 
     event_cursor: int
@@ -744,6 +745,7 @@ class ClaudeHookRecord:
     task_status: str | None = None
     background_task_count: int = 0
     background_tasks: list[_JsonObject] | None = None
+    notification_message: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1924,6 +1926,7 @@ def build_hook_settings(
         "SessionStart": [{"hooks": [session_start_hook]}],
         "Stop": [{"hooks": [hook]}],
         "StopFailure": [{"hooks": [hook]}],
+        "Notification": [{"hooks": [hook]}],
         # ``UserPromptSubmit`` is the symmetric counterpart to
         # ``Stop`` — fires when a new user prompt reaches Claude
         # (web-UI message via tmux send-keys, or direct keystrokes
@@ -3491,7 +3494,23 @@ def _hook_record_from_jsonl_record(record: _JsonlRecord) -> ClaudeHookRecord:
         task_status=task_status,
         background_task_count=background_task_count,
         background_tasks=background_tasks,
+        notification_message=_notification_message(payload)
+        if event_name == "Notification"
+        else None,
     )
+
+
+def _notification_message(payload: object) -> str | None:
+    """Keep notification text and title, not unrelated hook metadata."""
+    if not isinstance(payload, dict):
+        return None
+    message = payload.get("message")
+    if not isinstance(message, str) or not message.strip():
+        return None
+    title = payload.get("title")
+    if isinstance(title, str) and title.strip():
+        return f"{title.strip()}\n\n{message.strip()}"
+    return message.strip()
 
 
 def _read_complete_jsonl_records(
@@ -4224,10 +4243,12 @@ class PaneSignals:
         ``"auto"``, or ``None`` when no mode footer is visible.
     :param btw_overlay: A settled ``/btw`` side-chat overlay, or ``None``
         when none is shown / it is still generating.
+    :param terminal_message: Visible numbered dialog text, or ``None``.
     """
 
     permission_mode: str | None = None
     btw_overlay: BtwOverlay | None = None
+    terminal_message: str | None = None
 
 
 def _btw_overlay_from_pane(pane: str) -> BtwOverlay | None:
@@ -6541,9 +6562,12 @@ def read_pane_signals(bridge_dir: Path) -> PaneSignals:
     if not isinstance(socket_path, str) or not isinstance(tmux_target, str):
         return PaneSignals()
     pane = _capture_pane(socket_path, tmux_target)
+    from omnigent.harnesses.claude_native.tui_messages import terminal_message_from_pane
+
     return PaneSignals(
         permission_mode=_permission_mode_from_pane(pane),
         btw_overlay=_btw_overlay_from_pane(pane),
+        terminal_message=terminal_message_from_pane(pane),
     )
 
 

--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -746,6 +746,8 @@ class _ForwardDedupeState:
     # single ``capture-pane`` subprocess (feeding both the permission-mode and
     # /btw signals) spawns at _PANE_POLL_INTERVAL_S, not every poll.
     pane_next_read: float = 0.0
+    pending_terminal_message_key: str | None = None
+    posted_terminal_message_key: str | None = None
     # Turn-settle latch driving the scheduled-wake boundary. The Stop edge
     # records the ended turn's id as PENDING; it activates (moves to
     # ``settled_response_id``) only once a fully-consumed transcript batch
@@ -1352,17 +1354,25 @@ async def forward_claude_transcript_to_session(
                             bridge_dir=bridge_dir,
                             dedupe=dedupe,
                         )
-                        # Footer-derived signals (permission mode, /btw overlay)
-                        # emit no event and live only in the rendered pane. One
-                        # throttled capture feeds both, so a shift+tab switch and
-                        # a settled /btw exchange both reach the web view without
-                        # spawning a capture-pane subprocess per signal.
-                        await _forward_pane_signals(
+                    else:
+                        hook_state = await _forward_available_status_events(
                             client=client,
                             session_id=current_session_id,
                             bridge_dir=bridge_dir,
+                            state=hook_state,
+                            retry_tracker=status_retries,
                             dedupe=dedupe,
+                            task_subjects=task_subjects,
+                            task_statuses=task_statuses,
+                            task_order=task_order,
                         )
+                    await _forward_pane_signals(
+                        client=client,
+                        session_id=current_session_id,
+                        bridge_dir=bridge_dir,
+                        dedupe=dedupe,
+                        response_id=state.current_response_id if state is not None else None,
+                    )
             except asyncio.CancelledError:
                 await _cancel_subagent_forward_task(subagent_task)
                 raise
@@ -3491,8 +3501,8 @@ async def _forward_available_status_events(
     ``POST /v1/sessions/{id}/events`` with type ``external_session_status``
     — the authoritative turn-end edges that drive sub-agent terminal
     delivery (see :data:`_HOOK_EVENT_TO_STATUS`). ``running`` stays
-    PTY-derived (the pane-activity watcher drives the UI badge). Other hook
-    event names advance the cursor without emitting (no status meaning).
+    PTY-derived (the pane-activity watcher drives the UI badge). Notifications
+    persist as UI-only notices without changing the turn status.
 
     Also forwards native task state changes (``TaskCreated``,
     ``TaskCompleted``, ``PostToolUse``/``TaskUpdate``) and
@@ -3574,6 +3584,32 @@ async def _forward_available_status_events(
             await _write_hook_state_async(bridge_dir, durable)
             continue
         if status is None:
+            if record.notification_message is not None:
+                source_id = (
+                    f"claude-notification:{record.claude_session_id}:"
+                    f"{record.recorded_at}:{record.event_cursor}:{record.byte_offset}"
+                )
+                if retry_tracker.retry_delay_s(source_id) is not None:
+                    return durable
+                try:
+                    await _post_terminal_notice(
+                        client,
+                        session_id=session_id,
+                        message=record.notification_message,
+                        source_id=source_id,
+                    )
+                except httpx.HTTPError as exc:
+                    decision = retry_tracker.record_failure(source_id, exc)
+                    _logger.warning(
+                        "Claude notification post failed; session=%s source_id=%s exhausted=%s",
+                        session_id,
+                        source_id,
+                        decision.exhausted,
+                        exc_info=True,
+                    )
+                    if not decision.exhausted:
+                        return durable
+                retry_tracker.clear(source_id)
             # Compaction boundary (PreCompact / SessionStart source=compact)
             # → forward as a compaction-status event so the web UI brackets
             # Claude's real terminal compaction with its spinner. Best-effort:
@@ -5095,12 +5131,12 @@ async def _forward_pane_signals(
     session_id: str,
     bridge_dir: Path,
     dedupe: _ForwardDedupeState,
+    response_id: str | None = None,
 ) -> None:
     """
     Capture the Claude pane ONCE per window and relay every footer signal.
 
-    Neither the permission mode nor a ``/btw`` side-chat is observable to
-    Omnigent through the transcript, deltas, or hooks — both live only in the
+    Permission mode, ``/btw`` side-chats, and terminal dialogs live only in the
     rendered pane. Rather than each spawning its own ``tmux capture-pane``
     subprocess, this reads the pane a single time (throttled to
     :data:`_PANE_POLL_INTERVAL_S`) and hands the one snapshot to each relay,
@@ -5111,6 +5147,7 @@ async def _forward_pane_signals(
     :param session_id: Omnigent session/conversation id.
     :param bridge_dir: Native Claude bridge directory.
     :param dedupe: Shared per-session dedupe state; mutated in place.
+    :param response_id: Active turn, or ``None`` before the transcript exists.
     """
     now = time.monotonic()
     if now < dedupe.pane_next_read:
@@ -5122,6 +5159,73 @@ async def _forward_pane_signals(
     )
     await _relay_btw_overlay(
         client, session_id=session_id, overlay=signals.btw_overlay, dedupe=dedupe
+    )
+    await _relay_terminal_message(
+        client,
+        session_id=session_id,
+        message=signals.terminal_message,
+        response_id=response_id,
+        dedupe=dedupe,
+    )
+
+
+async def _relay_terminal_message(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    message: str | None,
+    response_id: str | None,
+    dedupe: _ForwardDedupeState,
+) -> None:
+    """Persist stable dialogs once per turn; never answer a terminal prompt."""
+    if message is None:
+        dedupe.pending_terminal_message_key = None
+        return
+    key = hashlib.sha256(f"{response_id or session_id}\x00{message}".encode()).hexdigest()
+    if key == dedupe.posted_terminal_message_key:
+        return
+    if key != dedupe.pending_terminal_message_key:
+        dedupe.pending_terminal_message_key = key
+        return
+    try:
+        await _post_terminal_notice(
+            client,
+            session_id=session_id,
+            message=(
+                "Claude displayed this prompt in the terminal. "
+                "Use its approval card if available, or open the terminal to respond.\n\n"
+                f"{message}"
+            ),
+            source_id=f"claude-terminal:{key}",
+        )
+    except httpx.HTTPError:
+        _logger.debug("Claude terminal notice post failed; session=%s", session_id, exc_info=True)
+        return
+    dedupe.posted_terminal_message_key = key
+
+
+async def _post_terminal_notice(
+    client: httpx.AsyncClient,
+    *,
+    session_id: str,
+    message: str,
+    source_id: str,
+) -> None:
+    """Use a durable UI-only notice, excluded from model context and turn status."""
+    await _post_external_conversation_item(
+        client,
+        session_id=session_id,
+        item=ClaudeTranscriptItem(
+            source_id=source_id,
+            response_id=source_id,
+            item_type="error",
+            data={
+                "source": "harness",
+                "code": "claude_terminal_notice",
+                "message": message,
+                "level": "info",
+            },
+        ),
     )
 
 

--- a/omnigent/harnesses/claude_native/tui_messages.py
+++ b/omnigent/harnesses/claude_native/tui_messages.py
@@ -1,0 +1,59 @@
+"""Read-only extraction of Claude dialogs absent from its transcript."""
+
+from __future__ import annotations
+
+import re
+
+_OPTION = re.compile(r"^\s*(?P<caret>[❯›>])?\s*(?P<number>\d+)\.\s+(?P<label>\S.*)$")
+_BORDER = re.compile(r"^\s*[╭╰┌└┏┗╔╚]?[─━═]{8,}[╮╯┐┘┓┛╗╝]?\s*$")
+_SIDES = re.compile(r"^\s*[│┃║] ?|\s*[│┃║]\s*$")
+_FOOTER = re.compile(r"\b(?:Esc|Enter|Tab) to (?:cancel|confirm|select|continue|amend)\b")
+_TITLE = re.compile(r"^\s*(?:Tool use|Bash command|Permission request)\s*$")
+
+
+def terminal_message_from_pane(pane: str) -> str | None:
+    """Return the visible dialog, including context and choices, without driving it."""
+    lines = [_SIDES.sub("", line) for line in pane.splitlines()]
+    selected = next(
+        (
+            index
+            for index in range(len(lines) - 1, -1, -1)
+            if (match := _OPTION.match(lines[index])) and match.group("caret")
+        ),
+        None,
+    )
+    if selected is None:
+        return None
+    start = next(
+        (index + 1 for index in range(selected - 1, -1, -1) if _BORDER.match(lines[index])),
+        0,
+    )
+    title = next((index for index in range(start, selected) if _TITLE.match(lines[index])), None)
+    if title is not None:
+        start = title
+    footer = next(
+        (index for index in range(selected + 1, len(lines)) if _FOOTER.search(lines[index])),
+        None,
+    )
+    end = footer + 1 if footer is not None else len(lines)
+    region = lines[start:end]
+    options = [match for line in region if (match := _OPTION.match(line))]
+    if len(options) < 2 or len({match.group("number") for match in options}) != len(options):
+        return None
+    if footer is None and not (
+        title is not None and any(line.strip().endswith("?") for line in region)
+    ):
+        return None
+    if any(
+        line.lstrip().startswith(("❯", "›", ">")) and not _OPTION.match(line)
+        for line in lines[selected + 1 :]
+    ):
+        return None
+    normalized = [
+        f"{match.group('number')}. {match.group('label')}"
+        if (match := _OPTION.match(line))
+        else line.strip()
+        for line in region
+        if not _BORDER.match(line)
+    ]
+    return "\n".join(normalized).strip() or None

--- a/tests/e2e_ui/messages/test_claude_terminal_notices.py
+++ b/tests/e2e_ui/messages/test_claude_terminal_notices.py
@@ -1,0 +1,54 @@
+"""Terminal prompts reach the live chat and remain readable after reload."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import httpx
+from playwright.sync_api import Page, expect
+
+from omnigent.harnesses.claude_native import forwarder
+from omnigent.harnesses.claude_native.tui_messages import terminal_message_from_pane
+from tests.test_claude_native_tui_messages import TOOL_SEARCH_PROMPT
+
+
+def test_terminal_prompt_notice_streams_and_survives_reload(
+    page: Page, seeded_session: tuple[str, str]
+) -> None:
+    base_url, session_id = seeded_session
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.get_by_role("textbox", name="Message the agent")).to_be_visible(timeout=15_000)
+
+    async def relay() -> None:
+        async with httpx.AsyncClient(base_url=base_url) as client:
+            for _ in range(2):
+                dedupe = forwarder._ForwardDedupeState()
+                for _ in range(2):
+                    await forwarder._relay_terminal_message(
+                        client,
+                        session_id=session_id,
+                        message=terminal_message_from_pane(TOOL_SEARCH_PROMPT),
+                        response_id="terminal-notice-turn",
+                        dedupe=dedupe,
+                    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(asyncio.run, relay()).result(timeout=30)
+    for reload in (False, True):
+        if reload:
+            page.reload()
+        notice = page.get_by_test_id("error-pill")
+        expect(notice).to_have_count(1, timeout=15_000)
+        expect(notice).to_have_attribute("data-level", "info")
+        notice.locator('button[aria-expanded="false"]').click()
+        contents = notice.get_by_test_id("error-message-content")
+        for text in (
+            "ToolSearch",
+            "Databricks token refresh returned no token",
+            "settings.json to update hooks",
+            "1. Yes",
+            "2. Yes, and don't ask again",
+            "3. No",
+        ):
+            expect(contents).to_contain_text(text)

--- a/tests/e2e_ui/messages/test_native_claude_confirmations_notifications_in_chat.py
+++ b/tests/e2e_ui/messages/test_native_claude_confirmations_notifications_in_chat.py
@@ -1,0 +1,268 @@
+r"""Claude-native terminal confirmations + notifications must reach the chat.
+
+The ``claude-native`` ("Claude Code") wrapper is terminal-first: a real ``claude``
+CLI runs in the session terminal, the SPA's **Terminal** view attaches to that
+live TUI, and the SPA's **Chat** view renders the SAME canonical transcript
+(``GET /v1/sessions/{id}/items``). When Claude shows a *terminal-only* numbered
+tool-confirmation dialog — e.g. a ``ToolSearch`` prompt carrying its description,
+a ``PreToolUse`` warning that Omnigent policy evaluation was unavailable, a
+token-refresh failure, and Yes / remember / No choices — the chat gives NO
+explanation of what is waiting. Native notifications are missing from chat too.
+
+The bug has two independent facets, each guarded here so a partial fix cannot
+pass silently:
+
+facet 1 — the native Claude hook settings register no ``Notification`` hook, so a
+    native notification can never be relayed to chat. Asserted against the REAL
+    generated ``claude-settings.json`` of a live runner-launched session.
+
+facet 2 — the shared pane capture relays the permission-mode footer and a ``/btw``
+    side-chat, but NOT numbered dialogs: ``read_pane_signals`` only parses
+    ``PaneSignals(permission_mode, btw_overlay)`` and ``_forward_pane_signals``
+    only relays those two, so a captured dialog's warning + choices reach no chat
+    item. Reproduced provider-free (per the report) by driving the REAL relay
+    with a sanitized ``ToolSearch`` fail-ask dialog pane: the same capture that
+    mirrors the mode footer drops the dialog's warning and every choice.
+
+Expected behavior (the fail->pass target for the fix): mirror native
+notifications and the visible text of numbered dialogs to chat, preserving the
+warning and all displayed choices, without treating them as model output or
+auto-answering the prompt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from omnigent.harnesses.claude_native import bridge as claude_native_bridge
+from omnigent.harnesses.claude_native import forwarder
+
+# claude-native auto-launch + first-run pre-accept can take a while; the runner
+# writes claude-settings.json at launch (before any hook runs), so this only
+# waits out the bootstrap, not a model turn.
+_SETTINGS_READY_TIMEOUT_S = 120.0
+
+# The file the runner writes the composed hook settings to inside the bridge
+# dir (``_INVOCATION_SETTINGS_FILE`` in bridge.py).
+_SETTINGS_FILENAME = "claude-settings.json"
+
+
+# ── facet 2 fixtures: sanitized captured panes ──────────────────────────────
+# A settled ``/btw`` side-chat overlay — a signal the relay DOES mirror today.
+# Layout mirrors the real capture: inert scrollback, the ``▔`` overlay border,
+# the question, the answer, then the copy/fork/close footer.
+_BTW_BORDER = "▔" * 40
+_BTW_QUESTION = "/btw is this backward compatible?"
+_BTW_ANSWER = "Yes, the public API is unchanged."
+_BTW_PANE = "\n".join(
+    [
+        "welcome banner line",
+        "another line",
+        _BTW_BORDER,
+        "",
+        f"    {_BTW_QUESTION}",
+        "",
+        f"      {_BTW_ANSWER}",
+        "",
+        "    ↑/↓ to scroll · c to copy · f to fork · Esc to close",
+    ]
+)
+
+# The reported ToolSearch numbered tool-confirmation dialog, sanitized. It
+# carries the tool description, the "Omnigent policy evaluation unavailable"
+# PreToolUse warning, a token-refresh failure, and Yes / remember / No choices,
+# with a permission-mode footer BELOW it (exactly as a real capture would: the
+# mode footer is relayed, the dialog above it is not).
+_DIALOG_WARNING = "Omnigent policy evaluation unavailable"
+_DIALOG_TOKEN_REFRESH = "token refresh failed"
+_DIALOG_DESCRIPTION = "Search available tools and skills by query."
+_CHOICE_YES = "1. Yes"
+_CHOICE_REMEMBER = "2. Yes, and don't ask again for ToolSearch commands"
+_CHOICE_NO = "3. No, and tell Claude what to do differently"
+
+# The warning + every displayed choice the fix must mirror to chat.
+_DIALOG_NEEDLES = (_DIALOG_WARNING, _CHOICE_YES, _CHOICE_REMEMBER, _CHOICE_NO)
+
+_TOOLSEARCH_DIALOG_PANE = "\n".join(
+    [
+        "● I'll look up the deployment runbook for you.",
+        "",
+        "╭" + "─" * 70 + "╮",
+        "│ Tool use",
+        "│",
+        '│   ToolSearch(query: "deploy runbook")',
+        f"│   {_DIALOG_DESCRIPTION}",
+        "│",
+        f"│   ⚠ {_DIALOG_WARNING} (could not reach or",
+        f"│     authenticate to the Omnigent server); {_DIALOG_TOKEN_REFRESH}:",
+        "│     401 from gateway.",
+        "│",
+        "│   Do you want to proceed?",
+        f"│ ❯ {_CHOICE_YES}",
+        f"│   {_CHOICE_REMEMBER}",
+        f"│   {_CHOICE_NO} (esc)",
+        "╰" + "─" * 70 + "╯",
+        "  ⏸ manual mode on",
+    ]
+)
+
+
+def _wait_for_generated_settings(base_url: str, session_id: str) -> dict[str, Any]:
+    """Read the live session's real generated ``claude-settings.json``.
+
+    Resolves the bridge dir from the session's bridge-id label (the same way
+    the SPA's terminal view finds the pane) and polls until the runner has
+    written the composed hook settings.
+
+    :param base_url: Spawned server base URL.
+    :param session_id: The runner-launched claude-native session id.
+    :returns: The parsed settings object.
+    """
+    from omnigent.harnesses.claude_native.bridge import (
+        BRIDGE_ID_LABEL_KEY,
+        bridge_dir_for_bridge_id,
+    )
+
+    deadline = time.monotonic() + _SETTINGS_READY_TIMEOUT_S
+    last_candidate: Path | None = None
+    while time.monotonic() < deadline:
+        session = httpx.get(f"{base_url}/v1/sessions/{session_id}", timeout=10.0).json()
+        labels = session.get("labels") or {}
+        bridge_id = labels.get(BRIDGE_ID_LABEL_KEY) or session_id
+        last_candidate = bridge_dir_for_bridge_id(bridge_id) / _SETTINGS_FILENAME
+        if last_candidate.exists():
+            try:
+                return json.loads(last_candidate.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                pass  # mid-write; retry
+        time.sleep(1.0)
+    raise AssertionError(
+        f"claude-settings.json never appeared for session {session_id} within "
+        f"{_SETTINGS_READY_TIMEOUT_S}s (last looked at {last_candidate})"
+    )
+
+
+def test_native_hook_settings_register_notification_hook(
+    native_claude_mock_session: tuple[str, str],
+) -> None:
+    """facet 1: the live session's hook settings must register a Notification hook.
+
+    A native ``Notification`` (Claude asking for attention / permission, an idle
+    notice, ...) can only reach the chat transcript if the harness registers a
+    ``Notification`` hook. Today ``build_hook_settings`` registers none, so the
+    notice is terminal-only. This reads the REAL settings the runner generated
+    for a live claude-native session.
+    """
+    base_url, session_id = native_claude_mock_session
+
+    settings = _wait_for_generated_settings(base_url, session_id)
+    hooks = settings.get("hooks") or {}
+
+    # Sanity: these are the real generated settings, not an empty / half-written
+    # read — several always-on hooks are present.
+    assert "SessionStart" in hooks and "Stop" in hooks, (
+        f"expected the real generated claude-settings.json hooks; got keys={sorted(hooks)}"
+    )
+
+    # The bug: no Notification hook, so native notifications never reach chat.
+    assert "Notification" in hooks, (
+        "facet 1: claude-native hook settings register no 'Notification' hook, "
+        "so native Claude notifications are never relayed to the chat "
+        f"transcript. registered hooks={sorted(hooks)}"
+    )
+
+
+def test_pane_relay_mirrors_numbered_dialog(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """facet 2: the pane-capture relay must mirror a numbered dialog's text to chat.
+
+    Drives the REAL forwarder relay (``_forward_pane_signals`` ->
+    ``read_pane_signals`` -> the pane parsers) with sanitized captured panes,
+    substituting only the ``tmux capture-pane`` read (``_capture_pane``) with a
+    fixture — the report's provider-free reproduction. A ``/btw`` overlay pane is
+    the positive control (the relay mirrors it today); the ToolSearch dialog pane
+    is the bug: the same capture mirrors the permission-mode footer but drops the
+    warning and every choice.
+    """
+    # ``read_pane_signals`` reads tmux coordinates from the bridge dir before
+    # capturing; the capture itself is stubbed, so the values are inert.
+    (tmp_path / "tmux.json").write_text(
+        json.dumps({"socket_path": "sock", "tmux_target": "tgt"}), encoding="utf-8"
+    )
+
+    pane_holder = {"pane": ""}
+
+    def _fake_capture(*_args: Any, **_kwargs: Any) -> str:
+        """Serve the current fixture pane in place of a live tmux capture."""
+        return pane_holder["pane"]
+
+    # ``read_pane_signals`` looks up ``_capture_pane`` as a bridge-module global
+    # at call time, so patching it here intercepts the real parser's input.
+    monkeypatch.setattr(claude_native_bridge, "_capture_pane", _fake_capture)
+
+    def _drive(pane: str, times: int) -> list[dict[str, Any]]:
+        """Run the real pane-signals relay ``times`` polls over ``pane``.
+
+        :returns: The event bodies POSTed to the session's events endpoint.
+        """
+        pane_holder["pane"] = pane
+        calls: list[dict[str, Any]] = []
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            """Record each relayed event body; return a benign success."""
+            calls.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(200, json={"queued": False, "item_id": "item_x"})
+
+        async def _run() -> None:
+            dedupe = forwarder._ForwardDedupeState()
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport, base_url="http://ap") as client:
+                for _ in range(times):
+                    # Clear the per-poll capture throttle so every poll re-reads.
+                    dedupe.pane_next_read = 0.0
+                    await forwarder._forward_pane_signals(
+                        client,
+                        session_id="conv-native-claude",
+                        bridge_dir=tmp_path,
+                        dedupe=dedupe,
+                    )
+
+        asyncio.run(_run())
+        return calls
+
+    # Positive control: a settled /btw overlay IS relayed (two-read stability
+    # guard, so drive twice) — the relay pipeline works for what it parses.
+    btw_calls = _drive(_BTW_PANE, times=2)
+    btw_types = [c.get("type") for c in btw_calls]
+    assert "external_btw_sidechat" in btw_types, (
+        f"control: the /btw overlay should relay an external_btw_sidechat event; got {btw_types}"
+    )
+
+    # The bug: the ToolSearch numbered dialog. The SAME capture carries a
+    # permission-mode footer (relayed) and the dialog (dropped).
+    dialog_calls = _drive(_TOOLSEARCH_DIALOG_PANE, times=3)
+    dialog_types = [c.get("type") for c in dialog_calls]
+
+    # The relay ran and mirrored the permission mode from this very capture...
+    assert "external_permission_mode_change" in dialog_types, (
+        "the dialog capture's permission-mode footer should relay an "
+        f"external_permission_mode_change event; got {dialog_types}"
+    )
+
+    # ...but must ALSO mirror the numbered dialog's warning + every choice.
+    relayed = json.dumps(dialog_calls, ensure_ascii=False)
+    missing = [needle for needle in _DIALOG_NEEDLES if needle not in relayed]
+    assert not missing, (
+        "facet 2: the shared pane capture relayed the permission mode but "
+        "dropped the numbered tool-confirmation dialog — its warning and "
+        f"choices never reached a chat event. missing from the wire: {missing}. "
+        f"relayed event types: {dialog_types}"
+    )

--- a/tests/test_claude_native_tui_messages.py
+++ b/tests/test_claude_native_tui_messages.py
@@ -1,0 +1,301 @@
+"""Terminal-only dialogs and notifications must reach the chat without approving tools."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from omnigent.harnesses.claude_native import bridge, forwarder
+from omnigent.harnesses.claude_native.tui_messages import terminal_message_from_pane
+
+
+@pytest.fixture(autouse=True)
+def trusted_bridge_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(bridge, "_TRUSTED_PARENT", tmp_path)
+    monkeypatch.setattr(bridge, "_BRIDGE_ROOT", tmp_path)
+
+
+TOOL_SEARCH_PROMPT = """────────────────────────────────────────────────────────
+ Tool use
+ ToolSearch
+ Fetches full schema definitions for deferred tools so they can be called.
+ Deferred tools appear by name in system-reminder messages.
+ (ctrl+o to expand description)
+ PreToolUse: ToolSearch requires confirmation for this tool:
+ Omnigent policy evaluation unavailable (could not reach or authenticate to
+ the Omnigent server); please approve or deny this tool call manually.
+ Detail: Databricks token refresh returned no token
+ settings.json to update hooks
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and don't ask again for ToolSearch commands in /workspace
+   3. No
+ Esc to cancel · Tab to amend
+"""
+
+
+@pytest.mark.parametrize("caret", ["❯", "›", ">"])
+@pytest.mark.parametrize("with_footer", [True, False])
+def test_tool_search_dialog_preserves_context_and_all_choices(
+    caret: str, with_footer: bool
+) -> None:
+    pane = TOOL_SEARCH_PROMPT.replace("❯", caret)
+    if not with_footer:
+        pane = pane[: pane.index(" Esc to cancel")]
+    message = terminal_message_from_pane(pane)
+    assert message is not None
+    for text in (
+        "ToolSearch",
+        "Fetches full schema definitions",
+        "PreToolUse: ToolSearch requires confirmation",
+        "Omnigent policy evaluation unavailable",
+        "Databricks token refresh returned no token",
+        "settings.json to update hooks",
+        "1. Yes",
+        "2. Yes, and don't ask again for ToolSearch commands in /workspace",
+        "3. No",
+    ):
+        assert text in message
+    assert "────────────────" not in message
+
+
+def test_dialog_identity_ignores_selected_choice() -> None:
+    moved = TOOL_SEARCH_PROMPT.replace("❯ 1.", "  1.").replace("  3. No", "❯ 3. No")
+    assert terminal_message_from_pane(moved) == terminal_message_from_pane(TOOL_SEARCH_PROMPT)
+
+
+@pytest.mark.parametrize("side", ["│", "┃", "║"])
+def test_boxed_dialog_preserves_the_same_message(side: str) -> None:
+    lines = TOOL_SEARCH_PROMPT.splitlines()[1:]
+    pane = "\n".join(
+        ["╭────────────────────────────────────────────────────────╮"]
+        + [f"{side} {line} {side}" for line in lines]
+        + ["╰────────────────────────────────────────────────────────╯"]
+    )
+    assert terminal_message_from_pane(pane) == terminal_message_from_pane(TOOL_SEARCH_PROMPT)
+
+
+def test_other_numbered_dialogs_do_not_require_yes_no_choices() -> None:
+    message = terminal_message_from_pane(
+        "─────────────\nSign in\nChoose an account\n"
+        "› 1. Personal\n  2. Organization\nEnter to select"
+    )
+    assert message == "Sign in\nChoose an account\n1. Personal\n2. Organization\nEnter to select"
+
+
+@pytest.mark.parametrize(
+    "pane",
+    [
+        "",
+        "An answer\n1. Yes\n2. No\n❯",
+        "Select a file\n❯ 1. file.txt",
+        "An answer quoting options\n❯ 1. Yes\n2. No",
+        TOOL_SEARCH_PROMPT + "\n❯\n? for shortcuts",
+        TOOL_SEARCH_PROMPT + "\n❯ continue with the next task\n? for shortcuts",
+        TOOL_SEARCH_PROMPT.replace("3. No", "2. No"),
+    ],
+)
+def test_non_dialogs_are_not_forwarded(pane: str) -> None:
+    assert terminal_message_from_pane(pane) is None
+
+
+def test_notification_hook_is_registered_without_a_server(tmp_path: Path) -> None:
+    settings = bridge.build_hook_settings(tmp_path)
+    assert settings["hooks"]["Notification"] == settings["hooks"]["Stop"]
+    assert "matcher" not in settings["hooks"]["Notification"][0]
+
+
+@pytest.mark.parametrize("message", [None, 123, {}, "", "  "])
+def test_malformed_notifications_are_ignored(tmp_path: Path, message: object) -> None:
+    bridge.record_hook_event(tmp_path, {"hook_event_name": "Notification", "message": message})
+    result = bridge.read_hook_events_from_offset(tmp_path, 0, start_event_count=0)
+    assert result.records[0].notification_message is None
+
+
+@pytest.mark.asyncio
+async def test_pane_notices_retry_dedupe_and_keep_the_same_id_on_restart(tmp_path: Path) -> None:
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content))
+        return httpx.Response(503 if len(calls) == 1 else 200, json={})
+
+    message = terminal_message_from_pane(TOOL_SEARCH_PROMPT)
+    dedupe = forwarder._ForwardDedupeState()
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        for _ in range(5):
+            await forwarder._relay_terminal_message(
+                client, session_id="session", message=message, response_id="turn", dedupe=dedupe
+            )
+        assert len(calls) == 2
+        for _ in range(2):
+            await forwarder._relay_terminal_message(
+                client,
+                session_id="session",
+                message=message,
+                response_id="next-turn",
+                dedupe=dedupe,
+            )
+        assert len(calls) == 3
+        restarted = forwarder._ForwardDedupeState()
+        for _ in range(2):
+            await forwarder._relay_terminal_message(
+                client,
+                session_id="session",
+                message=message,
+                response_id="next-turn",
+                dedupe=restarted,
+            )
+    assert calls[0] == calls[1]
+    assert calls[2] == calls[3]
+    assert calls[1]["data"]["source_id"] != calls[2]["data"]["source_id"]
+    assert all(call["type"] == "external_conversation_item" for call in calls)
+    notice = calls[0]["data"]["item_data"]
+    assert notice["level"] == "info"
+    assert "Use its approval card if available" in notice["message"]
+    assert "Databricks token refresh returned no token" in notice["message"]
+
+
+@pytest.mark.asyncio
+async def test_pane_capture_relays_dialog_without_driving_terminal(tmp_path: Path) -> None:
+    (tmp_path / "tmux.json").write_text(
+        json.dumps({"socket_path": "socket", "tmux_target": "pane"})
+    )
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content))
+        return httpx.Response(200, json={})
+
+    dedupe = forwarder._ForwardDedupeState()
+    with (
+        patch.object(bridge, "_capture_pane", return_value=TOOL_SEARCH_PROMPT) as capture,
+        patch.object(bridge, "_run_tmux") as run_tmux,
+        patch.object(forwarder, "_PANE_POLL_INTERVAL_S", 0),
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="http://ap"
+        ) as client:
+            for _ in range(3):
+                await forwarder._forward_pane_signals(
+                    client, session_id="session", bridge_dir=tmp_path, dedupe=dedupe
+                )
+        assert capture.call_count == 3
+        run_tmux.assert_not_called()
+    assert len(calls) == 1
+    assert "3. No" in calls[0]["data"]["item_data"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_notification_delivery_keeps_cursor_until_post_succeeds(tmp_path: Path) -> None:
+    bridge.record_hook_event(
+        tmp_path,
+        {
+            "hook_event_name": "Notification",
+            "title": "Authentication",
+            "message": "Token refresh failed",
+            "notification_type": "auth_error",
+        },
+    )
+    bridge.record_hook_event(
+        tmp_path,
+        {
+            "hook_event_name": "Notification",
+            "message": "An unfamiliar notification",
+            "notification_type": "future_kind",
+        },
+    )
+    calls: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content))
+        return httpx.Response(503 if len(calls) == 1 else 200, json={})
+
+    state = forwarder.HookForwardState(event_cursor=0, byte_offset=0)
+    tracker = forwarder._PostRetryTracker(base_delay_s=0, max_delay_s=0)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://ap"
+    ) as client:
+        for attempt in range(3):
+            state = await forwarder._forward_available_status_events(
+                client=client,
+                session_id="session",
+                bridge_dir=tmp_path,
+                state=state,
+                retry_tracker=tracker,
+                dedupe=forwarder._ForwardDedupeState(),
+                task_subjects={},
+                task_statuses={},
+                task_order=[],
+            )
+            assert state.event_cursor == (0 if attempt == 0 else 2)
+    assert len(calls) == 3
+    assert calls[0] == calls[1]
+    assert calls[0]["data"]["item_data"]["message"] == "Authentication\n\nToken refresh failed"
+    assert calls[2]["data"]["item_data"]["message"] == "An unfamiliar notification"
+    assert all(call["type"] == "external_conversation_item" for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_startup_dialog_and_notification_forward_before_transcript_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bridge.record_hook_event(
+        tmp_path, {"hook_event_name": "Notification", "message": "Authentication required"}
+    )
+    calls: list[dict] = []
+    delivered = asyncio.Event()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(json.loads(request.content))
+        if len(calls) >= 2:
+            delivered.set()
+        return httpx.Response(200, json={})
+
+    @asynccontextmanager
+    async def client_factory(*args: object, **kwargs: object) -> AsyncIterator[httpx.AsyncClient]:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler), base_url="http://ap"
+        ) as client:
+            yield client
+
+    monkeypatch.setattr("omnigent.cli_auth.open_server_client", client_factory)
+    monkeypatch.setattr(forwarder, "_PANE_POLL_INTERVAL_S", 0)
+    monkeypatch.setattr(
+        forwarder,
+        "read_pane_signals",
+        lambda _bridge_dir: bridge.PaneSignals(
+            terminal_message=terminal_message_from_pane(TOOL_SEARCH_PROMPT)
+        ),
+    )
+    task = asyncio.create_task(
+        forwarder.forward_claude_transcript_to_session(
+            base_url="http://ap",
+            session_id="session",
+            bridge_dir=tmp_path,
+            headers={},
+            agent_name="claude-native-ui",
+            poll_interval_s=0.01,
+            start_at_end=False,
+        )
+    )
+    try:
+        await asyncio.wait_for(delivered.wait(), timeout=5)
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+    assert bridge.read_transcript_path(tmp_path) is None
+    assert all(call["type"] == "external_conversation_item" for call in calls)
+    assert calls[0]["data"]["item_data"]["message"] == "Authentication required"
+    assert "ToolSearch" in calls[1]["data"]["item_data"]["message"]


### PR DESCRIPTION
## Related issue

Closes #7212

## Summary

- Claude can be waiting on a terminal confirmation while the chat omits its explanation. Mirror every `Notification` hook's message/title and visible numbered dialogs, including the reported `ToolSearch` description, policy/authentication warning, and all displayed choices.
- Reuse the existing expandable, persistent informational notice. Notices are excluded from model context, do not change turn status, and never answer a tool prompt. Continue using an existing approval card or the terminal to respond; this is separate from the interactive fallback proposed in #6111.
- Forward startup notices even before a transcript exists. Reuse the shared pane capture, require two stable observations, normalize selection movement, retry failed delivery, and use server-side idempotency across restarts/refresh.

**ELI5:** If Claude says something important only in the terminal, the chat now keeps a readable copy. It does not press Yes for you.

```text
Notification hook ──> durable hook log ─┐
                                     ├─> forwarder ─> UI-only notice ─> live chat / reload
Shared pane capture ─> stable dialog ─┘
```

## Test Plan

**Results:** 653 backend/unit tests passed; the browser test passed; all applicable pre-commit checks passed, including Pyrefly (0 errors).

- `OMNIGENT_WRAPPER_BYPASS=1 uv run --no-sync pytest tests/test_claude_native_tui_messages.py tests/test_claude_native_hook.py tests/test_claude_native_bridge.py tests/test_claude_native_forwarder.py -n 4 --dist=loadfile -q`
- `OMNIGENT_WRAPPER_BYPASS=1 uv run --no-sync pytest tests/e2e_ui/messages/test_claude_terminal_notices.py --ui-skip-build -q` — browser test uses a freshly built SPA and the isolated mock-backed server; no provider credentials required. Omit `--ui-skip-build` for the first run.
- `pre-commit run` on all staged changes, including Pyrefly.
- Verified the baseline `main` hook settings lack `Notification`; new coverage also exercises the reported prompt, unknown notification types, startup without a transcript, retry/cursor handling, caret movement, and no terminal writes.

**Manual verification:** Start a new Claude-native session so it receives the updated hooks. Trigger a native tool confirmation or use a session already showing one. In chat, expand the new **Notice** and check that the description, warning, and numbered choices match the terminal. Refresh: one copy remains. Answer using its existing approval card or terminal; the notice itself must not execute the tool.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The browser test forwards a sanitized `ToolSearch` pane through the real parser/relay, server, SSE stream, and chat renderer, then repeats delivery with a fresh forwarder state and reloads. It asserts exactly one neutral notice containing the token-refresh warning, hook-settings hint, and all three choices. No frontend component changes.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Automated coverage uses the reported prompt as a sanitized fixture, mocked transport failures, and a real browser/server. A live vendor-authentication outage was not induced. The relay preserves **visible** dialog text: it cannot recover descriptions hidden behind expand controls or lines clipped by the terminal viewport. This PR does not replace the approval workflow or claim to mirror every arbitrary terminal frame.

## Changelog

Claude-native terminal notifications and visible confirmation dialogs now appear as persistent notices in chat, including their warnings and choices.

## Issues

Resolves [OMNI-7340](https://linear.app/omnigent/issue/OMNI-7340/bug-claude-native-terminal-confirmations-and-notifications-are-missing)
