### PR TITLE
fix(terminal): explain why the idle watcher declares tmux unavailable

### DIFF
--- a/omnigent/inner/terminal.py
+++ b/omnigent/inner/terminal.py
@@ -970,6 +970,14 @@ class TerminalInstance:
     # meaningful with ``keep_alive_after_exit`` / ``remain-on-exit``). ``None``
     # until the process exits or when tmux reports no numeric status.
     _last_exit_status: int | None = field(default=None, repr=False)
+    # Diagnostics for the "tmux unavailable" exit path: the stderr of the last
+    # failed capture-pane probe, and of the has-session probe that then
+    # confirmed the session gone. The has-session stderr is what separates a
+    # whole-server death ("no server running on <socket>" — machine slept, tmux
+    # killed, socket dir reaped) from a single-session kill ("can't find
+    # session"). ``None`` until such a probe fails.
+    _last_capture_probe_error: str | None = field(default=None, repr=False)
+    _last_session_probe_error: str | None = field(default=None, repr=False)
 
     @property
     def tmux_target(self) -> str:
@@ -1013,6 +1021,37 @@ class TerminalInstance:
     def _remember_pane_snapshot(self, snapshot: str) -> None:
         """Store a pane capture for later exit diagnostics."""
         self._last_pane_snapshot = snapshot
