### PR TITLE
feat(agent-sandbox): tune idle-suspend with one knob (OMNIGENT_MANAGED_IDLE_SHUTDOWN_S)

### DIFF
--- a/deploy/kubernetes/overlays/sandbox-runners/README.md
+++ b/deploy/kubernetes/overlays/sandbox-runners/README.md
@@ -278,34 +278,41 @@ PVC). This is a *suspend* (resumable) — distinct from the deployment-wide reap
 which logs its own `reaper terminated N generation(s)` when it deletes a
 long-abandoned sandbox for good.
 
-**Tune how fast idle sandboxes suspend.** Two server-env knobs plus one injected
-into the sandbox:
+**Tune how fast idle sandboxes suspend — one knob.** Set
+`OMNIGENT_MANAGED_IDLE_SHUTDOWN_S` and a sandbox suspends about that many seconds
+after the agent goes quiet. It derives the three underlying timers together
+(runner idle timeout, keepalive interval, shutdown window) so they can't drift or
+fight each other:
+
+```yaml
+sandbox:
+  provider: agent_sandbox
+# server env: OMNIGENT_MANAGED_IDLE_SHUTDOWN_S=30   # suspend ~30s after idle
+```
+
+Finish a turn → the runner idles out → keepalive stops → the controller suspends
+the sandbox, ~30s after the agent went quiet in total. Leave it unset in
+production (sandboxes then use the 1h defaults); a short value means a paused
+session re-wakes its sandbox on the next message, which is the intended trade for
+snappy reclamation.
+
+How the knob splits (roughly `runner_idle + window ≈ idle_shutdown`): the
+keepalive `interval` becomes a fraction of the value, the `window` is `2×` that
+interval (one missed-refresh of headroom), and the runner idle timeout carries
+the rest. Because keepalive runs on its **own timer** (not the fixed 30s liveness
+ping), the interval — and therefore the window — can safely go below 30s without
+a busy sandbox dying between refreshes; the initial (create/wake) deadline is
+floored separately at a boot grace so a short window never reaps a still-booting
+Pod.
+
+For manual control, the three underlying knobs still work (and
+`OMNIGENT_MANAGED_IDLE_SHUTDOWN_S` overrides them when set):
 
 | Knob | What | Default |
 |---|---|---|
 | `OMNIGENT_MANAGED_KEEPALIVE_INTERVAL_S` | how often the server refreshes a live sandbox's deadline | `600` |
 | `OMNIGENT_AGENT_SANDBOX_SHUTDOWN_WINDOW_S` | the inactivity window, floored at 2× the interval | `3600` |
 | `runner.idle_timeout_s` (via `host_config`) | how long the runner lives after its last turn | `3600` |
-
-The window floor is `2×` the interval so a busy sandbox always outlasts a missed
-refresh; lowering the interval lowers the floor with it. To watch a sandbox
-suspend seconds after it idles (a demo, or experimentation), set all three low —
-`host_config` in the server config, the other two in the server's environment:
-
-```yaml
-sandbox:
-  provider: agent_sandbox
-  host_config:
-    runner:
-      idle_timeout_s: 30      # runner exits 30s after the last turn
-# server env: OMNIGENT_MANAGED_KEEPALIVE_INTERVAL_S=15
-#             OMNIGENT_AGENT_SANDBOX_SHUTDOWN_WINDOW_S=30
-```
-
-Then: finish a turn → the runner exits ~30s later → nothing refreshes the
-deadline → the controller suspends the sandbox ~30s after that, and the
-`omnigent.sandbox.lifecycle` log goes quiet as it does. Leave these at their
-defaults in production.
 
 ### Durable workspace (`OMNIGENT_AGENT_SANDBOX_WORKSPACE_SIZE`)
 

--- a/omnigent/onboarding/sandboxes/agent_sandbox.py
+++ b/omnigent/onboarding/sandboxes/agent_sandbox.py
@@ -63,7 +63,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 import click
 
