### PR TITLE
feat(cli): record startup phase latency

### DIFF
--- a/omnigent/_runner_startup.py
+++ b/omnigent/_runner_startup.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
+import time
 from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from pathlib import Path
@@ -77,12 +78,106 @@ STARTUP_PHASE_LABELS: tuple[str, ...] = (
     STARTUP_PHASE_LAUNCHING_AGENT,
 )
 
+_NATIVE_HARNESS_PREPARATION_MESSAGES = {
+    "Preparing Claude...": "claude",
+    "Preparing Codex...": "codex",
+    "Preparing OpenCode...": "opencode",
+    "Preparing Pi...": "pi",
+    "Preparing Cursor...": "cursor",
+    "Preparing Kiro...": "kiro",
+    "Preparing Goose...": "goose",
+    "Preparing Hermes...": "hermes",
+    "Preparing Antigravity...": "antigravity",
+    "Preparing qwen...": "qwen",
+    "Preparing Kimi...": "kimi",
+}
+NATIVE_STARTUP_HARNESSES = frozenset(_NATIVE_HARNESS_PREPARATION_MESSAGES.values())
+
+
+def _startup_metric_phase(message: str) -> str | None:
+    """Map a rendered native-harness milestone to a bounded phase."""
+    lowered = message.casefold()
+    if message == STARTUP_PHASE_CONNECTING_REMOTE:
+        return "connect_server"
+    if message in _NATIVE_HARNESS_PREPARATION_MESSAGES:
+        return "prepare_harness"
+    if lowered == "connecting to local daemon...":
+        return "connect_local_daemon"
+    if lowered.startswith("creating ") and lowered.endswith(" session..."):
+        return "create_session"
+    if lowered.startswith("loading ") and lowered.endswith(" session..."):
+        return "load_session"
+    if lowered.startswith("updating ") and lowered.endswith(" session..."):
+        return "update_session"
+    if lowered.startswith("restoring ") and lowered.endswith(" session..."):
+        return "restore_session"
+    if lowered == "starting runner...":
+        return "start_runner"
+    if lowered == "waiting for runner...":
+        return "wait_runner"
+    if lowered.startswith("starting ") and lowered.endswith(" terminal..."):
+        return "start_terminal"
+    if lowered.startswith("restoring ") and lowered.endswith(" terminal..."):
+        return "restore_terminal"
+    if lowered.endswith(" terminal ready."):
+        return None
+    return "unknown"
+
 
 def _noop() -> None:
     """No-op default for :attr:`RunnerStartupProgress.finish`.
 
     :returns: None.
     """
+
+
+@dataclass
+class _StartupPhaseTimer:
+    harness: str
+    phase: str
+    started_at: float
+
+    def transition(self, phase: str | None) -> None:
+        transitioned_at = time.monotonic()
+        self._record("success", ended_at=transitioned_at)
+        if phase is not None:
+            self.phase = phase
+            self.started_at = transitioned_at
+
+    def finish(self, outcome: str) -> None:
+        if not self.phase:
+            return
+        self._record(outcome, ended_at=time.monotonic())
+
+    def _record(self, outcome: str, *, ended_at: float) -> None:
+        if not self.phase:
+            return
+        from omnigent.runtime.startup_metrics import record_startup_phase_duration
+
+        duration_ms = (ended_at - self.started_at) * 1000
+        record_startup_phase_duration(
+            duration_ms,
+            phase=self.phase,
+            harness=self.harness,
+            outcome=outcome,
+        )
+        self.phase = ""
+
+
+@contextlib.contextmanager
+def _record_startup_outcome(
+    phase_timer: _StartupPhaseTimer | None,
+) -> Generator[None, None, None]:
+    """Close the active startup phase with the context's outcome."""
+    try:
+        yield
+    except BaseException:
+        if phase_timer is not None:
+            phase_timer.finish("failure")
+        raise
+    else:
+        if phase_timer is not None:
+            phase_timer.finish("success")
 
 
 @dataclass
@@ -135,6 +230,7 @@ def runner_startup_progress(
     *,
     initial_message: str,
     enabled: bool | None = None,
+    metric_harness: str | None = None,
 ) -> Generator[RunnerStartupProgress, None, None]:
     """
     Context manager that renders runner-startup progress.
@@ -164,6 +260,8 @@ def runner_startup_progress(
         ``OMNIGENT_NO_SPINNER``. ``True`` always renders the
         spinner; ``False`` always falls back to plain echo. Used
         by tests; production callers should leave this ``None``.
+    :param metric_harness: Stable harness label for phase metrics. ``None``
+        infers known native harnesses from their preparation message.
     :yields: A :class:`RunnerStartupProgress` whose ``update``
         callback sets the current message.
     """