+
+    def _tmux_gone_diagnostics(self) -> str:
+        """Summarize why tmux vanished, for the "tmux unavailable" exit log.
+
+        The bare exit message can't tell an expected teardown (user quit, the
+        web client just detached, the pane already exited cleanly) from a real
+        fault (a crash frame left in the pane, a whole-server death). This
+        gathers the signals that do: the last capture-pane and has-session
+        stderr, how long since a web client last touched the terminal, any
+        recorded pane exit status, and the tail of the last captured pane.
+
+        :returns: A single-line, ``; ``-joined diagnostic summary.
+        """
+        parts: list[str] = []
+        if self._last_capture_probe_error:
+            parts.append(f"last capture error: {self._last_capture_probe_error}")
+        if self._last_session_probe_error:
+            parts.append(f"has-session said: {self._last_session_probe_error}")
+        if self._last_exit_status is not None:
+            parts.append(f"pane exit status: {self._last_exit_status}")
+        last_interaction = self._last_client_interaction_at
+        if last_interaction == float("-inf"):
+            parts.append("no web client interaction observed")
+        else:
+            idle_s = time.monotonic() - last_interaction
+            parts.append(f"{idle_s:.0f}s since web client interaction")
+        # The bottom of the pane is the most telling: a shell prompt or
+        # "[Process exited]" reads as clean teardown; a traceback as a fault.
+        tail = self.last_pane_text()
+        parts.append(f"last pane tail: {tail[-240:]!r}" if tail else "last pane: <none captured>")
+        return "; ".join(parts)
 
     def last_exit_status(self) -> int | None:
         """Return the inner process's exit code, if the pane has died.
@@ -1488,6 +1527,7 @@ class TerminalInstance:
                 await asyncio.sleep(_TMUX_PROBE_START_FAILURE_BACKOFF_SECONDS)
                 continue
             except RuntimeError as exc:
+                self._last_capture_probe_error = str(exc)
                 logger.warning(
                     "tmux capture-pane probe failed for terminal %s:%s: %s",
                     self.name,
@@ -1504,10 +1544,11 @@ class TerminalInstance:
                 if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
                     continue
                 logger.error(
-                    "tmux unavailable after %d consecutive probes for terminal %s:%s",
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s (%s)",
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
+                    self._tmux_gone_diagnostics(),
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1709,10 +1750,11 @@ class TerminalInstance:
                 if consecutive_capture_failures < _IDLE_EXIT_FAILURE_THRESHOLD:
                     continue
                 logger.error(
-                    "tmux unavailable after %d consecutive probes for terminal %s:%s",
+                    "tmux unavailable after %d consecutive probes for terminal %s:%s (%s)",
                     consecutive_capture_failures,
                     self.name,
                     self.session_key,
+                    self._tmux_gone_diagnostics(),
                 )
                 self.running = False
                 if on_exit is not None:
@@ -1785,6 +1827,7 @@ class TerminalInstance:
         except _TmuxProcessStartError:
             raise
         except RuntimeError as exc:
+            self._last_capture_probe_error = str(exc)
             logger.warning(
                 "tmux capture-pane probe failed for terminal %s:%s: %s",
                 self.name,
@@ -1806,7 +1849,8 @@ class TerminalInstance:
                 exc,
             )
             return None
-        except RuntimeError:
+        except RuntimeError as exc:
+            self._last_session_probe_error = str(exc)
             return False
         return True
 
@@ -2017,7 +2061,8 @@ class TerminalInstance:
                 exc,
             )
             return None
-        except RuntimeError:
+        except RuntimeError as exc:
+            self._last_session_probe_error = str(exc)
             return False
         return True
 

--- a/tests/inner/test_terminal.py
+++ b/tests/inner/test_terminal.py
@@ -119,6 +119,76 @@ def test_threaded_idle_watcher_keeps_last_pane_text_on_exit(tmp_path: Path) -> N
     assert instance.last_pane_text() == "startup failed\ntry config"
 
 
+def test_tmux_gone_diagnostics_summarizes_available_signals(tmp_path: Path) -> None:
+    """The exit-diagnostics summary folds in every signal it has."""
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+
+    # With nothing recorded yet it still states the baseline both ways.
+    baseline = instance._tmux_gone_diagnostics()
+    assert "no web client interaction observed" in baseline
+    assert "last pane: <none captured>" in baseline
+
+    instance._last_capture_probe_error = "tmux command failed (rc=1): no server running on /tmp/x"
+    instance._last_session_probe_error = "tmux command failed (rc=1): no server running on /tmp/x"
+    instance._last_exit_status = 137
+    instance._remember_pane_snapshot("\x1b[31mSegmentation fault\x1b[0m")
+    instance.note_client_interaction()
+
+    summary = instance._tmux_gone_diagnostics()
+    assert "last capture error: tmux command failed (rc=1): no server running" in summary
+    assert "has-session said: tmux command failed (rc=1): no server running" in summary
+    assert "pane exit status: 137" in summary
+    assert "since web client interaction" in summary
+    assert "last pane tail:" in summary and "Segmentation fault" in summary
+
+
+def test_tmux_unavailable_error_log_carries_the_cause(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The 'tmux unavailable' exit ERROR names why: probe stderr + pane tail.
+
+    Drives the real capture/has-session helpers (both failing) so the log
+    proves the probe errors are recorded and surfaced, not just formattable.
+    """
+    instance = TerminalInstance(
+        name="claude",
+        session_key="main",
+        socket_path=tmp_path / "tmux.sock",
+        private_dir=tmp_path,
+        running=True,
+    )
+
+    def _fail(*_args: str) -> str:
+        # The has-session stderr distinguishing a whole-server death.
+        raise RuntimeError("tmux command failed (rc=1): no server running on /tmp/x/default")
+
+    instance._tmux_output_sync = _fail  # type: ignore[method-assign]
+    instance._remember_pane_snapshot("running build...\nTraceback (most recent call last): boom")
+    instance.note_client_interaction()
+    exited = threading.Event()
+
+    with caplog.at_level(logging.ERROR, logger=terminal_mod.__name__):
+        instance.start_idle_watcher_thread(on_exit=exited.set, poll_interval_s=0.01)
+        assert exited.wait(timeout=2.0)
+
+    unavailable = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.ERROR and "tmux unavailable after" in record.getMessage()
+    ]
+    assert unavailable, "expected a 'tmux unavailable' ERROR"
+    message = unavailable[0]
+    assert "no server running" in message  # has-session stderr → whole-server death
+    assert "since web client interaction" in message
+    assert "Traceback" in message  # last pane tail carried into the exit log
+
+
 def test_threaded_idle_watcher_resets_transient_capture_failures(tmp_path: Path) -> None:
     """Successful pane captures reset the consecutive-failure threshold."""
     instance = TerminalInstance(


### PR DESCRIPTION
## Related issue
N/A

## Summary

The idle watcher declares a terminal dead when `capture-pane` fails
`_IDLE_EXIT_FAILURE_THRESHOLD` times in a row **and** `has-session` confirms the
tmux session is gone. That exit was logged as a bare line with **no cause**:

- the failed `capture-pane` stderr was logged only on a *separate* WARNING line (and in the threaded loop it was swallowed inside `_capture_pane_for_idle_or_none`),
- the `has-session` stderr — the thing that says *why* tmux is gone — was dropped entirely (`except RuntimeError: return False`),
- the last captured pane frame was never attached.

So there was no way to tell an **expected teardown** (user quit, the web client
just detached, the pane already exited cleanly) from a **real fault**, nor a
**whole-server death** (`no server running on <socket>` — machine slept/
hibernated, tmux killed, `/tmp` socket dir reaped, OOM) from a **single-session
kill** (`can't find session`).

This records the capture-pane and has-session stderr on the instance and folds
them — plus seconds since the last web-client interaction, any recorded pane
exit status, and the tail of the last captured pane — into the exit ERROR via a
new `_tmux_gone_diagnostics()`. The message becomes e.g.:

```
tmux unavailable after 3 consecutive probes for terminal claude:main
(last capture error: tmux command failed (rc=1): no server running on /tmp/…/default;
 has-session said: tmux command failed (rc=1): no server running on /tmp/…/default;
 12s since web client interaction; last pane tail: '… $ ')
```

**Purely additive logging** — the watcher's control flow and exit behavior are
unchanged. This is the instrumentation needed to decide whether the signature is
expected teardown (→ a KPI exclusion) or a real fault (→ its own fix); it does
not itself reclassify the signature.

## Test Plan

`tests/inner/test_terminal.py` (71 passed):

- `test_tmux_gone_diagnostics_summarizes_available_signals` — the summary folds in capture/has-session stderr, pane exit status, client-interaction age, and pane tail, and states a baseline when a signal is absent.
- `test_tmux_unavailable_error_log_carries_the_cause` — drives the **real** capture/has-session helpers (both failing with a "no server running" stderr) through the threaded watcher and asserts the emitted ERROR carries the stderr, the interaction age, and the last pane tail — proving the probe errors are recorded and surfaced, not just formattable.

```
cd <worktree> && .venv/bin/python -m pytest tests/inner/test_terminal.py -q   # 71 passed
```

Lint: `ruff format --check` + `ruff check` clean; `pyrefly check` 0 errors on `terminal.py`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [x] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Two new unit tests cover the diagnostics assembly and the end-to-end exit log;
existing watcher tests cover the unchanged control flow.

This pull request and its description were written by Isaac.