-from omnigent.onboarding.sandboxes.base import resolve_managed_keepalive_interval_s
+from omnigent.onboarding.sandboxes.base import (
+    resolve_managed_idle_shutdown_s,
+    resolve_managed_keepalive_interval_s,
+)
 from omnigent.onboarding.sandboxes.kubernetes import (
     _POD_READY_REQUEST_TIMEOUT_S,
     KubernetesSandboxLauncher,
@@ -95,6 +98,17 @@ SHUTDOWN_WINDOW_ENV_VAR: str = "OMNIGENT_AGENT_SANDBOX_SHUTDOWN_WINDOW_S"
 """Environment variable overriding :data:`DEFAULT_SHUTDOWN_WINDOW_S`."""
 
 DEFAULT_SHUTDOWN_WINDOW_S: int = 3600
+
+_BOOT_GRACE_S: int = 300
+"""Floor on the shutdownTime set at create/wake, decoupled from the steady
+window. A freshly created or woken Pod cannot get its first keepalive until it
+has booted, its host has started, and a session's runner has connected and
+dialed back (tens of seconds, longer on a cold image pull). If the steady window
+is shorter than that, the initial deadline would lapse before the first refresh
+and the controller would reap the Pod mid-boot. Flooring only the INITIAL
+deadline at this grace lets the steady window (which governs how fast an idle
+sandbox suspends) be short without breaking cold start. A sandbox that boots but
+never gets a runner is genuinely unused and suspends once this grace elapses."""
 """How far ahead of now ``spec.shutdownTime`` is set, in seconds.
 
 This is effectively the sandbox's inactivity timeout: a sandbox with no live
@@ -173,6 +187,11 @@ def resolve_shutdown_window_s() -> int:
     :returns: The window in seconds, always >= :func:`min_shutdown_window_s`.
     """
     floor = min_shutdown_window_s()
+    # The single idle-shutdown knob drives the window to its floor (2x interval);
+    # the runner idle timeout carries the rest of the budget. It wins over the
+    # explicit window env so the one knob stays authoritative.
+    if resolve_managed_idle_shutdown_s() is not None:
+        return floor
     # Fallbacks (empty/malformed/non-positive) must also respect the floor: with a
     # configurable interval, DEFAULT is no longer guaranteed >= floor.
     fallback = max(DEFAULT_SHUTDOWN_WINDOW_S, floor)
@@ -207,6 +226,17 @@ def resolve_shutdown_window_s() -> int:
                 fallback,
             )
     return fallback
+
+
+def initial_shutdown_window_s() -> int:
+    """Window for the shutdownTime set at create/wake time.
+
+    The steady :func:`resolve_shutdown_window_s`, floored at :data:`_BOOT_GRACE_S`
+    so a short steady window cannot expire the Pod before its first keepalive.
+    Once the runner connects, keepalive brings the deadline down to the steady
+    window.
+    """
+    return max(resolve_shutdown_window_s(), _BOOT_GRACE_S)
 
 
 def _shutdown_time(window_s: int, *, now: datetime | None = None) -> str:
@@ -351,7 +381,7 @@ class AgentSandboxLauncher(KubernetesSandboxLauncher):
 
         body = build_sandbox_manifest(
             manifest,
-            shutdown_time=_shutdown_time(resolve_shutdown_window_s()),
+            shutdown_time=_shutdown_time(initial_shutdown_window_s()),
             workspace_volume=resolve_workspace_volume(),
         )
         custom = self._load_custom()

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -58,6 +58,46 @@ MANAGED_KEEPALIVE_INTERVAL_ENV_VAR: str = "OMNIGENT_MANAGED_KEEPALIVE_INTERVAL_S
 _DEFAULT_MANAGED_KEEPALIVE_INTERVAL_S: float = 600.0
 _MIN_MANAGED_KEEPALIVE_INTERVAL_S: float = 5.0
 