@@ -172,6 +270,19 @@ def runner_startup_progress(
             sys.stderr.isatty(),
             dict(os.environ),
         )
+
+    metric_harness = metric_harness or _NATIVE_HARNESS_PREPARATION_MESSAGES.get(initial_message)
+    phase_timer = None
+    if metric_harness is not None:
+        phase_timer = _StartupPhaseTimer(
+            metric_harness,
+            _startup_metric_phase(initial_message) or "unknown",
+            time.monotonic(),
+        )
+
+    def _transition_metric_phase(message: str) -> None:
+        if phase_timer is not None:
+            phase_timer.transition(_startup_metric_phase(message))
 
     if enabled:
         from rich.live import Live
@@ -212,6 +323,7 @@ def runner_startup_progress(
                 ``"Launching your agent…"``.
             :returns: None.
             """
+            _transition_metric_phase(msg)
             spinner.update(text=msg)
 
         def _finish_rich() -> None:
@@ -225,10 +337,11 @@ def runner_startup_progress(
             _stopped[0] = True
             live.stop()
 
-        try:
-            yield RunnerStartupProgress(update=_update_rich, finish=_finish_rich)
-        finally:
-            _finish_rich()
+        with _record_startup_outcome(phase_timer):
+            try:
+                yield RunnerStartupProgress(update=_update_rich, finish=_finish_rich)
+            finally:
+                _finish_rich()
         return
 
     # Plain mode: each ``update`` prints a fresh line on stderr.
@@ -245,11 +358,13 @@ def runner_startup_progress(
             ``"Launching your agent…"``.
         :returns: None.
         """
+        _transition_metric_phase(msg)
         click.echo(f"omnigent: {msg}", err=True)
 
     # Plain mode has no live region to tear down, so ``finish`` is a
     # no-op (the printed lines stay in scrollback by design).
-    yield RunnerStartupProgress(update=_update_plain, finish=_noop)
+    with _record_startup_outcome(phase_timer):
+        yield RunnerStartupProgress(update=_update_plain, finish=_noop)
 
 
 def format_runner_log_tail(log_path: Path | None) -> str:

--- a/omnigent/_runner_startup.py
+++ b/omnigent/_runner_startup.py
@@ -97,6 +97,10 @@ NATIVE_STARTUP_HARNESSES = frozenset(_NATIVE_HARNESS_PREPARATION_MESSAGES.values
 def _startup_metric_phase(message: str) -> str | None:
     """Map a rendered native-harness milestone to a bounded phase."""
     lowered = message.casefold()
+    if message == STARTUP_PHASE_STARTING:
+        return "start_backend"
+    if message == STARTUP_PHASE_LOCAL_SERVER:
+        return "start_local_server"
     if message == STARTUP_PHASE_CONNECTING_REMOTE:
         return "connect_server"
     if message in _NATIVE_HARNESS_PREPARATION_MESSAGES:
@@ -138,16 +142,24 @@ class _StartupPhaseTimer:
     started_at: float
 
     def transition(self, phase: str | None) -> None:
-        transitioned_at = time.monotonic()
-        self._record("success", ended_at=transitioned_at)
-        if phase is not None:
-            self.phase = phase
-            self.started_at = transitioned_at
+        with contextlib.suppress(Exception):
+            transitioned_at = time.monotonic()
+            self._record("success", ended_at=transitioned_at)
+            if phase is not None:
+                self.phase = phase
+                self.started_at = transitioned_at
+            return
+        # Telemetry must never interrupt progress rendering or startup.
+        self.phase = ""
 
     def finish(self, outcome: str) -> None:
         if not self.phase:
             return
-        self._record(outcome, ended_at=time.monotonic())
+        with contextlib.suppress(Exception):
+            self._record(outcome, ended_at=time.monotonic())
+            return
+        # Best effort: startup remains authoritative if instrumentation fails.
+        self.phase = ""
 
     def _record(self, outcome: str, *, ended_at: float) -> None:
         if not self.phase:

--- a/omnigent/_runner_startup.py
+++ b/omnigent/_runner_startup.py
@@ -149,7 +149,8 @@ class _StartupPhaseTimer:
                 self.phase = phase
                 self.started_at = transitioned_at
             return
-        # Telemetry must never interrupt progress rendering or startup.
+        # Fail closed for the rest of this startup: telemetry must never
+        # interrupt progress rendering or repeatedly retry a broken recorder.
         self.phase = ""
 
     def finish(self, outcome: str) -> None:

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3593,7 +3593,7 @@ def _ensure_databricks_server_auth(server: str, *, non_interactive: bool = False
     _databricks_login(server, workspace_host, org_id=_org_id_from_url(server))
 
 
-def _ensure_backend(server: str | None) -> str:
+def _ensure_backend(server: str | None, *, metric_harness: str | None = None) -> str:
     """Ensure the host daemon is running and return the Omnigent server URL.
 
     The daemon is the single backend for ``attach`` / ``run`` / ``claude`` /
@@ -3605,6 +3605,9 @@ def _ensure_backend(server: str | None) -> str:
         ``""`` selects local mode: the daemon starts (or reuses) a
         persistent local Omnigent server and this returns its discovered loopback
         URL.
+    :param metric_harness: Canonical native harness key when the caller has
+        already resolved it. Dedicated harness commands fall back to the Click
+        command context.
     :returns: A concrete base URL, e.g. ``"http://127.0.0.1:8123"`` or the
         remote URL passed in.
     :raises click.ClickException: If local mode's server never becomes
@@ -3621,14 +3624,16 @@ def _ensure_backend(server: str | None) -> str:
         native_coding_agent_for_terminal_name,
     )
 
-    ctx = click.get_current_context(silent=True)
-    native_agent = None
-    if ctx is not None and ctx.info_name == "run":
-        native_agent = native_coding_agent_for_harness(ctx.params.get("harness"))
-    elif ctx is not None:
-        terminal_name = "antigravity" if ctx.info_name == "agy" else ctx.info_name
-        native_agent = native_coding_agent_for_terminal_name(terminal_name)
-    startup_harness = native_agent.key if native_agent is not None else None
+    startup_harness = metric_harness
+    if startup_harness is None:
+        ctx = click.get_current_context(silent=True)
+        native_agent = None
+        if ctx is not None and ctx.info_name == "run":
+            native_agent = native_coding_agent_for_harness(ctx.params.get("harness"))
+        elif ctx is not None:
+            terminal_name = "antigravity" if ctx.info_name == "agy" else ctx.info_name
+            native_agent = native_coding_agent_for_terminal_name(terminal_name)
+        startup_harness = native_agent.key if native_agent is not None else None
 
     # The foreground client owns these phase timers. Runtime processes initialize
     # their own providers, but that does not install one in this process.
@@ -7525,7 +7530,7 @@ def _dispatch_native_terminal_harness(
             f"the REPL-only option(s) {', '.join(unsupported)} have no effect there — remove them."
         )
 
-    server = _ensure_backend(server)
+    server = _ensure_backend(server, metric_harness=native_agent.key)
     passthrough = ("--model", model) if model else ()
 
     # Resolve --continue to a concrete conversation id (the wrappers take a

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3611,17 +3611,31 @@ def _ensure_backend(server: str | None) -> str:
         reachable.
     """
     from omnigent._runner_startup import (
-        NATIVE_STARTUP_HARNESSES,
         STARTUP_PHASE_CONNECTING_REMOTE,
         STARTUP_PHASE_LOCAL_SERVER,
         STARTUP_PHASE_STARTING,
         runner_startup_progress,
     )
+    from omnigent.native.native_coding_agents import (
+        native_coding_agent_for_harness,
+        native_coding_agent_for_terminal_name,
+    )
 
     ctx = click.get_current_context(silent=True)
-    startup_harness = ctx.info_name if ctx is not None else None
-    if startup_harness not in NATIVE_STARTUP_HARNESSES:
-        startup_harness = None
+    native_agent = None
+    if ctx is not None and ctx.info_name == "run":
+        native_agent = native_coding_agent_for_harness(ctx.params.get("harness"))
+    elif ctx is not None:
+        terminal_name = "antigravity" if ctx.info_name == "agy" else ctx.info_name
+        native_agent = native_coding_agent_for_terminal_name(terminal_name)
+    startup_harness = native_agent.key if native_agent is not None else None
+
+    # The foreground client owns these phase timers. Runtime processes initialize
+    # their own providers, but that does not install one in this process.
+    if startup_harness is not None:
+        from omnigent.runtime import telemetry
+
+        telemetry.init(service_name="omni-client")
 
     if server:
         # Remote / explicit-server mode: the server isn't ours to restart, so
@@ -3660,7 +3674,10 @@ def _ensure_backend(server: str | None) -> str:
     # It clears on context exit — before any auth-mode-change echo below and
     # before the REPL/terminal the caller brings up — and falls back to plain
     # stderr lines off a TTY (CI, daemon logfiles).
-    with runner_startup_progress(initial_message=STARTUP_PHASE_STARTING) as progress:
+    with runner_startup_progress(
+        initial_message=STARTUP_PHASE_STARTING,
+        metric_harness=startup_harness,
+    ) as progress:
         config_changed = _ensure_host_daemon(None)
         progress.update(STARTUP_PHASE_LOCAL_SERVER)
         local_url = _discover_local_server_url()

--- a/omnigent/cli.py
+++ b/omnigent/cli.py
@@ -3611,11 +3611,17 @@ def _ensure_backend(server: str | None) -> str:
         reachable.
     """
     from omnigent._runner_startup import (
+        NATIVE_STARTUP_HARNESSES,
         STARTUP_PHASE_CONNECTING_REMOTE,
         STARTUP_PHASE_LOCAL_SERVER,
         STARTUP_PHASE_STARTING,
         runner_startup_progress,
     )
+
+    ctx = click.get_current_context(silent=True)
+    startup_harness = ctx.info_name if ctx is not None else None
+    if startup_harness not in NATIVE_STARTUP_HARNESSES:
+        startup_harness = None
 
     if server:
         # Remote / explicit-server mode: the server isn't ours to restart, so
@@ -3634,7 +3640,10 @@ def _ensure_backend(server: str | None) -> str:
 
         server = _resolve_server_url(server).api_base
         with (
-            runner_startup_progress(initial_message=STARTUP_PHASE_CONNECTING_REMOTE),
+            runner_startup_progress(
+                initial_message=STARTUP_PHASE_CONNECTING_REMOTE,
+                metric_harness=startup_harness,
+            ),
             concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool,
         ):
             auth_future = pool.submit(_ensure_databricks_server_auth, server)

--- a/omnigent/runtime/startup_metrics.py
+++ b/omnigent/runtime/startup_metrics.py
@@ -1,0 +1,78 @@
+"""OpenTelemetry metrics for foreground CLI startup phases."""
+
+from __future__ import annotations
+
+import atexit
+import logging
+from functools import lru_cache
+from typing import Protocol
+
+from omnigent.runtime.telemetry import telemetry_enabled
+
+_logger = logging.getLogger(__name__)
+
+STARTUP_PHASE_DURATION_METRIC_NAME = "omnigent.client.startup.phase.duration"
+_OTEL_METER_NAME = "omnigent.client.startup"
+_EXIT_FLUSH_TIMEOUT_MS = 3_000
+_flush_registered = False
+
+
+class _Histogram(Protocol):
+    def record(self, amount: int | float, attributes: dict[str, str] | None = None) -> None: ...
+
+
+@lru_cache(maxsize=1)
+def _duration_histogram() -> _Histogram:
+    from opentelemetry import metrics as otel_metrics
+
+    return otel_metrics.get_meter(_OTEL_METER_NAME).create_histogram(
+        STARTUP_PHASE_DURATION_METRIC_NAME,
+        unit="ms",
+        description="Foreground CLI startup phase duration.",
+    )
+
+
+def _flush_startup_metrics() -> None:
+    """Best-effort flush for CLIs that exit before the periodic export."""
+    try:
+        from opentelemetry import metrics as otel_metrics
+
+        provider = otel_metrics.get_meter_provider()
+        force_flush = getattr(provider, "force_flush", None)
+        if force_flush is not None:
+            force_flush(timeout_millis=_EXIT_FLUSH_TIMEOUT_MS)
+    except Exception:
+        _logger.debug("failed to flush startup metrics", exc_info=True)
+
+
+def _register_exit_flush() -> None:
+    global _flush_registered
+
+    if _flush_registered:
+        return
+    _flush_registered = True
+    atexit.register(_flush_startup_metrics)
+
+
+def record_startup_phase_duration(
+    duration_ms: float,
+    *,
+    phase: str,
+    harness: str,
+    outcome: str,
+) -> None:
+    """Record one bounded foreground startup phase, best effort."""
+    if not telemetry_enabled():
+        return
+    try:
+        _duration_histogram().record(
+            max(0.0, duration_ms),
+            attributes={
+                "phase": phase,
+                "harness": harness,
+                "outcome": outcome,
+            },
+        )
+        _register_exit_flush()
+    except Exception:
+        _logger.debug("failed to record startup phase metric", exc_info=True)

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -10,6 +10,7 @@ wiring that routes ``--server`` through them.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import io
 import json
@@ -2290,6 +2291,32 @@ def test_ensure_backend_remote_passthrough(monkeypatch: pytest.MonkeyPatch) -> N
     # The daemon receives the normalized (slash-stripped) URL so its
     # pidfile target matches what later commands compute.
     assert calls == ["https://example.databricksapps.com"]
+
+
+def test_ensure_backend_labels_remote_connect_with_click_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The early remote-connect phase uses the active native harness label."""
+    captured: list[tuple[str, str | None]] = []
+
+    @contextlib.contextmanager
+    def _capture_progress(*, initial_message: str, metric_harness: str | None = None):
+        captured.append((initial_message, metric_harness))
+        yield
+
+    monkeypatch.setattr("omnigent._runner_startup.runner_startup_progress", _capture_progress)
+    monkeypatch.setattr(cli, "_ensure_host_daemon", lambda _server: None)
+    monkeypatch.setattr(cli, "_workspace_api_server_url", lambda server: server.rstrip("/"))
+    monkeypatch.setattr(cli, "_ensure_databricks_server_auth", lambda _server: None)
+
+    @click.command("codex")
+    def _codex() -> None:
+        _ensure_backend("https://example.databricksapps.com/")
+
+    result = CliRunner().invoke(_codex)
+
+    assert result.exit_code == 0, result.output
+    assert captured == [("Connecting to the server…", "codex")]
 
 
 def test_ensure_backend_local_discovers_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_backend.py
+++ b/tests/cli/test_backend.py
@@ -2293,11 +2293,23 @@ def test_ensure_backend_remote_passthrough(monkeypatch: pytest.MonkeyPatch) -> N
     assert calls == ["https://example.databricksapps.com"]
 
 
+@pytest.mark.parametrize(
+    ("command_name", "args", "expected_harness"),
+    [
+        ("codex", [], "codex"),
+        ("agy", [], "antigravity"),
+        ("run", ["--harness", "codex-native"], "codex"),
+    ],
+)
 def test_ensure_backend_labels_remote_connect_with_click_harness(
     monkeypatch: pytest.MonkeyPatch,
+    command_name: str,
+    args: list[str],
+    expected_harness: str,
 ) -> None:
-    """The early remote-connect phase uses the active native harness label."""
+    """Remote startup initializes metrics and resolves canonical harness labels."""
     captured: list[tuple[str, str | None]] = []
+    initialized: list[str | None] = []
 
     @contextlib.contextmanager
     def _capture_progress(*, initial_message: str, metric_harness: str | None = None):
@@ -2308,15 +2320,57 @@ def test_ensure_backend_labels_remote_connect_with_click_harness(
     monkeypatch.setattr(cli, "_ensure_host_daemon", lambda _server: None)
     monkeypatch.setattr(cli, "_workspace_api_server_url", lambda server: server.rstrip("/"))
     monkeypatch.setattr(cli, "_ensure_databricks_server_auth", lambda _server: None)
+    monkeypatch.setattr(
+        "omnigent.runtime.telemetry.init",
+        lambda service_name=None: initialized.append(service_name),
+    )
+
+    @click.command(command_name)
+    @click.option("--harness")
+    def _command(harness: str | None) -> None:
+        _ensure_backend("https://example.databricksapps.com/")
+
+    result = CliRunner().invoke(_command, args)
+
+    assert result.exit_code == 0, result.output
+    assert captured == [("Connecting to the server…", expected_harness)]
+    assert initialized == ["omni-client"]
+
+
+def test_ensure_backend_labels_local_startup_with_click_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local startup keeps the canonical harness across backend phase changes."""
+    captured: list[tuple[str, str | None]] = []
+
+    @contextlib.contextmanager
+    def _capture_progress(*, initial_message: str, metric_harness: str | None = None):
+        captured.append((initial_message, metric_harness))
+
+        class _Progress:
+            @staticmethod
+            def update(message: str) -> None:
+                captured.append((message, metric_harness))
+
+        yield _Progress()
+
+    monkeypatch.setattr("omnigent._runner_startup.runner_startup_progress", _capture_progress)
+    monkeypatch.setattr("omnigent.runtime.telemetry.init", lambda service_name=None: None)
+    monkeypatch.setattr(cli, "_ensure_host_daemon", lambda _server: False)
+    monkeypatch.setattr(cli, "_discover_local_server_url", lambda: "http://127.0.0.1:8123")
+    monkeypatch.setattr(cli, "_update_daemon_resolved_server_url", lambda *_args: None)
 
     @click.command("codex")
     def _codex() -> None:
-        _ensure_backend("https://example.databricksapps.com/")
+        _ensure_backend(None)
 
     result = CliRunner().invoke(_codex)
 
     assert result.exit_code == 0, result.output
-    assert captured == [("Connecting to the server…", "codex")]
+    assert captured == [
+        ("Starting up…", "codex"),
+        ("Starting the local server…", "codex"),
+    ]
 
 
 def test_ensure_backend_local_discovers_url(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6839,7 +6839,13 @@ def test_dispatch_native_terminal_harness_launches_registered_wrapper(
     expected_extra: dict[str, object],
 ) -> None:
     """Every registered native harness launches through the generic run dispatcher."""
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    backend_harnesses: list[str | None] = []
+
+    def _capture_backend(_server: str | None, *, metric_harness: str | None = None) -> str:
+        backend_harnesses.append(metric_harness)
+        return "http://localhost:0"
+
+    monkeypatch.setattr("omnigent.cli._ensure_backend", _capture_backend)
     captured: dict[str, object] = {}
     monkeypatch.setattr(target, lambda **kwargs: captured.update(kwargs))
 
@@ -6853,6 +6859,9 @@ def test_dispatch_native_terminal_harness_launches_registered_wrapper(
     )
 
     assert handled is True
+    # The run command resolves configured and first-run defaults before dispatch.
+    # Pass that canonical result instead of rediscovering the raw Click flag.
+    assert backend_harnesses == [harness.removesuffix("-native")]
     assert captured == {
         "server": "http://localhost:0",
         "session_id": "conv_abc123",
@@ -6874,7 +6883,7 @@ def test_dispatch_native_terminal_harness_cursor_launches_wrapper(
     TUI is the single source of turns. A top-level ``--model`` is forwarded as a
     passthrough ``--model`` flag.
     """
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "omnigent.harnesses.cursor_native.main.run_cursor_native",
@@ -6903,7 +6912,7 @@ def test_dispatch_native_terminal_harness_kiro_launches_wrapper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``run --harness kiro-native`` dispatches to the Kiro TUI wrapper."""
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "omnigent.harnesses.kiro_native.main.run_kiro_native",
@@ -6935,7 +6944,7 @@ def test_dispatch_native_terminal_harness_kiro_forwards_prompt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Kiro's native wrapper supports an initial prompt from generic run."""
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
     captured: dict[str, object] = {}
     monkeypatch.setattr(
         "omnigent.harnesses.kiro_native.main.run_kiro_native",
@@ -6966,7 +6975,7 @@ def test_dispatch_native_terminal_harness_forwards_prompt_to_claude_and_codex(
     no longer a REPL-only option for them. A multi-line prompt must arrive as
     one value — the wrappers put it on argv rather than pasting it.
     """
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
     captured: dict[str, object] = {}
     monkeypatch.setattr(target, lambda **kwargs: captured.update(kwargs))
 
@@ -7002,7 +7011,7 @@ def test_dispatch_native_terminal_harness_own_config_model_policy(
     expected_args: tuple[str, ...],
 ) -> None:
     """Own-config wrappers receive only models explicitly requested by users."""
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
     captured: dict[str, object] = {}
     monkeypatch.setattr(target, lambda **kwargs: captured.update(kwargs))
 
@@ -7080,7 +7089,7 @@ def test_dispatch_native_terminal_harness_continue_resumes_latest(
     ``cursor-native-ui`` conversation and hand that to the wrapper as the
     session id.
     """
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
     seen: dict[str, object] = {}
 
     def _fake_latest(*, base_url: str, agent_name: str, headers: object) -> str:
@@ -7113,7 +7122,7 @@ def test_dispatch_native_terminal_harness_continue_with_no_prior_fails_loud(
     as ``session_id`` would silently open a new session. Matches the REPL's
     ``_resolve_resume_target`` "No prior conversation" behavior.
     """
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
     monkeypatch.setattr("omnigent.chat._resolve_latest_conversation_id", lambda **_kw: None)
     monkeypatch.setattr("omnigent.chat._remote_headers", lambda **_kw: {})
 
@@ -7132,7 +7141,7 @@ def test_dispatch_native_terminal_harness_explicit_id_skips_latest_lookup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An explicit ``--resume <id>`` wins over ``--continue`` (no latest lookup)."""
-    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s: "http://localhost:0")
+    monkeypatch.setattr("omnigent.cli._ensure_backend", lambda _s, **_kwargs: "http://localhost:0")
 
     def _must_not_lookup(**_kw: object) -> str:
         raise AssertionError("latest-conversation lookup ran despite an explicit id")

--- a/tests/cli/test_runner_startup.py
+++ b/tests/cli/test_runner_startup.py
@@ -243,6 +243,25 @@ def test_runner_startup_progress_records_active_phase_failure(monkeypatch) -> No
     assert recorded == [(1250.0, "failure")]
 
 
+def test_runner_startup_progress_ignores_metric_failures(monkeypatch, capsys) -> None:
+    """Instrumentation failures never interrupt progress or the startup body."""
+    ticks = iter((1.0, 2.0))
+    monkeypatch.setattr("omnigent._runner_startup.time.monotonic", lambda: next(ticks))
+    monkeypatch.setattr(
+        startup_metrics,
+        "record_startup_phase_duration",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("metric failed")),
+    )
+
+    with runner_startup_progress(
+        initial_message="Preparing Codex...",
+        enabled=False,
+    ) as progress:
+        progress.update("Waiting for runner...")
+
+    assert "Waiting for runner" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize(
     ("message", "harness"),
     [

--- a/tests/cli/test_runner_startup.py
+++ b/tests/cli/test_runner_startup.py
@@ -31,6 +31,7 @@ from omnigent._runner_startup import (
     format_runner_log_tail,
     runner_startup_progress,
 )
+from omnigent.runtime import startup_metrics
 
 # ---------------------------------------------------------------------------
 # format_runner_log_tail
@@ -191,6 +192,92 @@ def test_runner_startup_progress_plain_mode_does_not_swallow_exceptions(
     # The initial message still printed; the exception did not
     # suppress it.
     assert "omnigent: Starting" in capsys.readouterr().err
+
+
+def test_runner_startup_progress_records_phase_durations(monkeypatch, capsys) -> None:
+    """Metric phases close on transitions without affecting rendered text."""
+    ticks = iter((1.0, 2.0, 4.5))
+    recorded: list[tuple[float, str, str, str]] = []
+    monkeypatch.setattr("omnigent._runner_startup.time.monotonic", lambda: next(ticks))
+    monkeypatch.setattr(
+        startup_metrics,
+        "record_startup_phase_duration",
+        lambda duration, *, phase, harness, outcome: recorded.append(
+            (duration, phase, harness, outcome)
+        ),
+    )
+
+    with runner_startup_progress(
+        initial_message="Preparing Codex...",
+        enabled=False,
+    ) as progress:
+        progress.update("Waiting for runner...")
+        progress.update("Codex terminal ready.")
+
+    assert recorded == [
+        (1000.0, "prepare_harness", "codex", "success"),
+        (2500.0, "wait_runner", "codex", "success"),
+    ]
+    assert "Waiting for runner" in capsys.readouterr().err
+
+
+def test_runner_startup_progress_records_active_phase_failure(monkeypatch) -> None:
+    """An exception classifies the active phase as failed before propagating."""
+    ticks = iter((1.0, 2.25))
+    recorded: list[tuple[float, str]] = []
+    monkeypatch.setattr("omnigent._runner_startup.time.monotonic", lambda: next(ticks))
+    monkeypatch.setattr(
+        startup_metrics,
+        "record_startup_phase_duration",
+        lambda duration, *, phase, harness, outcome: recorded.append((duration, outcome)),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with runner_startup_progress(
+            initial_message="Waiting for runner...",
+            enabled=False,
+            metric_harness="codex",
+        ):
+            raise RuntimeError("boom")
+
+    assert recorded == [(1250.0, "failure")]
+
+
+@pytest.mark.parametrize(
+    ("message", "harness"),
+    [
+        ("Preparing Claude...", "claude"),
+        ("Preparing Codex...", "codex"),
+        ("Preparing OpenCode...", "opencode"),
+        ("Preparing Pi...", "pi"),
+        ("Preparing Cursor...", "cursor"),
+        ("Preparing Kiro...", "kiro"),
+        ("Preparing Goose...", "goose"),
+        ("Preparing Hermes...", "hermes"),
+        ("Preparing Antigravity...", "antigravity"),
+        ("Preparing qwen...", "qwen"),
+        ("Preparing Kimi...", "kimi"),
+    ],
+)
+def test_runner_startup_progress_infers_native_harness(
+    monkeypatch,
+    message: str,
+    harness: str,
+) -> None:
+    """Every built-in native startup reports a bounded harness label."""
+    ticks = iter((1.0, 2.0))
+    recorded: list[str] = []
+    monkeypatch.setattr("omnigent._runner_startup.time.monotonic", lambda: next(ticks))
+    monkeypatch.setattr(
+        startup_metrics,
+        "record_startup_phase_duration",
+        lambda duration, *, phase, harness, outcome: recorded.append(harness),
+    )
+
+    with runner_startup_progress(initial_message=message, enabled=False):
+        pass
+
+    assert recorded == [harness]
 
 
 def test_runner_startup_progress_rich_mode_writes_only_to_stderr(

--- a/tests/test_startup_metrics.py
+++ b/tests/test_startup_metrics.py
@@ -1,0 +1,79 @@
+"""Tests for foreground startup phase metrics."""
+
+from __future__ import annotations
+
+from opentelemetry import metrics as otel_metrics
+
+from omnigent.runtime import startup_metrics
+
+
+class _FakeHistogram:
+    def __init__(self) -> None:
+        self.records: list[tuple[float, dict[str, str]]] = []
+
+    def record(self, amount: float, attributes: dict[str, str] | None = None) -> None:
+        self.records.append((amount, attributes or {}))
+
+
+def test_record_startup_phase_duration_records_bounded_attributes(monkeypatch) -> None:
+    histogram = _FakeHistogram()
+    registered: list[bool] = []
+    monkeypatch.setenv("OMNIGENT_TELEMETRY_ENABLED", "true")
+    monkeypatch.setattr(startup_metrics, "_duration_histogram", lambda: histogram)
+    monkeypatch.setattr(startup_metrics, "_register_exit_flush", lambda: registered.append(True))
+
+    startup_metrics.record_startup_phase_duration(
+        123.5,
+        phase="wait_runner",
+        harness="codex",
+        outcome="success",
+    )
+
+    assert histogram.records == [
+        (
+            123.5,
+            {"phase": "wait_runner", "harness": "codex", "outcome": "success"},
+        )
+    ]
+    assert registered == [True]
+
+
+def test_record_startup_phase_duration_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("OMNIGENT_TELEMETRY_ENABLED", raising=False)
+    monkeypatch.setattr(
+        startup_metrics,
+        "_duration_histogram",
+        lambda: (_ for _ in ()).throw(AssertionError("histogram should not be created")),
+    )
+
+    startup_metrics.record_startup_phase_duration(
+        10,
+        phase="connect_server",
+        harness="codex",
+        outcome="success",
+    )
+
+
+def test_exit_flush_uses_bounded_timeout(monkeypatch) -> None:
+    calls: list[int] = []
+
+    class _Provider:
+        def force_flush(self, *, timeout_millis: int) -> None:
+            calls.append(timeout_millis)
+
+    monkeypatch.setattr(otel_metrics, "get_meter_provider", lambda: _Provider())
+
+    startup_metrics._flush_startup_metrics()
+
+    assert calls == [3000]
+
+
+def test_exit_flush_is_registered_once(monkeypatch) -> None:
+    callbacks: list[object] = []
+    monkeypatch.setattr(startup_metrics, "_flush_registered", False)
+    monkeypatch.setattr(startup_metrics.atexit, "register", callbacks.append)
+
+    startup_metrics._register_exit_flush()
+    startup_metrics._register_exit_flush()
+
+    assert callbacks == [startup_metrics._flush_startup_metrics]


### PR DESCRIPTION
## Related issue

N/A

## Summary

- Record each user-visible CLI startup phase in the `omnigent.client.startup.phase.duration` histogram.
- Attach bounded `harness`, `phase`, and `outcome` labels so operators can compare harness startup paths without unbounded cardinality.
- Best-effort flush the global OpenTelemetry meter provider for up to three seconds when the CLI exits.

ELI5: Omnigent now starts a stopwatch for every startup message, records whether that step succeeded, and tags the result with the selected harness.

```text
CLI startup progress
        |
        v
phase timer -- success/failure --> OTel histogram
        |                              |
        +---- harness + phase labels ---+
                                       |
                                       v
                                configured exporter
```

## Test Plan

- `uv run --frozen --group test pytest tests/test_startup_metrics.py tests/cli/test_runner_startup.py -q` (22 passed)
- `uv run --frozen --group test pytest tests/cli/test_backend.py::test_ensure_backend_labels_remote_connect_with_click_harness -q`
- `uv run pre-commit run --all-files`
- Broad CLI suite: 488 passed; one pre-existing credential-profile test failed independently of this change.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover success and failure recording, nested/repeated progress, harness label normalization, disabled telemetry, remote-connect labeling, and exit flushing.

## Changelog

CLI startup telemetry now reports per-phase latency broken down by harness and outcome.
