### PR TITLE
fix(terminal): classify why the idle watcher declares tmux unavailable

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -970,6 +970,13 @@ class TerminalInstance:
     # meaningful with ``keep_alive_after_exit`` / ``remain-on-exit``). ``None``
     # until the process exits or when tmux reports no numeric status.
     _last_exit_status: int | None = field(default=None, repr=False)
+    # Detail of the most recent ``capture-pane`` probe the idle watcher saw
+    # rejected (the tmux ``rc``/stderr text). Retained so the "tmux unavailable"
+    # exit ERROR can name *why* tmux went away — its stderr distinguishes a
+    # vanished server ("no server running") from a single lost session ("can't
+    # find session") — instead of only reporting that it did. ``None`` until a
+    # probe is rejected; cleared on the next successful capture.
+    _last_idle_probe_error: str | None = field(default=None, repr=False)
 
     @property
     def tmux_target(self) -> str:
@@ -1504,10 +1511,13 @@ class TerminalInstance:
                 if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
                     continue
                 logger.error(
-                    "tmux unavailable after %d consecutive probes for terminal %s:%s",
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s "
+                    "(keep_alive_after_exit=%s): last capture-pane error: %s",
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
+                    self.keep_alive_after_exit,
+                    exc,
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1709,10 +1719,13 @@ class TerminalInstance:
                 if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
                     continue
                 logger.error(
-                    "tmux unavailable after %d consecutive probes for terminal %s:%s",
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s "
+                    "(keep_alive_after_exit=%s): %s",
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
+                    self.keep_alive_after_exit,
+                    self._diagnose_tmux_gone_sync(),
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1781,10 +1794,11 @@ class TerminalInstance:
             and terminal liveness is therefore unknown.
         """
         try:
-            return self._tmux_output_sync("capture-pane", "-t", self.tmux_target, "-p", "-e")
+            snapshot = self._tmux_output_sync("capture-pane", "-t", self.tmux_target, "-p", "-e")
         except _TmuxProcessStartError:
             raise
         except RuntimeError as exc:
+            self._last_idle_probe_error = str(exc)
             logger.warning(
                 "tmux capture-pane probe failed for terminal %s:%s: %s",
                 self.name,
@@ -1792,6 +1806,8 @@ class TerminalInstance:
                 exc,
             )
             return None
+        self._last_idle_probe_error = None
+        return snapshot
 
     def _tmux_session_exists_sync(self) -> bool | None:
         """Confirm tmux exists, or return ``None`` when the probe cannot start."""
@@ -1809,6 +1825,36 @@ class TerminalInstance:
         except RuntimeError:
             return False
         return True
+
+    def _diagnose_tmux_gone_sync(self) -> str:
+        """Classify why tmux went away, for the idle watcher's exit ERROR.
+
+        Called once when the threaded watcher declares the terminal dead, so
+        the ERROR can say *what* failed rather than only that the terminal is
+        gone. Re-probes ``has-session`` and, when tmux reports the session
+        gone, the server-wide ``list-sessions`` — separating a vanished private
+        server (crash / OOM / external kill / socket removed) from a single
+        session that disappeared while the server stayed up, which are triaged
+        differently — and appends the last rejected ``capture-pane`` stderr. A
+        probe that cannot start leaves liveness genuinely unknown.
+
+        :returns: A compact, non-empty human-readable reason.
+        """
+        try:
+            self._tmux_output_sync("has-session", "-t", self.tmux_target)
+            state = "session reappeared on re-probe (transient probe failure)"
+        except _TmuxProcessStartError as exc:
+            state = f"tmux liveness unknown, probe could not start: {exc}"
+        except RuntimeError as has_session_exc:
+            try:
+                self._tmux_output_sync("list-sessions")
+                state = f"session gone, tmux server still alive: {has_session_exc}"
+            except _TmuxProcessStartError as exc:
+                state = f"session gone; server liveness unknown, probe could not start: {exc}"
+            except RuntimeError as server_exc:
+                state = f"tmux server not reachable: {server_exc}"
+        last = self._last_idle_probe_error
+        return f"{state}; last capture-pane error: {last}" if last else state
 
     def _pane_is_dead(self) -> bool | None:
         """

--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -302,6 +302,11 @@ _IDLE_POLL_INTERVAL_SECONDS = 1.0
 _IDLE_EXIT_FAILURE_THRESHOLD = 3
 # Avoid adding probe pressure while the host cannot start another process.
 _TMUX_PROBE_START_FAILURE_BACKOFF_SECONDS = 1.0
+# Substrings in a failed tmux probe's stderr that classify the "tmux unavailable"
+# exit: a whole private server gone vs. a single session removed while the server
+# stayed up. Matched case-insensitively; see :meth:`TerminalInstance._classify_tmux_exit`.
+_TMUX_SERVER_GONE_MARKERS = ("no server running", "error connecting", "no such file")
+_TMUX_SESSION_GONE_MARKERS = ("can't find session", "can’t find session", "session not found")
 
 # Process creation can fail temporarily while the host is under resource
 # pressure. Only those errno values leave terminal liveness unknown; permanent
@@ -970,13 +975,17 @@ class TerminalInstance:
     # meaningful with ``keep_alive_after_exit`` / ``remain-on-exit``). ``None``
     # until the process exits or when tmux reports no numeric status.
     _last_exit_status: int | None = field(default=None, repr=False)
-    # Detail of the most recent ``capture-pane`` probe the idle watcher saw
-    # rejected (the tmux ``rc``/stderr text). Retained so the "tmux unavailable"
-    # exit ERROR can name *why* tmux went away — its stderr distinguishes a
-    # vanished server ("no server running") from a single lost session ("can't
-    # find session") — instead of only reporting that it did. ``None`` until a
-    # probe is rejected; cleared on the next successful capture.
-    _last_idle_probe_error: str | None = field(default=None, repr=False)
+    # Diagnostics the idle watcher records as tmux probes fail, so the
+    # "tmux unavailable" exit ERROR can *classify* why tmux went away rather than
+    # only reporting that it did. ``_last_capture_probe_error`` is the stderr of
+    # the last rejected ``capture-pane``; ``_last_session_probe_error`` is the
+    # stderr of the ``has-session`` probe that then confirmed the session gone —
+    # and that one is the discriminator: "no server running on <socket>" is a
+    # whole-server death (machine slept, tmux killed, socket dir reaped, OOM)
+    # while "can't find session" is a single-session kill. Both ``None`` until a
+    # probe is rejected; each is cleared on its next successful probe.
+    _last_capture_probe_error: str | None = field(default=None, repr=False)
+    _last_session_probe_error: str | None = field(default=None, repr=False)
 
     @property
     def tmux_target(self) -> str:
@@ -1495,6 +1504,7 @@ class TerminalInstance:
                 await asyncio.sleep(_TMUX_PROBE_START_FAILURE_BACKOFF_SECONDS)
                 continue
             except RuntimeError as exc:
+                self._last_capture_probe_error = str(exc)
                 logger.warning(
                     "tmux capture-pane probe failed for terminal %s:%s: %s",
                     self.name,
@@ -1511,13 +1521,11 @@ class TerminalInstance:
                 if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
                     continue
                 logger.error(
-                    "tmux unavailable after %d consecutive probes for terminal %s:%s "
-                    "(keep_alive_after_exit=%s): last capture-pane error: %s",
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s: %s",
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
-                    self.keep_alive_after_exit,
-                    exc,
+                    self._classify_tmux_exit(),
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1719,13 +1727,11 @@ class TerminalInstance:
                 if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
                     continue
                 logger.error(
-                    "tmux unavailable after %d consecutive probes for terminal %s:%s "
-                    "(keep_alive_after_exit=%s): %s",
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s: %s",
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
-                    self.keep_alive_after_exit,
-                    self._diagnose_tmux_gone_sync(),
+                    self._classify_tmux_exit(),
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1798,7 +1804,7 @@ class TerminalInstance:
         except _TmuxProcessStartError:
             raise
         except RuntimeError as exc:
-            self._last_idle_probe_error = str(exc)
+            self._last_capture_probe_error = str(exc)
             logger.warning(
                 "tmux capture-pane probe failed for terminal %s:%s: %s",
                 self.name,
@@ -1806,7 +1812,7 @@ class TerminalInstance:
                 exc,
             )
             return None
-        self._last_idle_probe_error = None
+        self._last_capture_probe_error = None
         return snapshot
 
     def _tmux_session_exists_sync(self) -> bool | None:
@@ -1822,39 +1828,81 @@ class TerminalInstance:
                 exc,
             )
             return None
-        except RuntimeError:
+        except RuntimeError as exc:
+            self._last_session_probe_error = str(exc)
             return False
+        self._last_session_probe_error = None
         return True
 
-    def _diagnose_tmux_gone_sync(self) -> str:
-        """Classify why tmux went away, for the idle watcher's exit ERROR.
+    def _classify_tmux_exit(self) -> str:
+        """Classify why the idle watcher declared tmux unavailable, for its ERROR.
 
-        Called once when the threaded watcher declares the terminal dead, so
-        the ERROR can say *what* failed rather than only that the terminal is
-        gone. Re-probes ``has-session`` and, when tmux reports the session
-        gone, the server-wide ``list-sessions`` — separating a vanished private
-        server (crash / OOM / external kill / socket removed) from a single
-        session that disappeared while the server stayed up, which are triaged
-        differently — and appends the last rejected ``capture-pane`` stderr. A
-        probe that cannot start leaves liveness genuinely unknown.
+        Reads only the diagnostics recorded while the probes were failing — no
+        fresh tmux call — so it is safe on both the async and threaded watchers
+        and cannot race a server that is still tearing down. Emits two grep-able
+        tokens the reliability dashboard can group or exclude on, then the
+        supporting evidence:
 
-        :returns: A compact, non-empty human-readable reason.
+        - ``cause=`` — a hard classification from the probe stderr:
+          ``server-vanished`` (whole private server gone), ``session-killed``
+          (server alive, this session removed), or ``unknown``.
+        - ``likely=`` — a softer teardown-vs-fault hint (see
+          :meth:`_classify_tmux_exit_likelihood`).
+
+        :returns: A compact, non-empty classified reason.
         """
-        try:
-            self._tmux_output_sync("has-session", "-t", self.tmux_target)
-            state = "session reappeared on re-probe (transient probe failure)"
-        except _TmuxProcessStartError as exc:
-            state = f"tmux liveness unknown, probe could not start: {exc}"
-        except RuntimeError as has_session_exc:
-            try:
-                self._tmux_output_sync("list-sessions")
-                state = f"session gone, tmux server still alive: {has_session_exc}"
-            except _TmuxProcessStartError as exc:
-                state = f"session gone; server liveness unknown, probe could not start: {exc}"
-            except RuntimeError as server_exc:
-                state = f"tmux server not reachable: {server_exc}"
-        last = self._last_idle_probe_error
-        return f"{state}; last capture-pane error: {last}" if last else state
+        session_err = self._last_session_probe_error or ""
+        capture_err = self._last_capture_probe_error or ""
+        probe_text = f"{session_err} {capture_err}".lower()
+        if any(m in probe_text for m in _TMUX_SERVER_GONE_MARKERS):
+            cause = "server-vanished"
+        elif any(m in probe_text for m in _TMUX_SESSION_GONE_MARKERS):
+            cause = "session-killed"
+        else:
+            cause = "unknown"
+
+        tail = self.last_pane_text()
+        likely = self._classify_tmux_exit_likelihood(tail)
+
+        evidence: list[str] = [f"keep_alive_after_exit={self.keep_alive_after_exit}"]
+        if session_err:
+            evidence.append(f"has-session said: {session_err}")
+        if capture_err:
+            evidence.append(f"last capture error: {capture_err}")
+        if self._last_exit_status is not None:
+            evidence.append(f"pane exit status: {self._last_exit_status}")
+        last_interaction = self._last_client_interaction_at
+        if last_interaction == float("-inf"):
+            evidence.append("no web client interaction observed")
+        else:
+            idle_s = time.monotonic() - last_interaction
+            evidence.append(f"{idle_s:.0f}s since web client interaction")
+        evidence.append(
+            f"last pane tail: {tail[-240:]!r}" if tail else "last pane: <none captured>"
+        )
+        return f"cause={cause} likely={likely} ({'; '.join(evidence)})"
+
+    def _classify_tmux_exit_likelihood(self, tail: str | None) -> str:
+        """Return a teardown-vs-fault hint for the "tmux unavailable" exit.
+
+        Deliberately a hint, not a verdict: a clean pane exit status or a benign
+        ``[process exited]`` / ``logout`` frame reads as expected teardown, a
+        nonzero exit or a Python/Go crash frame as a possible fault, and
+        anything else stays ``unknown`` rather than being guessed.
+
+        :param tail: The last captured pane text, or ``None`` if none was kept.
+        :returns: ``expected-teardown``, ``possible-fault``, or ``unknown``.
+        """
+        if self._last_exit_status == 0:
+            return "expected-teardown"
+        low = (tail or "").lower()
+        if "traceback (most recent call last)" in low or "panic:" in low:
+            return "possible-fault"
+        if self._last_exit_status is not None:
+            return "possible-fault"
+        if "[process exited]" in low or "logout" in low:
+            return "expected-teardown"
+        return "unknown"
 
     def _pane_is_dead(self) -> bool | None:
         """
@@ -2063,8 +2111,10 @@ class TerminalInstance:
                 exc,
             )
             return None
-        except RuntimeError:
+        except RuntimeError as exc:
+            self._last_session_probe_error = str(exc)
             return False
+        self._last_session_probe_error = None
         return True
 
     async def _tmux(self, *args: str) -> None:

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -432,19 +432,48 @@ def test_capture_probe_logs_command_return_code_and_stderr(
 
 
 @pytest.mark.parametrize(
-    ("list_sessions_rc", "expected_fragment"),
+    ("session_err", "exit_status", "pane_tail", "expected_cause", "expected_likely"),
     [
-        (1, "tmux server not reachable"),
-        (0, "session gone, tmux server still alive"),
+        # Whole private server gone + a clean pane exit → expected teardown.
+        (
+            "has-session -t main: no server running on /tmp/x",
+            0,
+            None,
+            "server-vanished",
+            "expected-teardown",
+        ),
+        # Server gone + a crash frame left in the pane → possible fault.
+        (
+            "has-session -t main: no server running on /tmp/x",
+            None,
+            "Traceback (most recent call last):\n  File 'x.py'",
+            "server-vanished",
+            "possible-fault",
+        ),
+        # Server alive, this session removed; nothing else to go on → unknown.
+        ("has-session -t main: can't find session: main", None, None, "session-killed", "unknown"),
+        # A benign "[process exited]" frame reads as teardown even without a status.
+        (
+            "has-session -t main: no server running on /tmp/x",
+            None,
+            "[process exited]",
+            "server-vanished",
+            "expected-teardown",
+        ),
+        # No recorded probe stderr at all → both fields fall back to unknown.
+        (None, None, None, "unknown", "unknown"),
     ],
 )
-def test_diagnose_tmux_gone_sync_classifies_server_vs_session(
+def test_classify_tmux_exit_labels_cause_and_likelihood(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    list_sessions_rc: int,
-    expected_fragment: str,
+    session_err: str | None,
+    exit_status: int | None,
+    pane_tail: str | None,
+    expected_cause: str,
+    expected_likely: str,
 ) -> None:
-    """Exit diagnosis separates a dead server from a lost session, keeping capture stderr."""
+    """The exit classifier turns recorded probe state into grep-able cause/likely labels."""
     instance = TerminalInstance(
         name="claude",
         session_key="main",
@@ -452,34 +481,30 @@ def test_diagnose_tmux_gone_sync_classifies_server_vs_session(
         private_dir=tmp_path,
         running=True,
     )
-    instance._last_idle_probe_error = (
-        "tmux command failed (rc=1): tmux -S sock capture-pane -t main -p -e: no server running"
+    instance._last_session_probe_error = session_err
+    instance._last_exit_status = exit_status
+    instance._last_pane_snapshot = pane_tail
+    # The classifier must read recorded state only — never spawn a fresh probe.
+    monkeypatch.setattr(
+        terminal_mod.subprocess,
+        "run",
+        lambda *a, **k: pytest.fail("classifier must not spawn a fresh tmux probe"),
     )
 
-    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
-        # ``has-session`` always fails here (the watcher only diagnoses once the
-        # session is already gone); ``list-sessions`` decides server liveness.
-        if "list-sessions" in cmd:
-            return SimpleNamespace(
-                returncode=list_sessions_rc, stdout=b"", stderr=b"no server running"
-            )
-        return SimpleNamespace(returncode=1, stdout=b"", stderr=b"can't find session: main")
+    reason = instance._classify_tmux_exit()
 
-    monkeypatch.setattr(terminal_mod.subprocess, "run", _fake_run)
-
-    reason = instance._diagnose_tmux_gone_sync()
-
-    assert expected_fragment in reason
-    assert "last capture-pane error:" in reason
-    assert "no server running" in reason
+    assert f"cause={expected_cause}" in reason
+    assert f"likely={expected_likely}" in reason
+    if session_err:
+        assert "has-session said:" in reason
 
 
-def test_threaded_idle_watcher_exit_error_names_cause(
+def test_threaded_idle_watcher_exit_error_classifies_cause(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The ``tmux unavailable`` exit ERROR carries why tmux went away, not just that it did."""
+    """The ``tmux unavailable`` exit ERROR carries a classified cause, from recorded state."""
     instance = TerminalInstance(
         name="claude",
         session_key="main",
@@ -490,22 +515,27 @@ def test_threaded_idle_watcher_exit_error_names_cause(
     exited = threading.Event()
 
     def _capture() -> None:
-        # Simulate a swallowed capture-pane rejection: record the stderr and
-        # signal "tmux gone" to the watcher by returning None implicitly.
-        instance._last_idle_probe_error = (
+        # Swallowed capture-pane rejection: record its stderr, return None.
+        instance._last_capture_probe_error = (
             "tmux command failed (rc=1): tmux -S sock capture-pane -t main -p -e: "
             "no server running on /tmp/x"
         )
 
+    def _session_gone() -> bool:
+        # has-session then confirms the whole server is gone; record its stderr.
+        instance._last_session_probe_error = (
+            "tmux command failed (rc=1): tmux -S sock has-session -t main: "
+            "no server running on /tmp/x"
+        )
+        return False
+
     instance._capture_pane_for_idle_or_none = _capture  # type: ignore[method-assign]
-    instance._tmux_session_exists_sync = lambda: False  # type: ignore[method-assign]
-    # The one-shot diagnosis re-probe finds the whole server unreachable.
+    instance._tmux_session_exists_sync = _session_gone  # type: ignore[method-assign]
+    # The exit ERROR must classify from recorded state, without a fresh probe.
     monkeypatch.setattr(
         terminal_mod.subprocess,
         "run",
-        lambda *args, **kwargs: SimpleNamespace(
-            returncode=1, stdout=b"", stderr=b"no server running on /tmp/x"
-        ),
+        lambda *a, **k: pytest.fail("exit classification must not spawn a fresh tmux probe"),
     )
 
     with caplog.at_level(logging.ERROR, logger=terminal_mod.__name__):
@@ -515,8 +545,8 @@ def test_threaded_idle_watcher_exit_error_names_cause(
     message = caplog.text
     assert "tmux unavailable after" in message
     assert "consecutive probes" in message
+    assert "cause=server-vanished" in message
     assert "keep_alive_after_exit=False" in message
-    assert "tmux server not reachable" in message
     assert "no server running on /tmp/x" in message
 
 

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -431,6 +431,95 @@ def test_capture_probe_logs_command_return_code_and_stderr(
     assert "fork failed: resource temporarily unavailable" in message
 
 
+@pytest.mark.parametrize(
+    ("list_sessions_rc", "expected_fragment"),
+    [
+        (1, "tmux server not reachable"),
+        (0, "session gone, tmux server still alive"),
+    ],
+)
+def test_diagnose_tmux_gone_sync_classifies_server_vs_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    list_sessions_rc: int,
+    expected_fragment: str,
+) -> None:
+    """Exit diagnosis separates a dead server from a lost session, keeping capture stderr."""
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    instance._last_idle_probe_error = (
+        "tmux command failed (rc=1): tmux -S sock capture-pane -t main -p -e: no server running"
+    )
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        # ``has-session`` always fails here (the watcher only diagnoses once the
+        # session is already gone); ``list-sessions`` decides server liveness.
+        if "list-sessions" in cmd:
+            return SimpleNamespace(
+                returncode=list_sessions_rc, stdout=b"", stderr=b"no server running"
+            )
+        return SimpleNamespace(returncode=1, stdout=b"", stderr=b"can't find session: main")
+
+    monkeypatch.setattr(terminal_mod.subprocess, "run", _fake_run)
+
+    reason = instance._diagnose_tmux_gone_sync()
+
+    assert expected_fragment in reason
+    assert "last capture-pane error:" in reason
+    assert "no server running" in reason
+
+
+def test_threaded_idle_watcher_exit_error_names_cause(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The ``tmux unavailable`` exit ERROR carries why tmux went away, not just that it did."""
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+    exited = threading.Event()
+
+    def _capture() -> None:
+        # Simulate a swallowed capture-pane rejection: record the stderr and
+        # signal "tmux gone" to the watcher by returning None implicitly.
+        instance._last_idle_probe_error = (
+            "tmux command failed (rc=1): tmux -S sock capture-pane -t main -p -e: "
+            "no server running on /tmp/x"
+        )
+
+    instance._capture_pane_for_idle_or_none = _capture  # type: ignore[method-assign]
+    instance._tmux_session_exists_sync = lambda: False  # type: ignore[method-assign]
+    # The one-shot diagnosis re-probe finds the whole server unreachable.
+    monkeypatch.setattr(
+        terminal_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=1, stdout=b"", stderr=b"no server running on /tmp/x"
+        ),
+    )
+
+    with caplog.at_level(logging.ERROR, logger=terminal_mod.__name__):
+        instance.start_idle_watcher_thread(on_exit=exited.set, poll_interval_s=0.01)
+        assert exited.wait(timeout=1.0)
+
+    message = caplog.text
+    assert "tmux unavailable after" in message
+    assert "consecutive probes" in message
+    assert "keep_alive_after_exit=False" in message
+    assert "tmux server not reachable" in message
+    assert "no server running on /tmp/x" in message
+
+
 def test_threaded_idle_watcher_fires_on_tick_each_poll(tmp_path: Path) -> None:
     """``on_tick`` fires every poll (not only on pane change), so the
     claude-native status-file poller runs on the watcher cadence.


### PR DESCRIPTION
## Related issue

N/A — diagnostics / observability change (`Refactor / chore`), no issue required.

## Summary

The threaded terminal idle-watchdog declares a terminal dead after N consecutive failed tmux probes and logs `tmux unavailable after N consecutive probes` — **with no cause**. That signature is the **single largest mid-session error-rate KPI contributor** on released builds (dashboard `perf_failure_issues` → "tmux unavailable after repeated probes"), yet a vanished tmux server (crash / OOM / external kill) is **indistinguishable in the logs** from a single lost session (a clean user quit / expected teardown).

This PR is **logging only** — no change to the watchdog's decision logic. It **instruments** the failing probes and **classifies** the exit:

- **Instrument** — as the probes fail, record the rejected `capture-pane` stderr (`_last_capture_probe_error`) and the `has-session` stderr that then confirmed the session gone (`_last_session_probe_error`).
- **Classify** — at exit, `_classify_tmux_exit()` reads *only that recorded state* (no fresh tmux call, so it can't race a server still tearing down) and emits two grep-able tokens the reliability dashboard can group or exclude on:
  - `cause=` — `server-vanished` (whole private server gone), `session-killed` (server alive, this session removed), or `unknown`, from the probe stderr.
  - `likely=` — a softer `expected-teardown` / `possible-fault` / `unknown` hint from the pane exit status and the last-pane tail (a `[process exited]` frame vs a traceback).
- The ERROR then appends the supporting evidence: has-session / capture stderr, pane exit status, seconds since the last web-client interaction, and the pane tail. On both the async and threaded watchers.

The `tmux unavailable after … consecutive probes` substring is preserved, so the dashboard's classification of this signature is unchanged. This is what lets us **confirm the "expected teardown" hypothesis** before excluding it from the KPI, and **catch the `server-vanished` / `possible-fault` case** where omnigent itself lost the tmux server — which today hides behind the same opaque line.

Before → after:

```
- tmux unavailable after 3 consecutive probes for terminal claude:main
+ tmux unavailable after 3 consecutive probes for terminal claude:main: cause=server-vanished likely=expected-teardown (keep_alive_after_exit=False; has-session said: tmux command failed (rc=1): … has-session -t main: no server running on /tmp/…; last capture error: …; pane exit status: 0; 2s since web client interaction; last pane tail: '… logout')
```

## Test Plan

Run against this branch's source (o3 `.venv`):

```
python -m pytest tests/inner/test_terminal.py -q          # 75 passed
ruff check omnigent/inner/terminal.py tests/inner/test_terminal.py   # clean
pyrefly check omnigent/inner/terminal.py                  # 0 errors
```

New tests:

- `test_classify_tmux_exit_labels_cause_and_likelihood` — parametrized over the recorded state: proves `cause` (server-vanished / session-killed / unknown) and `likely` (expected-teardown / possible-fault / unknown) are labeled correctly, and that the classifier **never spawns a fresh tmux probe**.
- `test_threaded_idle_watcher_exit_error_classifies_cause` — proves the threaded watcher's exit ERROR carries `cause=server-vanished` and the evidence, purely from state recorded during the failing probes.

## Demo

- [ ] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [x] Not applicable — no behavioral change (exit-ERROR log text only)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Unit tests cover the classifier's `cause`/`likely` matrix and the enriched exit ERROR on the threaded watcher, and assert the classification reads recorded state only (no fresh tmux call). No integration/E2E needed — the change is confined to log-message construction on the idle-watcher exit path.

## Changelog

N/A — internal diagnostics; no user-facing change.

## Note

A concurrent session opened #7228 for the same signature (raw diagnostic dump). This PR differs by emitting an explicit **classification** (`cause=` / `likely=`) the dashboard can group on, and by capturing the has-session stderr inline rather than re-probing at exit. Per maintainer direction both are left open for review.

This pull request and its description were written by Isaac.