+MANAGED_IDLE_SHUTDOWN_ENV_VAR: str = "OMNIGENT_MANAGED_IDLE_SHUTDOWN_S"
+"""Single high-level knob: seconds from an agent going idle until its managed
+sandbox suspends. When set it derives the keepalive interval, the shutdown
+window, and the runner idle timeout together, so a deployment tunes idle-suspend
+timing with ONE value instead of three, and takes precedence over the individual
+interval/window knobs. See :func:`managed_runner_idle_timeout_s` for the split."""
+
+# window == 2 x interval (the floor): one whole missed refresh of headroom.
+_KEEPALIVE_WINDOW_FLOOR_MULTIPLIER: int = 2
+# The runner must not exit mid tool-call, so its idle timeout never goes below this.
+_MIN_MANAGED_RUNNER_IDLE_S: float = 5.0
+# Cap the derived interval so a long idle-shutdown does not leave a huge window.
+_MAX_IDLE_SHUTDOWN_INTERVAL_S: float = 120.0
+# The derived interval is this fraction of idle_shutdown, keeping the window
+# (2 x interval) to roughly a third of the budget and the runner idle to the rest.
+_IDLE_SHUTDOWN_INTERVAL_DIVISOR: float = 6.0
+
+
+def resolve_managed_idle_shutdown_s() -> float | None:
+    """Parse the single idle-shutdown knob, or ``None`` when unset/invalid.
+
+    A malformed, non-finite, or non-positive value falls through to ``None`` (the
+    individual interval/window/runner knobs then apply) rather than raising, so a
+    typo cannot make sandboxes unlaunchable.
+    """
+    raw = os.environ.get(MANAGED_IDLE_SHUTDOWN_ENV_VAR, "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = float(raw)
+    except ValueError:
+        _logger.warning("ignoring %s=%r (not a number)", MANAGED_IDLE_SHUTDOWN_ENV_VAR, raw)
+        return None
+    if not math.isfinite(parsed) or parsed <= 0:
+        _logger.warning(
+            "ignoring %s=%r (must be finite and positive)", MANAGED_IDLE_SHUTDOWN_ENV_VAR, raw
+        )
+        return None
+    return parsed
+
 
 def resolve_managed_keepalive_interval_s() -> float:
     """
@@ -70,7 +110,18 @@ def resolve_managed_keepalive_interval_s() -> float:
     provider sets its shutdown-window floor to twice this, so the window can
     never fall below what the loop can actually refresh in time. Lower it (with a
     correspondingly low window) to watch a sandbox suspend soon after it idles.
+
+    The single :func:`resolve_managed_idle_shutdown_s` knob, when set, takes
+    precedence and drives the cadence (a fraction of the idle-shutdown budget).
     """
+    idle_shutdown = resolve_managed_idle_shutdown_s()
+    if idle_shutdown is not None:
+        return min(
+            _MAX_IDLE_SHUTDOWN_INTERVAL_S,
+            max(
+                _MIN_MANAGED_KEEPALIVE_INTERVAL_S, idle_shutdown / _IDLE_SHUTDOWN_INTERVAL_DIVISOR
+            ),
+        )
     raw = os.environ.get(MANAGED_KEEPALIVE_INTERVAL_ENV_VAR, "").strip()
     if not raw:
         return _DEFAULT_MANAGED_KEEPALIVE_INTERVAL_S
@@ -104,6 +155,24 @@ def resolve_managed_keepalive_interval_s() -> float:
         )
         return _MIN_MANAGED_KEEPALIVE_INTERVAL_S
     return parsed
