### PR TITLE
fix(codex-native): tolerate a replaced active turn on steer and interrupt

### DIFF
--- a/omnigent/inner/codex_native_executor.py
+++ b/omnigent/inner/codex_native_executor.py
@@ -60,6 +60,7 @@ _logger = logging.getLogger(__name__)
 
 _NO_ACTIVE_TURN_ERROR_CODE = -32600
 _NO_ACTIVE_TURN_ERROR_MESSAGE = "no active turn to steer"
+_ACTIVE_TURN_MISMATCH_MARKERS = ("expected active turn id", "but found")
 
 
 def _is_no_active_turn_to_steer(error: CodexAppServerResponseError) -> bool:
@@ -69,6 +70,30 @@ def _is_no_active_turn_to_steer(error: CodexAppServerResponseError) -> bool:
         and error.message is not None
         and error.message.strip().casefold() == _NO_ACTIVE_TURN_ERROR_MESSAGE
     )
+
+
+def _is_active_turn_mismatch(error: CodexAppServerResponseError) -> bool:
+    """Return whether a newer turn replaced the one we recorded.
+
+    The app-server rejects a steer/interrupt with ``expected active turn id `X`
+    but found `Y``` (also code -32600) when a turn started after we read the
+    bridge's ``active_turn_id``. Match on the phrasing, not the ids, since the
+    message quotes them and the backtick formatting varies across builds.
+    """
+    if error.code != _NO_ACTIVE_TURN_ERROR_CODE or error.message is None:
+        return False
+    message = error.message.casefold()
+    return all(marker in message for marker in _ACTIVE_TURN_MISMATCH_MARKERS)
+
+
+def _is_stale_active_turn(error: CodexAppServerResponseError) -> bool:
+    """Return whether our recorded active turn is no longer the thread's active one.
+
+    Covers both -32600 shapes: the turn ended ("no active turn to steer") and a
+    newer turn replaced it ("expected active turn id X but found Y"). Both call
+    for the same recovery — re-read bridge state and retarget the live turn.
+    """
+    return _is_no_active_turn_to_steer(error) or _is_active_turn_mismatch(error)
 
 
 async def _start_codex_turn(
@@ -182,11 +207,12 @@ async def _inject_codex_turn(
         )
         return
     except CodexAppServerResponseError as error:
-        if not _is_no_active_turn_to_steer(error):
+        if not _is_stale_active_turn(error):
             raise
 
-    # Codex authoritatively says A ended. Clear A only if it is still the
-    # bridge's value; a concurrent turn/started(B) must survive this recovery.
+    # Codex authoritatively says A is no longer the active turn (it ended, or a
+    # newer turn B replaced it). Clear A only if it is still the bridge's value;
+    # a concurrent turn/started(B) must survive this recovery.
     clear_active_turn_id_if_matches(bridge_dir, expected_turn_id)
     recovered_state = read_bridge_state(bridge_dir)
     if recovered_state is None or recovered_state.session_id != state.session_id:
@@ -334,13 +360,25 @@ class CodexNativeExecutor(Executor):
                     _logger.warning("Codex native MCP startup interrupt failed", exc_info=True)
                 _logger.info("Codex native MCP startup cancelled: %s", ", ".join(pending))
             if state.active_turn_id is not None:
-                await client.request(
-                    "turn/interrupt",
-                    {
-                        "threadId": state.thread_id,
-                        "turnId": state.active_turn_id,
-                    },
-                )
+                try:
+                    await client.request(
+                        "turn/interrupt",
+                        {
+                            "threadId": state.thread_id,
+                            "turnId": state.active_turn_id,
+                        },
+                    )
+                except CodexAppServerResponseError as error:
+                    # The recorded turn already ended or was replaced by a newer
+                    # one, so there is nothing left to interrupt — not a failure.
+                    # The local cancel map was already flipped above.
+                    if not _is_stale_active_turn(error):
+                        raise
+                    _logger.info(
+                        "Codex native interrupt: recorded turn already advanced; "
+                        "nothing to interrupt (turn_id=%s)",
+                        state.active_turn_id,
+                    )
         finally:
             await client.close()
         return True

--- a/tests/inner/test_codex_native_executor.py
+++ b/tests/inner/test_codex_native_executor.py
@@ -827,6 +827,59 @@ def test_stale_steer_recovery_preserves_and_steers_concurrent_new_turn(
     assert state.active_turn_id == "turn_b"
 
 
+def test_stale_active_turn_mismatch_steer_recovers_to_newer_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A newer turn replacing ours ("expected active turn id X but found Y") recovers.
+
+    Regression: the app-server reports this -32600 variant — distinct from
+    "no active turn to steer" — when a turn started after we read bridge state.
+    It used to propagate and fail the turn ("Codex native turn injection
+    failed"); it must reconcile and steer the live turn instead.
+    """
+
+    class _MismatchSteerClient(_FakeCodexNativeClient):
+        """Publish turn B, then reject the stale steer to A with the mismatch error."""
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            """Model turn B winning the race, reported via the mismatch message."""
+            type(self).requests.append((method, params))
+            if method == "turn/steer" and params["expectedTurnId"] == "turn_a":
+                from omnigent.harnesses.codex_native.bridge import update_active_turn_id
+
+                update_active_turn_id(tmp_path, "turn_b")
+                raise CodexAppServerResponseError(
+                    {
+                        "code": -32600,
+                        "message": "expected active turn id `turn_a` but found `turn_b`",
+                    }
+                )
+            if method == "turn/steer":
+                return {"result": {"turnId": "turn_b"}}
+            raise AssertionError(f"recovery must not double-start: {method}")
+
+    _MismatchSteerClient.requests = []
+    _MismatchSteerClient.created = []
+    monkeypatch.setattr(
+        "omnigent.harnesses.codex_native.app_server.CodexAppServerClient",
+        _MismatchSteerClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id="turn_a")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    events = _collect_turn_events(executor, "follow up")
+
+    assert [type(event) for event in events] == [TurnComplete]
+    assert [
+        (method, params.get("expectedTurnId")) for method, params in _MismatchSteerClient.requests
+    ] == [("turn/steer", "turn_a"), ("turn/steer", "turn_b")]
+    assert all(method != "turn/start" for method, _params in _MismatchSteerClient.requests)
+    state = read_bridge_state(tmp_path)
+    assert state is not None
+    assert state.active_turn_id == "turn_b"
+
+
 async def test_concurrent_steering_during_turn_start_is_not_dropped(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1519,3 +1572,48 @@ def test_interrupt_with_no_active_turn_and_no_pending_mcp_is_noop(
 
     assert interrupted is False
     assert _FakeCodexNativeClient.requests == []
+
+
+def test_interrupt_tolerates_stale_active_turn_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Interrupting a turn a newer one replaced is not a failure.
+
+    Regression: the recorded turn can end or be replaced before Stop lands, so
+    ``turn/interrupt`` gets -32600 "expected active turn id X but found Y". That
+    used to raise and surface as "Harness interrupt failed or timed out"; the
+    turn we targeted is already gone, so the interrupt has nothing left to do.
+    """
+
+    class _MismatchInterruptClient(_FakeCodexNativeClient):
+        """Reject the recorded-turn interrupt with the mismatch error."""
+
+        async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+            """Fail only the recorded-turn interrupt; accept everything else."""
+            type(self).requests.append((method, params))
+            if method == "turn/interrupt" and params["turnId"] == "turn_gone":
+                raise CodexAppServerResponseError(
+                    {
+                        "code": -32600,
+                        "message": "expected active turn id turn_gone but found turn_new",
+                    }
+                )
+            return {"result": {}}
+
+    _MismatchInterruptClient.requests = []
+    _MismatchInterruptClient.created = []
+    _MismatchInterruptClient.next_turn = 1
+    monkeypatch.setattr(
+        "omnigent.harnesses.codex_native.app_server.CodexAppServerClient",
+        _MismatchInterruptClient,
+    )
+    _seed_bridge(tmp_path, active_turn_id="turn_gone")
+    executor = CodexNativeExecutor(bridge_dir=tmp_path)
+
+    interrupted = asyncio.run(executor.interrupt_session("key"))
+
+    assert interrupted is True
+    assert _MismatchInterruptClient.requests == [
+        ("turn/interrupt", {"threadId": "thread_123", "turnId": "turn_gone"}),
+    ]


### PR DESCRIPTION
## Related issue

No tracked issue — surfaced by triaging the omnigent debug-log **mid-session
error rate** KPI (`omnigent_debug_logs`, last 7d). Two of the ranked mid-session
failure labels on the **released** `0.12.0` build resolve to a single root cause
fixed here:

- `Codex native turn injection failed` (`omnigent.inner.codex_native_executor.run_turn`)
- `Harness interrupt failed or timed out` (`_executor_adapter._safe_interrupt` → `codex_native_executor.interrupt_session`)

Both carry the same underlying app-server error:
`CodexAppServerResponseError {'code': -32600, 'message': 'expected active turn id X but found Y'}`.

## Summary

- The native Codex app-server rejects `turn/steer` and `turn/interrupt` with a
  `-32600` **`expected active turn id X but found Y`** when the `active_turn_id`
  we recorded in the bridge was replaced by a newer turn between our
  read-bridge-state and the RPC.
- Only the *exact* other `-32600` message — `"no active turn to steer"` — was
  recognized (`_is_no_active_turn_to_steer`). The mismatch variant fell through:
  a mid-turn steer surfaced to the UI as **"Codex native turn injection failed"**,
  and Stop surfaced as **"Harness interrupt failed or timed out"** — both counted
  against the mid-session error rate.
- Recognize the mismatch as a *stale active turn* (`_is_stale_active_turn`). On
  **steer** it flows through the recovery `_inject_codex_turn` was already written
  for — re-read bridge state and steer the live turn `Y` (the code even comments
  "a concurrent `turn/started(B)` must survive this recovery"). On **interrupt**
  it is benign: the turn we targeted is already gone, so there is nothing left to
  interrupt.

### ELI5

You tell Codex "change turn A." By the time the message lands, Codex already
moved on to turn B, so it answers "you asked about A, but I'm on B now." We used
to treat that reply as a hard failure. Now we notice it means "you're pointing at
an old turn," look up the current turn, and either steer it (for a message) or
shrug (for Stop — the old turn is over anyway).

```
read bridge state: active_turn_id = A
                      │   (turn A ends; turn B starts)
                      ▼
   turn/steer(expectedTurnId=A) ──► -32600 "expected active turn id A but found B"
                      │
        before: raise ─┴─► ExecutorError → "Codex native turn injection failed"
        after:  stale-active-turn ─► re-read state → turn/steer(B) ✓
```

## Test Plan

`tests/inner/test_codex_native_executor.py` (32 passed):

- `test_stale_active_turn_mismatch_steer_recovers_to_newer_turn` — a steer that
  gets the mismatch error reconciles and steers the live turn `B` (no
  `turn/start`, final `active_turn_id == "turn_b"`, ends `TurnComplete`).
- `test_interrupt_tolerates_stale_active_turn_mismatch` — an interrupt that gets
  the mismatch returns `True` and does not raise.
- Existing `test_steer_does_not_retry_ambiguous_or_unrelated_errors` still passes,
  so an unrelated `-32600` ("invalid turn id") and a bare `RuntimeError` are still
  **not** swallowed.

```
cd <worktree> && .venv/bin/python -m pytest tests/inner/test_codex_native_executor.py -q
# 32 passed
```

Lint: `ruff format --check` + `ruff check` clean on both files; `pyrefly check`
reports 0 errors on `codex_native_executor.py`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two new unit tests cover the previously-unhandled mismatch on both the steer and
interrupt paths; the pre-existing ambiguous-error test guards against
over-broadening (only the two known `-32600` stale-turn shapes are recovered).

## Changelog

Codex sessions no longer fail a message or Stop when a new turn began at the same moment.

This pull request and its description were written by Isaac.