+
+
+def managed_runner_idle_timeout_s() -> float | None:
+    """Runner idle timeout derived from the single idle-shutdown knob, or ``None``.
+
+    Split so that ``runner_idle + shutdown_window`` (window is
+    ``2 x interval``) is about ``idle_shutdown``: the sandbox suspends
+    roughly ``idle_shutdown`` seconds after the agent goes quiet: the runner
+    gives up after ``runner_idle``, keepalive stops, and the window lapses.
+    Floored at :data:`_MIN_MANAGED_RUNNER_IDLE_S` so the runner does not exit
+    mid tool-call. ``None`` when the knob is unset (the operator's own
+    ``runner.idle_timeout_s``, if any, then stands).
+    """
+    idle_shutdown = resolve_managed_idle_shutdown_s()
+    if idle_shutdown is None:
+        return None
+    window = _KEEPALIVE_WINDOW_FLOOR_MULTIPLIER * resolve_managed_keepalive_interval_s()
+    return max(_MIN_MANAGED_RUNNER_IDLE_S, idle_shutdown - window)
 
 
 # Ceiling for the in-sandbox host restart backoff, so a host that crashes on

--- a/omnigent/server/managed_host_keepalive.py
+++ b/omnigent/server/managed_host_keepalive.py
@@ -98,6 +98,17 @@ def configure(
         _executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="managed-keepalive")
 
 
+def keepalive_interval_s() -> float:
+    """Current per-runner keepalive cadence, in seconds.
+
+    The runner tunnel's keepalive loop sleeps this between refreshes; it is the
+    same value :func:`touch` throttles to, so the loop cannot outrun the
+    throttle. Set by :func:`configure` from
+    :func:`~omnigent.onboarding.sandboxes.base.resolve_managed_keepalive_interval_s`.
+    """
+    return _min_interval_s
+
+
 def touch(runner_id: str) -> None:
     """Keep the sandbox behind *runner_id* warm, at most every :data:`_min_interval_s`.
 

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -1007,6 +1007,30 @@ def _unsupported_launcher_factory(provider: str) -> Callable[[], SandboxHostLaun
     return _reject
 
 
+def _apply_managed_idle_shutdown_runner_idle(
+    host_config: dict[str, object] | None,
+) -> dict[str, object] | None:
+    """Inject the idle-shutdown-derived runner idle timeout into *host_config*.
+
+    When the single ``OMNIGENT_MANAGED_IDLE_SHUTDOWN_S`` knob is set, the runner
+    must give up in step with the (derived) shutdown window, or a large default
+    ``runner.idle_timeout_s`` would keep the sandbox warm long past the intended
+    idle-shutdown. Sets ``runner.idle_timeout_s`` only when the operator has not
+    set one explicitly (their value wins). A no-op when the knob is unset.
+    """
+    from omnigent.onboarding.sandboxes.base import managed_runner_idle_timeout_s
+
+    runner_idle = managed_runner_idle_timeout_s()
+    if runner_idle is None:
+        return host_config
+    merged = dict(host_config or {})
+    existing = merged.get("runner")
+    runner = dict(existing) if isinstance(existing, dict) else {}
+    runner.setdefault("idle_timeout_s", round(runner_idle))
+    merged["runner"] = runner
+    return merged
+
+
 def _parse_host_config(raw: dict[str, object]) -> dict[str, object] | None:
     """
     Extract and validate the top-level ``sandbox.host_config`` block.
@@ -1261,6 +1285,8 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
     # Validated regardless of provider (like server_url): a malformed
     # host_config should stop startup even for staged/unsupported providers.
     host_config = _parse_host_config(raw)
+    if provider == "agent_sandbox":
+        host_config = _apply_managed_idle_shutdown_runner_idle(host_config)
     if provider == "modal":
         launcher_factory = _modal_launcher_factory(
             _parse_modal_image(raw), _parse_modal_secrets(raw)

--- a/omnigent/server/routes/runner_tunnel.py
+++ b/omnigent/server/routes/runner_tunnel.py
@@ -495,6 +495,10 @@ def create_runner_tunnel_router(
                 _ping_loop(ws, session, runner_id, registry),
                 name=f"tunnel-ping:{runner_id}",
             )
+            keepalive_task = asyncio.create_task(
+                _keepalive_loop(runner_id),
+                name=f"tunnel-keepalive:{runner_id}",
+            )
             receive_task = asyncio.create_task(
                 _receive_loop(ws, session, runner_id, registry),
                 name=f"tunnel-receive:{runner_id}",
@@ -567,12 +571,13 @@ def create_runner_tunnel_router(
                         )
                     raise task_error
             finally:
-                for task in (sender_task, ping_task, receive_task):
+                for task in (sender_task, ping_task, receive_task, keepalive_task):
                     task.cancel()
                 await asyncio.gather(
                     sender_task,
                     ping_task,
                     receive_task,
+                    keepalive_task,
                     return_exceptions=True,
                 )
                 registry.deregister(runner_id, session)
@@ -717,6 +722,27 @@ async def _receive_loop(
         registry.route_response_frame(runner_id, resp_frame, session=session)
 
 
+async def _keepalive_loop(runner_id: str) -> None:
+    """Refresh the managed sandbox behind *runner_id* on its own cadence.
+
+    Separate from :func:`_ping_loop` (fixed ``PING_INTERVAL_S``) so a deployment
+    can refresh a managed sandbox faster than the 30s liveness ping (which is
+    what lets the sandbox's shutdown window be short) or slower to save calls.
+    Fires once immediately so a freshly connected (or reconnected) runner
+    extends its sandbox right away, then every
+    :func:`managed_host_keepalive.keepalive_interval_s`. Best-effort:
+    :func:`managed_host_keepalive.touch` swallows its own errors and no-ops when
+    the host has no extendable sandbox, so this loop only ever ends when it is
+    cancelled at tunnel teardown.
+
+    :param runner_id: Runner whose bound sandbox to keep warm.
+    :returns: None (runs until cancelled).
+    """
+    while True:
+        managed_host_keepalive.touch(runner_id)
+        await asyncio.sleep(managed_host_keepalive.keepalive_interval_s())
+
+
 async def _ping_loop(
     ws: WebSocket,
     session: RunnerSession,
@@ -775,9 +801,6 @@ async def _ping_loop(
         # Best-effort and deduplicated inside the chokepoint; the enqueue
         # inherits this handler's workspace scope via copy_context.
         session_live_state.touch_runner_liveness([runner_id])
-        # A live runner tunnel is also the signal that this sandbox is still
-        # in use; rate-limited inside, so calling it per ping is fine.
-        managed_host_keepalive.touch(runner_id)
         try:
             await registry.send_text(
                 session,

--- a/tests/onboarding/sandboxes/test_agent_sandbox.py
+++ b/tests/onboarding/sandboxes/test_agent_sandbox.py
@@ -605,3 +605,42 @@ def test_terminate_still_hard_deletes(
 
     assert custom.deleted == [_SANDBOX_ID]
     assert core.deleted_secrets == [f"{_SANDBOX_ID}-token"]
+
+
+def test_idle_shutdown_knob_makes_death_track_its_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single OMNIGENT_MANAGED_IDLE_SHUTDOWN_S knob splits into runner-idle +
+    window so a sandbox suspends ~that many seconds after the agent goes idle."""
+    from omnigent.onboarding.sandboxes.base import (
+        managed_runner_idle_timeout_s,
+        resolve_managed_keepalive_interval_s,
+    )
+
+    monkeypatch.delenv(SHUTDOWN_WINDOW_ENV_VAR, raising=False)
+    monkeypatch.delenv("OMNIGENT_MANAGED_KEEPALIVE_INTERVAL_S", raising=False)
+    for target in (30, 60, 120, 300):
+        monkeypatch.setenv("OMNIGENT_MANAGED_IDLE_SHUTDOWN_S", str(target))
+        runner_idle = managed_runner_idle_timeout_s()
+        assert runner_idle is not None
+        death = runner_idle + resolve_shutdown_window_s()
+        assert abs(death - target) <= resolve_managed_keepalive_interval_s()
+
+
+def test_idle_shutdown_overrides_explicit_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The one knob wins over an explicit shutdown-window env var."""
+    monkeypatch.setenv(SHUTDOWN_WINDOW_ENV_VAR, "3600")
+    monkeypatch.setenv("OMNIGENT_MANAGED_IDLE_SHUTDOWN_S", "30")
+    assert resolve_shutdown_window_s() == min_shutdown_window_s()
+
+
+def test_initial_window_floors_at_boot_grace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A short steady window still gets a boot-safe initial (create/wake) deadline."""
+    from omnigent.onboarding.sandboxes.agent_sandbox import (
+        _BOOT_GRACE_S,
+        initial_shutdown_window_s,
+    )
+
+    monkeypatch.setenv("OMNIGENT_MANAGED_IDLE_SHUTDOWN_S", "30")
+    assert resolve_shutdown_window_s() < _BOOT_GRACE_S
+    assert initial_shutdown_window_s() == _BOOT_GRACE_S

--- a/tests/server/integration/test_runner_tunnel_route.py
+++ b/tests/server/integration/test_runner_tunnel_route.py
@@ -1235,3 +1235,25 @@ async def test_ping_loop_restamps_runner_liveness(
         with contextlib.suppress(asyncio.TimeoutError):
             await communicator.wait(timeout=1.0)
         session_live_state.configure(None)
+
+
+async def test_keepalive_loop_fires_faster_than_the_ping_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The keepalive loop runs on its own cadence, decoupled from the 30s ping
+    loop, so a short interval yields several refreshes within one ping period."""
+    from omnigent.server.routes import runner_tunnel
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        runner_tunnel.managed_host_keepalive, "touch", lambda rid: calls.append(rid)
+    )
+    monkeypatch.setattr(
+        runner_tunnel.managed_host_keepalive, "keepalive_interval_s", lambda: 0.01
+    )
+    task = asyncio.create_task(runner_tunnel._keepalive_loop("r1"))
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    assert len(calls) >= 3 and set(calls) == {"r1"}

--- a/tests/server/test_managed_host_keepalive.py
+++ b/tests/server/test_managed_host_keepalive.py
@@ -266,3 +266,13 @@ def test_successful_keepalive_logs_at_info_on_the_server_logger(
     with caplog.at_level(logging.INFO, logger="omnigent.server.managed_host_keepalive"):
         managed_host_keepalive._keep_alive_for_runner("r1")
     assert any("kept managed sandbox sbx1 alive" in r.getMessage() for r in caplog.records)
+
+
+def test_keepalive_interval_accessor_reflects_configure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The interval the tunnel keepalive loop sleeps is the value configure snapshotted."""
+    monkeypatch.setenv("OMNIGENT_MANAGED_KEEPALIVE_INTERVAL_S", "12")
+    monkeypatch.setattr(
+        managed_host_keepalive, "_min_interval_s", managed_host_keepalive._min_interval_s
+    )
+    managed_host_keepalive.configure(SimpleNamespace(), None, None)
+    assert managed_host_keepalive.keepalive_interval_s() == 12.0

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -4850,3 +4850,16 @@ def test_agent_sandbox_reuses_the_kubernetes_config_block() -> None:
     # keep_alive is what the managed path needs from it, so it must not be the
     # raising capability default it inherits two levels up.
     assert type(launcher).keep_alive is not SandboxHostLauncher.keep_alive
+
+
+def test_idle_shutdown_injects_runner_idle_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The single idle-shutdown knob sets a matching runner idle timeout in
+    host_config, but never overrides an explicit operator value."""
+    from omnigent.server.managed_hosts import _apply_managed_idle_shutdown_runner_idle as apply
+
+    monkeypatch.setenv("OMNIGENT_MANAGED_IDLE_SHUTDOWN_S", "30")
+    assert apply(None) == {"runner": {"idle_timeout_s": 20}}
+    assert apply({"runner": {"idle_timeout_s": 999}})["runner"]["idle_timeout_s"] == 999
+    assert apply({"runner": {"foo": 1}})["runner"] == {"foo": 1, "idle_timeout_s": 20}
+    monkeypatch.delenv("OMNIGENT_MANAGED_IDLE_SHUTDOWN_S")
+    assert apply({"providers": {}}) == {"providers": {}}


### PR DESCRIPTION
## Related issue

N/A — customer follow-up to #6230 / #6994: idle-suspend timing needed to be tunable with a single parameter, and reliably fast (sub-60s), instead of three interacting knobs with a hard floor.

## Summary

Adds **one knob** — `OMNIGENT_MANAGED_IDLE_SHUTDOWN_S` — that makes an agent-sandbox managed sandbox suspend about that many seconds after the agent goes quiet. It derives the three underlying timers together so they can't drift or fight:

- **runner idle timeout** (injected into `host_config.runner.idle_timeout_s` at config parse, unless the operator set one),
- **keepalive interval** (`base.resolve_managed_keepalive_interval_s`),
- **shutdown window** (`agent_sandbox.resolve_shutdown_window_s`),

split so `runner_idle + window ≈ idle_shutdown` (verified across 30–1800s: death tracks the knob within one interval).

Two enablers make a *reliable* sub-60s death possible — the previous design couldn't go below ~60s:

- **Keepalive gets its own per-runner timer**, decoupled from the fixed 30s liveness ping loop (`runner_tunnel._keepalive_loop`). Keepalive previously rode `PING_INTERVAL_S = 30`, so the `interval` knob was a no-op below 30s and the window floor (`2×interval`) was effectively 60s. With its own timer the interval — and thus the window — can safely go below 30s without a busy sandbox dying between refreshes. (This also resolves #6994's Polly note that sub-30s cadence wasn't deliverable.)
- **The create/wake deadline is decoupled from the steady window** (`initial_shutdown_window_s`, floored at a boot grace). A short steady window no longer reaps a still-booting Pod before its first keepalive.

The manual `OMNIGENT_MANAGED_KEEPALIVE_INTERVAL_S` / `OMNIGENT_AGENT_SANDBOX_SHUTDOWN_WINDOW_S` / `runner.idle_timeout_s` knobs still work; the single knob overrides them when set.

## Test Plan

```
pytest tests/onboarding/sandboxes/test_agent_sandbox.py \
       tests/server/test_managed_hosts.py \
       tests/server/test_managed_host_keepalive.py \
       tests/server/integration/test_runner_tunnel_route.py \
       tests/onboarding/sandboxes/test_kubernetes.py
# all pass (406 in the sandbox/keepalive/tunnel subset)
```

New unit tests: the knob makes `runner_idle + window` track its value across 30/60/120/300s; the knob overrides an explicit window; the initial deadline floors at the boot grace; the parse-time runner-idle injection respects an explicit operator value; the keepalive interval accessor reflects `configure`; and the keepalive loop fires several times within one ping period (proving it's decoupled from the 30s ping). `ruff` + `pyrefly` clean on changed files.

The derivation was verified numerically end-to-end (death ≈ idle_shutdown_s exactly for 25/30/60/120/300/1800). A live kind-cluster end-to-end timing run is pending a lab-cluster rebuild (the local kind cluster was lost to a Colima restart, unrelated to this change).

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Manual verification is the numeric derivation check (death ≈ idle_shutdown across values) plus the decoupled-keepalive-loop unit test; a live cluster timing run is pending a lab rebuild as noted above. No behavior changes when the knob is unset (default 1h timers preserved).

## Changelog

Add `OMNIGENT_MANAGED_IDLE_SHUTDOWN_S`: a single knob that tunes how long after an agent goes idle its agent-sandbox managed sandbox suspends; keepalive now refreshes on its own timer (decoupled from the 30s liveness ping) so short windows are reliable.

This pull request and its description were written by Isaac.
