### PR TITLE
feat(sandbox): add Gensee managed provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Omnigent lets you:
   disposable [Modal](https://modal.com), [Daytona](https://www.daytona.io),
   [Blaxel](https://blaxel.ai),
   [Islo](https://islo.dev), [E2B](https://e2b.dev),
+  [Gensee](https://gensee.ai),
   [CoreWeave](https://docs.coreweave.com/products/sandboxes),
   [Kubernetes](https://kubernetes.io), [OpenShell](https://github.com/NVIDIA/OpenShell),
   [Boxlite](https://github.com/boxlite-ai/boxlite),

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -90,6 +90,9 @@ deploy/
 ├── e2b/               ← E2B sandbox-provider guide (boots from a pre-built
 │   └── README.md         E2B template); NOT a server deploy target.
 │
+├── gensee/            ← Gensee managed sandbox-provider guide (ephemeral
+│   └── README.md         provider-managed runtimes); NOT a server deploy target.
+│
 ├── openshell/         ← NVIDIA OpenShell sandbox-provider guide (self-hosted
 │   └── README.md         gRPC gateway, on-prem/air-gapped); NOT a server target.
 │
@@ -284,8 +287,8 @@ omnigent sandbox connect --provider modal --sandbox-id <id> --server https://you
 > rather than a registry image — build it once first; see
 > [`e2b/README.md`](e2b/README.md).
 
-**Server-managed (Modal, Daytona, Blaxel, Islo, or E2B).** With *managed hosts*, creating a
-session with `"host_type": "managed"` (e.g.
+**Server-managed (Modal, Daytona, Blaxel, Islo, E2B, or Gensee).** With
+*managed hosts*, creating a session with `"host_type": "managed"` (e.g.
 `POST /v1/sessions {"agent_id": ..., "host_type": "managed"}`) makes the
 server provision a sandbox, start a host in it, and run the session there.
 No laptop, no CLI steps per session; the sandbox is terminated when the
@@ -304,7 +307,11 @@ sandbox:
 
 Modal credentials come from the server's environment (`MODAL_TOKEN_ID` /
 `MODAL_TOKEN_SECRET`, or a mounted `~/.modal.toml`), not the config file.
-Daytona reads `DAYTONA_API_KEY`. Blaxel reads `BL_WORKSPACE` and `BL_API_KEY`. Islo reads `ISLO_API_KEY` and optional `ISLO_BASE_URL`. E2B reads `E2B_API_KEY` from the server environment.
+Daytona reads `DAYTONA_API_KEY`. Blaxel reads `BL_WORKSPACE` and `BL_API_KEY`.
+Islo reads `ISLO_API_KEY` and optional `ISLO_BASE_URL`. E2B reads `E2B_API_KEY`.
+Gensee reads `GENSEE_CONTROLLER_API_TOKEN`; see
+[`gensee/README.md`](gensee/README.md) for its managed-only configuration.
+All credentials come from the server environment.
 Each sandbox authenticates back with a server-minted, per-launch token, so
 no user credentials ever enter the sandbox.
 
@@ -316,7 +323,7 @@ for a later sweep, while the session history and durable host binding stay
 available for a fresh sandbox generation. Both
 `terminate_after_offline_days` and `sweep_interval_s` must be positive integers.
 
-**The host image.** Most sandboxes boot from the official prebaked host image (`ghcr.io/omnigent-ai/omnigent-host:latest`, published by CI from the `host` target of [`docker/Dockerfile`](docker/Dockerfile)), so the host starts in seconds instead of installing Omnigent at boot. The image ships the coding-harness CLIs (`claude`, `codex`, `pi`, `kiro-cli`). Blaxel uses `blaxel/omnigent-host:latest`, which combines this host runtime with Blaxel's required `sandbox-api`. E2B uses its provider template. To use a custom image instead, build the same `host` target and point the provider config at it:
+**The host image.** Most sandboxes boot from the official prebaked host image (`ghcr.io/omnigent-ai/omnigent-host:latest`, published by CI from the `host` target of [`docker/Dockerfile`](docker/Dockerfile)), so the host starts in seconds instead of installing Omnigent at boot. The image ships the coding-harness CLIs (`claude`, `codex`, `pi`, `kiro-cli`). Blaxel uses `blaxel/omnigent-host:latest`, which combines this host runtime with Blaxel's required `sandbox-api`. E2B uses its provider template. Gensee uses a provider-managed runtime rather than this registry-image setting. To use a custom image with a provider that accepts one, build the same `host` target and point the provider config at it:
 
 ```bash
 docker build -f docker/Dockerfile --target host \

--- a/deploy/gensee/README.md
+++ b/deploy/gensee/README.md
@@ -1,0 +1,181 @@
+# Omnigent on Gensee
+
+[GenseeAI](https://gensee.ai) provides
+[open-source, forkable runtimes with checkpoint/restore support](https://github.com/GenseeAI/gensee-crate)
+for managed Omnigent sessions. The built-in launcher talks to the Gensee
+control plane over HTTPS; no cloud-provider credentials or Gensee
+implementation packages are installed in Omnigent.
+
+Gensee is currently a **managed-host provider only**. Creating a managed
+session allocates one sandbox, asks its runtime agent to clone or initialize the
+workspace and start `omnigent host`, then waits for that host to connect back.
+Deleting or reaping the session releases the sandbox and its workspace data.
+
+It does not implement `omnigent sandbox create`, remote exec/file-copy
+primitives, stopped-sandbox resume, or workspace fork/merge capabilities.
+
+## Prerequisites
+
+You need:
+
+1. A Gensee service endpoint and API token. Gensee currently provisions these
+   for contracted organizations.
+2. An Omnigent server with a public HTTPS URL reachable from the sandbox
+   runtime.
+3. Any model-provider credentials users need, supplied either by interactive
+   login inside their sandbox or through the explicit `env` allowlist below.
+
+Keep the Gensee API token in the server process environment:
+
+```bash
+export GENSEE_CONTROLLER_API_TOKEN='<token>'
+```
+
+Do not write the token into `config.yaml`.
+
+## Server configuration
+
+The production endpoint and standard token variable are defaults, so the
+minimal configuration is:
+
+```yaml
+sandbox:
+  provider: gensee
+  server_url: https://omnigent.example.com
+```
+
+Use an explicit block for a dedicated or development endpoint:
+
+```yaml
+sandbox:
+  provider: gensee
+  server_url: https://omnigent.example.com
+  gensee:
+    endpoint: https://sandbox.gensee.ai
+    api_token_env: GENSEE_CONTROLLER_API_TOKEN
+    workspace_root: /mnt/gensee-tclone/workspaces
+    operation_timeout_s: 900
+    poll_interval_s: 2
+    request_timeout_s: 40
+    retry_timeout_s: 60
+    env: []
+  reaper:
+    enabled: true
+    terminate_after_offline_days: 1
+    sweep_interval_s: 3600
+```
+
+For a multi-provider server, place the same `gensee` block inside its provider
+entry:
+
+```yaml
+sandbox:
+  server_url: https://omnigent.example.com
+  providers:
+    - provider: gensee
+      gensee:
+        endpoint: https://sandbox.gensee.ai
+    - provider: e2b
+```
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `endpoint` | `https://sandbox.gensee.ai` | Gensee HTTPS control-plane base URL |
+| `api_token_env` | `GENSEE_CONTROLLER_API_TOKEN` | Server environment variable holding the API token |
+| `workspace_root` | `/mnt/gensee-tclone/workspaces` | Absolute workspace root inside each sandbox |
+| `operation_timeout_s` | `900` | Shared deadline for host-start operation submission, retries, and polling; late responses are rejected |
+| `poll_interval_s` | `2` | Interval between operation-status requests |
+| `request_timeout_s` | `40` | HTTP I/O timeout, capped by the remaining operation budget during host startup |
+| `retry_timeout_s` | `60` | Retry budget for transport errors and HTTP 500/502/503/504 responses; `0` disables retries |
+| `env` | `[]` | Server environment variable names copied into the sandbox secret |
+
+The endpoint must use HTTPS and cannot contain credentials, a query, or a
+fragment. Unknown settings and malformed values stop server startup rather
+than failing on the first user session.
+
+`GENSEE_CONTROLLER_URL` overrides the default endpoint when constructing the
+launcher directly. An explicit `sandbox.gensee.endpoint` takes precedence in
+the server-managed configuration.
+
+## Credential boundary
+
+The Gensee API token stays in the Omnigent server and authorizes lifecycle
+requests. Each sandbox receives a separate server-minted Omnigent host token
+through Gensee's short-lived secret store; the token is not included in the
+durable operation request.
+
+By default, no model or Git credentials are injected. If an operator configures
+an allowlist such as:
+
+```yaml
+gensee:
+  env: [OPENAI_API_KEY, GIT_TOKEN]
+```
+
+the corresponding values are read from the Omnigent server environment and
+sent to the Gensee secret store. Only list variables that every sandbox on that
+server is authorized to receive. For per-user credentials, leave `env` empty
+and let each user sign in from their own sandbox terminal.
+
+Public errors include only the controller's error message, with known launch
+and API credentials redacted. Raw response bodies are not exposed in session
+errors or cleanup logs.
+
+## Lifecycle and cleanup
+
+The launcher uses the following controller operations:
+
+- allocate an ephemeral sandbox;
+- store one short-lived launch secret;
+- submit and poll `start_omnigent_host`;
+- query allocation and runtime-agent readiness;
+- release the allocation idempotently.
+
+The Omnigent launch token lasts seven days. Sandbox release is safe to retry,
+which lets session deletion and the deployment-wide reaper recover from
+temporary control-plane failures. The reaper is disabled unless configured;
+see the main [deployment guide](../README.md#run-hosts-in-cloud-sandboxes).
+
+An allocation request can succeed even if its response is lost. The launcher
+attempts to release the requested allocation after ambiguous failures. If
+cleanup also fails, the error and server log retain the allocation ID so the
+operator can locate and release it through the control plane.
+
+## Verify
+
+Start the server, then confirm Gensee is advertised:
+
+```bash
+curl -fsS https://omnigent.example.com/v1/info
+```
+
+Create a managed session with `sandbox_provider: gensee` in the web UI or API.
+The session should progress through provisioning and starting, then its host
+should appear online. Delete the test session and confirm the corresponding
+allocation is released in the Gensee control plane.
+
+For a repeatable live check, run the opt-in lifecycle E2E against a non-production Omnigent server configured with Gensee. It creates one managed session without an LLM turn, waits for its host and runner, deletes the session, and verifies the exact Gensee allocation is released:
+
+```bash
+OMNIGENT_E2E_GENSEE=1 \
+OMNIGENT_E2E_GENSEE_SERVER_URL=https://omnigent.example.com \
+OMNIGENT_E2E_GENSEE_AGENT_ID=ag_example \
+OMNIGENT_E2E_GENSEE_SERVER_TOKEN='<optional-omnigent-bearer-token>' \
+GENSEE_CONTROLLER_API_TOKEN='<token>' \
+.venv/bin/python -m pytest tests/e2e/integrations/deploy/gensee/test_managed_lifecycle.py -v
+```
+
+Omit `OMNIGENT_E2E_GENSEE_SERVER_TOKEN` when the test server has authentication disabled. Set `GENSEE_CONTROLLER_URL` if the server uses a non-default controller endpoint, and set `OMNIGENT_E2E_GENSEE_WORKSPACE_ROOT` if its configured `workspace_root` differs from the default. The test is skipped unless `OMNIGENT_E2E_GENSEE=1` is set and always attempts to delete the session it created.
+
+## Troubleshooting
+
+- **`GENSEE_CONTROLLER_API_TOKEN` must contain the API token** — expose the
+  configured token variable to the Omnigent server process or Pod.
+- **Controller is not ready** — verify the endpoint's `/readyz` response and
+  certificate chain from the Omnigent server host.
+- **Operation timed out** — inspect the allocation in the Gensee control plane;
+  only increase `operation_timeout_s` after checking sandbox startup and agent
+  logs.
+- **The sandbox starts but the host never connects** — confirm `server_url` is
+  publicly reachable from the sandbox runtime and that its TLS certificate is
+  valid.

--- a/docs/extending/sandbox_providers.md
+++ b/docs/extending/sandbox_providers.md
@@ -1,8 +1,8 @@
 # Sandbox providers
 
 Omnigent supports running agent hosts in remote sandboxes. Built-in providers
-(Modal, Daytona, Blaxel, CoreWeave Sandbox, E2B, Islo, OpenShell, Boxlite,
-Kubernetes, microsandbox)
+(Modal, Daytona, Blaxel, CoreWeave Sandbox, E2B, Gensee, Islo, OpenShell,
+Boxlite, Kubernetes, microsandbox)
 ship with the core package. Third-party packages can add new providers through
 the `omnigent.sandbox_providers` entrypoint group.
 
@@ -13,9 +13,9 @@ Each sandbox provider implements the
 Providers that exec into a running sandbox (Modal, Daytona, …) inherit
 `ExecModelHostLauncher`, which provides a default `start_host` that probes
 `$HOME`, creates a workspace, clones a repo, and backgrounds `omnigent host`.
-Providers whose sandbox boots running the host directly (Kubernetes) inherit
-`SandboxHostLauncher` and override `start_host` to build the infrastructure
-manifest instead.
+Providers whose sandbox boots running the host directly (Kubernetes), or whose
+control plane owns host startup (Gensee), inherit `SandboxHostLauncher` and
+override `start_host` without exposing a general-purpose exec transport.
 
 ## Creating a community sandbox provider
 

--- a/omnigent/onboarding/sandboxes/base.py
+++ b/omnigent/onboarding/sandboxes/base.py
@@ -808,8 +808,9 @@ class SandboxHostLauncher(SandboxLifecycle):
     Every managed-host provider — exec-model or entrypoint-as-host — implements
     this. :meth:`start_host` is abstract here; the exec-model default lives on
     :class:`ExecModelHostLauncher`. Entrypoint-as-host providers (e.g.
-    Kubernetes) inherit this class directly and override :meth:`start_host`
-    without needing any exec transport.
+    Kubernetes) and provider-native host launchers (e.g. Gensee) inherit this
+    class directly and override :meth:`start_host` without needing any exec
+    transport.
     """
 
     def reaper_identity(self, workspace_id: int) -> AbstractContextManager[None]:
@@ -861,7 +862,7 @@ class ExecModelHostLauncher(SandboxHostLauncher, SandboxExecTransport):
     managed-host bootstrap. A provider that only needs to change how the
     repository is obtained overrides :meth:`materialize_workspace` alone.
 
-    Entrypoint-as-host providers (e.g. Kubernetes) inherit
+    Entrypoint-as-host and provider-native host launchers inherit
     :class:`SandboxHostLauncher` directly and do NOT need ``run()`` or any
     exec transport.
     """

--- a/omnigent/onboarding/sandboxes/gensee.py
+++ b/omnigent/onboarding/sandboxes/gensee.py
@@ -1,0 +1,550 @@
+"""Gensee managed sandbox launcher.
+
+Gensee allocates one ephemeral sandbox runtime for each managed Omnigent host.
+The runtime starts an Omnigent-compatible environment and connects back to the
+server; lifecycle operations travel over Gensee's HTTPS control-plane API. This
+is therefore a managed-only, provider-native host launcher: it does not expose
+remote exec or the ``omnigent sandbox create`` CLI bootstrap primitives.
+
+The controller credential is read from the server process environment. Host
+launch tokens and explicitly configured environment values are uploaded to the
+controller's short-lived secret store instead of being embedded in operation
+records.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import secrets
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, ClassVar
+from urllib.parse import quote, unquote, urlsplit
+
+import click
+import httpx
+
+from omnigent.onboarding.sandboxes.base import SandboxHostLauncher
+from omnigent.onboarding.sandboxes.types import RepoWorkspace, SandboxCapabilities
+
+API_TOKEN_ENV_VAR: str = "GENSEE_CONTROLLER_API_TOKEN"
+"""Environment variable containing the Gensee control-plane API token."""
+
+CONTROLLER_URL_ENV_VAR: str = "GENSEE_CONTROLLER_URL"
+"""Optional default controller URL override for direct launcher use."""
+
+DEFAULT_CONTROLLER_URL: str = "https://sandbox.gensee.ai"
+DEFAULT_WORKSPACE_ROOT: str = "/mnt/gensee-tclone/workspaces"
+DEFAULT_OPERATION_TIMEOUT_S: int = 900
+DEFAULT_POLL_INTERVAL_S: int = 2
+DEFAULT_REQUEST_TIMEOUT_S: int = 40
+DEFAULT_RETRY_TIMEOUT_S: int = 60
+MANAGED_TOKEN_TTL_S: int = 7 * 24 * 3600
+
+_SCHEME = "gensee+controller"
+_TRANSIENT_HTTP_STATUS = frozenset({500, 502, 503, 504})
+_TERMINAL_OPERATION_STATES = frozenset({"succeeded", "failed", "cancelled"})
+_ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_BACKEND_NAME_RE = re.compile(r"[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?")
+_MAX_ERROR_DETAIL_CHARS = 4096
+_LOG = logging.getLogger(__name__)
+
+
+class GenseeControlError(click.ClickException):
+    """A Gensee control-plane request failed."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class _OperationDeadline:
+    operation_id: str
+    expires_at: float
+
+    def remaining(self) -> float:
+        remaining = self.expires_at - time.monotonic()
+        if remaining <= 0:
+            raise GenseeControlError(
+                f"Gensee controller operation {self.operation_id} timed out"
+            ) from None
+        return remaining
+
+
+class GenseeSandboxLauncher(SandboxHostLauncher):
+    """Launch one ephemeral Gensee runtime per managed Omnigent host."""
+
+    provider: ClassVar[str] = "gensee"
+
+    def __init__(
+        self,
+        *,
+        endpoint: str | None = None,
+        api_token_env: str = API_TOKEN_ENV_VAR,
+        workspace_root: str = DEFAULT_WORKSPACE_ROOT,
+        operation_timeout_s: float = DEFAULT_OPERATION_TIMEOUT_S,
+        poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+        request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+        retry_timeout_s: float = DEFAULT_RETRY_TIMEOUT_S,
+        env: Sequence[str] | None = None,
+        _transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.endpoint = _normalize_endpoint(
+            endpoint or os.environ.get(CONTROLLER_URL_ENV_VAR, DEFAULT_CONTROLLER_URL)
+        )
+        self.api_token_env = _validate_env_name(api_token_env, field="api_token_env")
+        self.workspace_root = _validate_workspace_root(workspace_root)
+        self.operation_timeout_s = _positive_timeout(
+            operation_timeout_s, field="operation_timeout_s"
+        )
+        self.poll_interval_s = _positive_timeout(poll_interval_s, field="poll_interval_s")
+        self.request_timeout_s = _positive_timeout(request_timeout_s, field="request_timeout_s")
+        self.retry_timeout_s = _nonnegative_timeout(retry_timeout_s, field="retry_timeout_s")
+        self.env = _validate_env_names(env or ())
+        self._transport = _transport
+        self._secret_values: set[str] = set()
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            managed_launch=True,
+            programmatic_terminate=True,
+        )
+
+    def prepare(self) -> None:
+        """Verify local credentials and control-plane readiness."""
+        self._api_token()
+        response = self._request("GET", "/readyz", authenticated=False)
+        if response.get("ok") is not True:
+            raise GenseeControlError("Gensee controller is not ready")
+
+    def provision(self, name: str) -> str:
+        """Allocate one ephemeral sandbox and return its opaque ID."""
+        allocation_id = _allocation_name(name)
+        try:
+            response = self._request(
+                "POST",
+                "/v1/sandbox-allocations:allocate",
+                {
+                    "protocol_version": 1,
+                    "user_id": allocation_id,
+                    "allocation_id": allocation_id,
+                    "idempotency_key": f"allocate-{allocation_id}",
+                },
+            )
+            allocation = _mapping(response, "allocation")
+            returned_id = _string(allocation, "allocation_id")
+            if returned_id != allocation_id:
+                raise GenseeControlError("Gensee controller returned an unexpected allocation ID")
+            return _sandbox_id(returned_id)
+        except (GenseeControlError, ValueError) as error:
+            # Even a rejected retry can follow a creation whose response was lost.
+            detail = (
+                error.message
+                if isinstance(error, GenseeControlError)
+                else "Gensee controller returned an invalid allocation ID"
+            )
+            cleanup_detail = ""
+            try:
+                self._release(allocation_id)
+            except GenseeControlError as cleanup_error:
+                cleanup_detail = f"; cleanup failed: {cleanup_error.message}"
+                _LOG.warning(
+                    "Gensee allocation cleanup failed allocation_id=%s: %s",
+                    allocation_id,
+                    cleanup_error.message,
+                )
+            raise GenseeControlError(
+                f"Gensee allocation {allocation_id} failed: {detail}{cleanup_detail}"
+            ) from None
+
+    def start_host(
+        self,
+        sandbox_id: str,
+        *,
+        token: str,
+        host_id: str,
+        host_name: str,
+        server_url: str,
+        repos: Sequence[RepoWorkspace] = (),
+        host_config: dict[str, object] | None = None,
+        on_stage: Callable[[str], None] | None = None,
+    ) -> str:
+        """Ask the sandbox agent to materialize a workspace and start its host."""
+        if len(repos) > 1:
+            raise GenseeControlError(
+                "The 'gensee' provider supports at most one repository per session"
+            )
+        repo = repos[0] if repos else None
+        if on_stage is not None:
+            on_stage("cloning" if repo is not None else "starting")
+
+        allocation_id = _allocation_id(sandbox_id)
+        secret_id = f"secret-{secrets.token_hex(16)}"
+        missing_env = [name for name in self.env if name not in os.environ]
+        if missing_env:
+            names = ", ".join(missing_env)
+            raise GenseeControlError(
+                f"configured Gensee environment variables are not set: {names}"
+            )
+        environment = {name: os.environ[name] for name in self.env}
+        self._secret_values.update((token, *environment.values()))
+        self._request(
+            "POST",
+            "/v1/sandbox-secrets:put",
+            {
+                "protocol_version": 1,
+                "allocation_id": allocation_id,
+                "secret_id": secret_id,
+                "token": json.dumps(
+                    {
+                        "version": 1,
+                        "host_token": token,
+                        "environment": environment,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+            },
+        )
+        operation = self._submit_and_wait(
+            allocation_id,
+            "start_omnigent_host",
+            {
+                "secret_id": secret_id,
+                "workspace": str(self.workspace_root / allocation_id),
+                "host_id": host_id,
+                "host_name": host_name,
+                "server_url": server_url,
+                "repo_url": repo.url if repo is not None else None,
+                "repo_branch": repo.branch if repo is not None else None,
+                "repo_name": repo.repo_name if repo is not None else None,
+                "host_config": host_config,
+            },
+        )
+        if repo is not None and on_stage is not None:
+            on_stage("starting")
+        response = _mapping(operation, "response")
+        result = _mapping(response, "result")
+        runtime = _mapping(result, "runtime")
+        return _string(runtime, "workspace")
+
+    def is_running(self, sandbox_id: str) -> bool | None:
+        """Return runtime-agent readiness, preserving transitional states as unknown."""
+        allocation_id = _allocation_id(sandbox_id)
+        response = self._request(
+            "GET",
+            f"/v1/sandbox-allocations/{quote(allocation_id, safe='')}",
+        )
+        allocation = _mapping(response, "allocation")
+        if allocation.get("state") != "active":
+            return False
+        runtime = _mapping(allocation, "runtime")
+        observed = runtime.get("observed_state")
+        if observed == "running" and runtime.get("ready") is True:
+            return True
+        if observed in {"absent", "deleting", "deleted", "stopped", "stopping"}:
+            return False
+        return None
+
+    def terminate(self, sandbox_id: str) -> None:
+        """Release an allocation; the controller treats repeats as success."""
+        self._release(_allocation_id(sandbox_id))
+
+    def _release(self, allocation_id: str) -> None:
+        try:
+            self._request(
+                "POST",
+                "/v1/sandbox-allocations:release",
+                {
+                    "protocol_version": 1,
+                    "allocation_id": allocation_id,
+                    "idempotency_key": f"release-{allocation_id}",
+                },
+            )
+        except GenseeControlError as error:
+            if error.status_code != 404:
+                raise
+
+    def _submit_and_wait(
+        self,
+        allocation_id: str,
+        action: str,
+        parameters: dict[str, object],
+    ) -> dict[str, Any]:
+        operation_id = f"operation-{secrets.token_hex(16)}"
+        started_at = time.monotonic()
+        deadline = _OperationDeadline(operation_id, started_at + self.operation_timeout_s)
+        response = self._request(
+            "POST",
+            "/v1/sandbox-operations:submit",
+            {
+                "protocol_version": 1,
+                "allocation_id": allocation_id,
+                "operation_id": operation_id,
+                "idempotency_key": operation_id,
+                "action": action,
+                "parameters": parameters,
+            },
+            deadline=deadline,
+        )
+        operation = _mapping(response, "operation")
+        previous_state: object = None
+        while operation.get("state") not in _TERMINAL_OPERATION_STATES:
+            state = operation.get("state")
+            if state != previous_state:
+                _LOG.info(
+                    "Gensee operation state operation_id=%s allocation_id=%s "
+                    "action=%s state=%s elapsed_ms=%d",
+                    operation_id,
+                    allocation_id,
+                    action,
+                    self._safe_error_detail(str(state)),
+                    round((time.monotonic() - started_at) * 1000),
+                )
+                previous_state = state
+            time.sleep(min(self.poll_interval_s, deadline.remaining()))
+            response = self._request(
+                "GET",
+                f"/v1/sandbox-operations/{quote(operation_id, safe='')}",
+                deadline=deadline,
+            )
+            operation = _mapping(response, "operation")
+        deadline.remaining()
+        if operation.get("state") != "succeeded":
+            response_value = operation.get("response")
+            error = response_value.get("error") if isinstance(response_value, dict) else None
+            detail = self._public_error_message(error)
+            raise GenseeControlError(
+                f"Gensee controller operation {operation_id} failed"
+                + (f": {detail}" if detail else "")
+            )
+        return operation
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, object] | None = None,
+        *,
+        authenticated: bool = True,
+        deadline: _OperationDeadline | None = None,
+    ) -> dict[str, Any]:
+        headers = {"Accept": "application/json"}
+        if authenticated:
+            headers["Authorization"] = f"Bearer {self._api_token()}"
+        retry_deadline = time.monotonic() + self.retry_timeout_s
+        retry_delay = 1.0
+        retrying = False
+        while True:
+            timeout = self.request_timeout_s
+            if deadline is not None:
+                timeout = min(timeout, deadline.remaining())
+            if retrying:
+                retry_remaining = retry_deadline - time.monotonic()
+                if retry_remaining <= 0:
+                    raise GenseeControlError("Gensee controller retry budget exhausted")
+                timeout = min(timeout, retry_remaining)
+            try:
+                with httpx.Client(
+                    base_url=f"{self.endpoint}/",
+                    timeout=timeout,
+                    transport=self._transport,
+                ) as client:
+                    response = client.request(
+                        method,
+                        path.lstrip("/"),
+                        json=payload,
+                        headers=headers,
+                    )
+            except (httpx.HTTPError, OSError) as error:
+                if self._wait_to_retry(retry_deadline, retry_delay, deadline):
+                    retry_delay = min(retry_delay * 2, 10)
+                    retrying = True
+                    continue
+                detail = self._safe_error_detail(str(error)) or type(error).__name__
+                raise GenseeControlError(f"Gensee controller request failed: {detail}") from None
+
+            if deadline is not None:
+                deadline.remaining()
+            if response.status_code in _TRANSIENT_HTTP_STATUS and self._wait_to_retry(
+                retry_deadline, retry_delay, deadline
+            ):
+                retry_delay = min(retry_delay * 2, 10)
+                retrying = True
+                continue
+            if response.is_error:
+                try:
+                    body = response.json()
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    body = None
+                detail = self._public_error_message(
+                    body.get("error") if isinstance(body, dict) else None
+                )
+                raise GenseeControlError(
+                    f"Gensee controller returned HTTP {response.status_code}"
+                    + (f": {detail}" if detail else ""),
+                    status_code=response.status_code,
+                )
+            try:
+                value = response.json()
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                raise GenseeControlError("Gensee controller returned invalid JSON") from None
+            if not isinstance(value, dict):
+                raise GenseeControlError("Gensee controller response must be an object")
+            if deadline is not None:
+                deadline.remaining()
+            return value
+
+    def _public_error_message(self, error: object) -> str:
+        if not isinstance(error, dict) or not isinstance(error.get("message"), str):
+            return ""
+        return self._safe_error_detail(error["message"])
+
+    def _safe_error_detail(self, message: str) -> str:
+        variants: set[str] = set()
+        for secret in self._secret_values:
+            if secret:
+                variants.add(secret)
+                # Error messages can contain JSON nested inside another JSON string.
+                for ensure_ascii in (True, False):
+                    escaped = json.dumps(secret, ensure_ascii=ensure_ascii)[1:-1]
+                    variants.add(escaped)
+                    variants.add(json.dumps(escaped, ensure_ascii=ensure_ascii)[1:-1])
+        for secret in sorted(variants, key=len, reverse=True):
+            message = message.replace(secret, "[redacted]")
+        return message[:_MAX_ERROR_DETAIL_CHARS]
+
+    def _api_token(self) -> str:
+        token = os.environ.get(self.api_token_env)
+        if token is None or not token.strip():
+            raise GenseeControlError(
+                f"environment variable {self.api_token_env!r} must contain the "
+                "Gensee controller API token"
+            )
+        self._secret_values.add(token.strip())
+        return token.strip()
+
+    @staticmethod
+    def _wait_to_retry(
+        retry_deadline: float, delay: float, operation_deadline: _OperationDeadline | None = None
+    ) -> bool:
+        remaining = retry_deadline - time.monotonic()
+        if operation_deadline is not None:
+            remaining = min(remaining, operation_deadline.remaining())
+        if remaining <= 0:
+            return False
+        time.sleep(min(delay, remaining))
+        if operation_deadline is not None:
+            operation_deadline.remaining()
+        return time.monotonic() < retry_deadline
+
+
+def _normalize_endpoint(value: str) -> str:
+    endpoint = value.strip().rstrip("/")
+    try:
+        parsed = urlsplit(endpoint)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError as error:
+        raise ValueError(f"invalid Gensee controller endpoint: {error}") from error
+    if (
+        parsed.scheme != "https"
+        or not hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError(
+            "Gensee controller endpoint must be an HTTPS URL without "
+            "credentials, a query, or a fragment"
+        )
+    if port is not None and not 1 <= port <= 65535:
+        raise ValueError("Gensee controller endpoint port is out of range")
+    return endpoint
+
+
+def _validate_env_name(value: str, *, field: str) -> str:
+    if not _ENV_NAME_RE.fullmatch(value):
+        raise ValueError(f"Gensee {field} must be an environment variable name")
+    return value
+
+
+def _validate_env_names(values: Sequence[str]) -> tuple[str, ...]:
+    result = tuple(_validate_env_name(value, field="env entry") for value in values)
+    if len(result) != len(set(result)):
+        raise ValueError("Gensee env must not contain duplicate names")
+    return result
+
+
+def _validate_workspace_root(value: str) -> PurePosixPath:
+    if "\x00" in value:
+        raise ValueError("Gensee workspace_root must not contain NUL bytes")
+    path = PurePosixPath(value)
+    if not path.is_absolute() or path == PurePosixPath("/") or ".." in path.parts:
+        raise ValueError("Gensee workspace_root must be an absolute non-root path")
+    return path
+
+
+def _positive_timeout(value: float, *, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"Gensee {field} must be a positive number")
+    return float(value)
+
+
+def _nonnegative_timeout(value: float, *, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ValueError(f"Gensee {field} must be a non-negative number")
+    return float(value)
+
+
+def _allocation_name(name: str) -> str:
+    prefix = "".join(
+        character.lower() if character.isascii() and character.isalnum() else "-"
+        for character in name
+    )
+    prefix = prefix.strip("-")[:20] or "omnigent"
+    return f"{prefix}-{secrets.token_hex(6)}"
+
+
+def _sandbox_id(allocation_id: str) -> str:
+    _validate_backend_identifier(allocation_id, kind="allocation")
+    return f"{_SCHEME}:///{quote(allocation_id, safe='')}"
+
+
+def _allocation_id(sandbox_id: str) -> str:
+    parsed = urlsplit(sandbox_id)
+    if parsed.scheme != _SCHEME or parsed.netloc or parsed.query or parsed.fragment:
+        raise GenseeControlError(f"invalid Gensee sandbox ID: {sandbox_id!r}")
+    allocation_id = unquote(parsed.path.removeprefix("/"))
+    try:
+        _validate_backend_identifier(allocation_id, kind="allocation")
+    except ValueError as error:
+        raise GenseeControlError(f"invalid Gensee sandbox ID: {sandbox_id!r}") from error
+    return allocation_id
+
+
+def _validate_backend_identifier(value: str, *, kind: str) -> None:
+    if not _BACKEND_NAME_RE.fullmatch(value):
+        raise ValueError(f"invalid Gensee {kind} ID")
+
+
+def _mapping(value: dict[str, Any], key: str) -> dict[str, Any]:
+    result = value.get(key)
+    if not isinstance(result, dict):
+        raise GenseeControlError(f"Gensee controller response is missing object {key!r}")
+    return result
+
+
+def _string(value: dict[str, Any], key: str) -> str:
+    result = value.get(key)
+    if not isinstance(result, str) or not result:
+        raise GenseeControlError(f"Gensee controller response is missing string {key!r}")
+    return result

--- a/omnigent/onboarding/sandboxes/registry.py
+++ b/omnigent/onboarding/sandboxes/registry.py
@@ -179,6 +179,11 @@ def _builtin_contribution() -> SandboxProviderContribution:
                 name="e2b",
                 launcher_class="omnigent.onboarding.sandboxes.e2b:E2BSandboxLauncher",
             ),
+            "gensee": SandboxProviderMetadata(
+                name="gensee",
+                launcher_class="omnigent.onboarding.sandboxes.gensee:GenseeSandboxLauncher",
+                managed_token_ttl_s=7 * 24 * 3600,
+            ),
             "openshell": SandboxProviderMetadata(
                 name="openshell",
                 launcher_class="omnigent.onboarding.sandboxes.openshell:OpenShellSandboxLauncher",

--- a/omnigent/server/managed_hosts.py
+++ b/omnigent/server/managed_hosts.py
@@ -34,7 +34,7 @@ stores into ``create_app``):
 
        sandbox:
          # lakebox|modal|daytona|blaxel|boxlite|cwsandbox|islo|e2b|openshell|
-         # kubernetes|microsandbox
+         # kubernetes|microsandbox|gensee
          provider: modal
          server_url: https://omnigent.example.com
          # For SEVERAL providers, replace `provider:` with a `providers:`
@@ -112,9 +112,15 @@ stores into ``create_app``):
            network: host                     # host (default)|public-only|all
            host_ports: [8317]                # extra guest-to-host ports (the
                                              # server_url port is always allowed)
+         gensee:                 # optional block (provider: gensee)
+           endpoint: https://sandbox.gensee.ai
+           api_token_env: GENSEE_CONTROLLER_API_TOKEN
+           workspace_root: /mnt/gensee-tclone/workspaces
+           env: [OPENAI_API_KEY, GIT_TOKEN]  # SERVER env var NAMES injected
 
    Most providers default to a public prebaked host image, so
-   ``provider`` + ``server_url`` is a complete config. Registry-backed
+   ``provider`` + ``server_url`` is a complete config. Gensee instead starts a
+   provider-managed runtime. Registry-backed
    providers use ``ghcr.io/omnigent-ai/omnigent-host:latest`` (see
    :data:`omnigent.onboarding.sandboxes.base.DEFAULT_HOST_IMAGE`); Blaxel uses
    ``blaxel/omnigent-host:latest``, which adds its required ``sandbox-api``.
@@ -126,7 +132,9 @@ stores into ``create_app``):
    launcher reads ``DAYTONA_API_KEY`` (plus optional
    ``DAYTONA_API_URL`` / ``DAYTONA_TARGET``), and the Islo launcher
    reads ``ISLO_API_KEY`` (plus optional ``ISLO_BASE_URL``) from the
-   server process environment. The Blaxel launcher reads ``BL_WORKSPACE``
+   server process environment. Gensee reads the environment variable named by
+   ``sandbox.gensee.api_token_env`` (``GENSEE_CONTROLLER_API_TOKEN`` by
+   default). The Blaxel launcher reads ``BL_WORKSPACE``
    and ``BL_API_KEY`` or the local ``bl login`` profile. The OpenShell
    launcher needs no API key:
    it connects to the gateway made active with ``openshell gateway
@@ -203,6 +211,7 @@ SUPPORTED_SANDBOX_PROVIDERS: frozenset[str] = frozenset(
         "cwsandbox",
         "islo",
         "e2b",
+        "gensee",
         "openshell",
         "kubernetes",
         "microsandbox",
@@ -218,6 +227,7 @@ PROVIDERS_WITH_MANAGED_LAUNCH: frozenset[str] = frozenset(
         "cwsandbox",
         "islo",
         "e2b",
+        "gensee",
         "openshell",
         "kubernetes",
         "microsandbox",
@@ -1432,6 +1442,36 @@ def _parse_single_provider_sandbox_config(raw: dict[str, object]) -> ManagedSand
         # outlives the (operator-overridable) sandbox lifetime — mirrors
         # the cwsandbox path.
         token_ttl_s = managed_token_ttl_s()
+    elif provider == "gensee":
+        from omnigent.onboarding.sandboxes.gensee import MANAGED_TOKEN_TTL_S
+
+        section = _parse_provider_section(raw, "gensee")
+        if section is not None:
+            _reject_unknown_keys(
+                section,
+                {
+                    "endpoint",
+                    "api_token_env",
+                    "workspace_root",
+                    "operation_timeout_s",
+                    "poll_interval_s",
+                    "request_timeout_s",
+                    "retry_timeout_s",
+                    "env",
+                },
+                "sandbox.gensee",
+            )
+        launcher_factory = _gensee_launcher_factory(
+            endpoint=_parse_provider_string(raw, "gensee", "endpoint"),
+            api_token_env=_parse_provider_string(raw, "gensee", "api_token_env"),
+            workspace_root=_parse_provider_string(raw, "gensee", "workspace_root"),
+            operation_timeout_s=_parse_provider_positive_int(raw, "gensee", "operation_timeout_s"),
+            poll_interval_s=_parse_provider_positive_int(raw, "gensee", "poll_interval_s"),
+            request_timeout_s=_parse_provider_positive_int(raw, "gensee", "request_timeout_s"),
+            retry_timeout_s=_parse_provider_nonnegative_int(raw, "gensee", "retry_timeout_s"),
+            env=_parse_provider_env(raw, "gensee"),
+        )
+        token_ttl_s = MANAGED_TOKEN_TTL_S
     elif provider == "openshell":
         launcher_factory = _openshell_launcher_factory(
             image=_parse_provider_image(raw, "openshell"),
@@ -2084,6 +2124,50 @@ def _e2b_launcher_factory(
     return _build
 
 
+def _gensee_launcher_factory(
+    *,
+    endpoint: str | None,
+    api_token_env: str | None,
+    workspace_root: str | None,
+    operation_timeout_s: int | None,
+    poll_interval_s: int | None,
+    request_timeout_s: int | None,
+    retry_timeout_s: int | None,
+    env: list[str] | None,
+) -> Callable[[], SandboxHostLauncher]:
+    """Build the launcher factory for the YAML ``provider: gensee`` path."""
+    from omnigent.onboarding.sandboxes.gensee import (
+        API_TOKEN_ENV_VAR,
+        DEFAULT_OPERATION_TIMEOUT_S,
+        DEFAULT_POLL_INTERVAL_S,
+        DEFAULT_REQUEST_TIMEOUT_S,
+        DEFAULT_RETRY_TIMEOUT_S,
+        DEFAULT_WORKSPACE_ROOT,
+        GenseeSandboxLauncher,
+    )
+
+    def _build() -> SandboxHostLauncher:
+        return GenseeSandboxLauncher(
+            endpoint=endpoint,
+            api_token_env=api_token_env or API_TOKEN_ENV_VAR,
+            workspace_root=workspace_root or DEFAULT_WORKSPACE_ROOT,
+            operation_timeout_s=operation_timeout_s or DEFAULT_OPERATION_TIMEOUT_S,
+            poll_interval_s=poll_interval_s or DEFAULT_POLL_INTERVAL_S,
+            request_timeout_s=request_timeout_s or DEFAULT_REQUEST_TIMEOUT_S,
+            retry_timeout_s=(
+                retry_timeout_s if retry_timeout_s is not None else DEFAULT_RETRY_TIMEOUT_S
+            ),
+            env=env,
+        )
+
+    try:
+        _build()
+    except ValueError as exc:
+        raise ValueError(f"server config 'sandbox.gensee' is invalid: {exc}") from exc
+
+    return _build
+
+
 def _parse_e2b_template(raw: dict[str, object]) -> str | None:
     """
     Extract and validate the e2b template from the ``sandbox`` dict.
@@ -2488,6 +2572,21 @@ def _parse_provider_positive_int(raw: dict[str, object], provider: str, key: str
         return None
     if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
         raise ValueError(f"server config 'sandbox.{provider}.{key}' must be a positive integer")
+    return value
+
+
+def _parse_provider_nonnegative_int(raw: dict[str, object], provider: str, key: str) -> int | None:
+    """Extract an optional non-negative integer provider field."""
+    section = _parse_provider_section(raw, provider)
+    if section is None:
+        return None
+    value = section.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(
+            f"server config 'sandbox.{provider}.{key}' must be a non-negative integer"
+        )
     return value
 
 

--- a/tests/e2e/integrations/deploy/gensee/test_managed_lifecycle.py
+++ b/tests/e2e/integrations/deploy/gensee/test_managed_lifecycle.py
@@ -1,0 +1,186 @@
+"""Optional live end-to-end test for the Gensee managed-host lifecycle.
+
+The test targets an existing Omnigent server configured with the built-in
+Gensee provider. It creates one managed session without sending an LLM prompt,
+waits for the sandbox host and runner to connect, deletes that exact session,
+and verifies that the corresponding Gensee allocation is released.
+
+This test is opt-in because it provisions a billable external sandbox. The
+agent must use a harness available in the Gensee runtime image.
+``OMNIGENT_E2E_GENSEE_SERVER_TOKEN`` is optional for auth-disabled servers and
+is sent as an Omnigent server Bearer token when present.
+
+    OMNIGENT_E2E_GENSEE=1 \
+    OMNIGENT_E2E_GENSEE_SERVER_URL=https://omnigent.example.com \
+    OMNIGENT_E2E_GENSEE_AGENT_ID=ag_example \
+    OMNIGENT_E2E_GENSEE_SERVER_TOKEN=... \
+    GENSEE_CONTROLLER_API_TOKEN=... \
+    .venv/bin/python -m pytest tests/e2e/integrations/deploy/gensee/test_managed_lifecycle.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import PurePosixPath
+from urllib.parse import quote
+
+import httpx
+import pytest
+
+from omnigent.onboarding.sandboxes.gensee import (
+    DEFAULT_WORKSPACE_ROOT,
+    GenseeSandboxLauncher,
+)
+
+pytestmark = [
+    pytest.mark.skipif(
+        os.environ.get("OMNIGENT_E2E_GENSEE") != "1",
+        reason="set OMNIGENT_E2E_GENSEE=1 to provision a live Gensee sandbox",
+    ),
+    pytest.mark.timeout(1200),
+]
+
+_READY_TIMEOUT_S = 900.0
+_RELEASE_TIMEOUT_S = 120.0
+_POLL_INTERVAL_S = 5.0
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        pytest.fail(f"{name} must be set when OMNIGENT_E2E_GENSEE=1")
+    return value
+
+
+def _server_headers() -> dict[str, str]:
+    token = os.environ.get("OMNIGENT_E2E_GENSEE_SERVER_TOKEN", "").strip()
+    return {"Authorization": f"Bearer {token}"} if token else {}
+
+
+def _assert_gensee_enabled(client: httpx.Client) -> None:
+    response = client.get("/v1/info")
+    response.raise_for_status()
+    info = response.json()
+    providers = info.get("sandbox_providers") or []
+    assert "gensee" in providers or info.get("sandbox_provider") == "gensee", (
+        "the target Omnigent server does not advertise Gensee as a managed sandbox provider"
+    )
+
+
+def _assert_agent_exists(client: httpx.Client, agent_id: str) -> None:
+    response = client.get("/v1/agents")
+    response.raise_for_status()
+    agents = response.json().get("data") or []
+    assert any(agent.get("id") == agent_id for agent in agents), (
+        f"agent {agent_id!r} is not registered on the target Omnigent server"
+    )
+
+
+def _wait_until_ready(client: httpx.Client, session_id: str) -> dict[str, object]:
+    deadline = time.monotonic() + _READY_TIMEOUT_S
+    last_snapshot: dict[str, object] = {}
+    while time.monotonic() < deadline:
+        response = client.get(
+            f"/v1/sessions/{quote(session_id, safe='')}",
+            params={"include_items": "false"},
+        )
+        response.raise_for_status()
+        last_snapshot = response.json()
+        sandbox_status = last_snapshot.get("sandbox_status") or {}
+        if isinstance(sandbox_status, dict) and sandbox_status.get("stage") == "failed":
+            pytest.fail(f"Gensee managed launch failed: {sandbox_status.get('error')}")
+        if last_snapshot.get("host_online") is True and last_snapshot.get("runner_online") is True:
+            return last_snapshot
+        time.sleep(_POLL_INTERVAL_S)
+    pytest.fail(
+        f"Gensee host and runner did not become ready within {_READY_TIMEOUT_S:.0f}s; "
+        f"last sandbox status was {last_snapshot.get('sandbox_status')!r}"
+    )
+
+
+def _sandbox_id_from_snapshot(snapshot: dict[str, object]) -> str:
+    workspace = snapshot.get("workspace")
+    assert isinstance(workspace, str) and workspace, "ready session did not report its workspace"
+    workspace_path = PurePosixPath(workspace)
+    expected_root = PurePosixPath(
+        os.environ.get("OMNIGENT_E2E_GENSEE_WORKSPACE_ROOT", DEFAULT_WORKSPACE_ROOT)
+    )
+    assert workspace_path.parent == expected_root, (
+        f"session workspace {workspace!r} is not directly beneath the expected "
+        f"Gensee workspace root {str(expected_root)!r}"
+    )
+    allocation_id = workspace_path.name
+    return f"gensee+controller:///{quote(allocation_id, safe='')}"
+
+
+def _wait_until_released(launcher: GenseeSandboxLauncher, sandbox_id: str) -> None:
+    deadline = time.monotonic() + _RELEASE_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if launcher.is_running(sandbox_id) is False:
+            return
+        time.sleep(_POLL_INTERVAL_S)
+    pytest.fail(
+        f"Gensee allocation {sandbox_id!r} was still active "
+        f"{_RELEASE_TIMEOUT_S:.0f}s after session deletion"
+    )
+
+
+def test_gensee_managed_session_lifecycle() -> None:
+    """A managed session provisions, becomes ready, and releases its allocation."""
+    server_url = _required_env("OMNIGENT_E2E_GENSEE_SERVER_URL").rstrip("/")
+    agent_id = _required_env("OMNIGENT_E2E_GENSEE_AGENT_ID")
+    _required_env("GENSEE_CONTROLLER_API_TOKEN")
+
+    session_id: str | None = None
+    deleted = False
+    with httpx.Client(
+        base_url=f"{server_url}/",
+        headers=_server_headers(),
+        timeout=30.0,
+    ) as client:
+        _assert_gensee_enabled(client)
+        _assert_agent_exists(client, agent_id)
+        try:
+            response = client.post(
+                "/v1/sessions",
+                json={
+                    "agent_id": agent_id,
+                    "host_type": "managed",
+                    "sandbox_provider": "gensee",
+                    "title": f"Gensee managed lifecycle E2E {int(time.time())}",
+                },
+            )
+            response.raise_for_status()
+            session_id = response.json()["id"]
+
+            snapshot = _wait_until_ready(client, session_id)
+            assert isinstance(snapshot.get("host_id"), str)
+            sandbox_id = _sandbox_id_from_snapshot(snapshot)
+
+            launcher = GenseeSandboxLauncher()
+            assert launcher.is_running(sandbox_id) is True
+
+            response = client.delete(
+                f"/v1/sessions/{quote(session_id, safe='')}",
+                timeout=120.0,
+            )
+            response.raise_for_status()
+            assert response.json() == {
+                "id": session_id,
+                "object": "conversation.deleted",
+                "deleted": True,
+            }
+            deleted = True
+
+            _wait_until_released(launcher, sandbox_id)
+            assert client.get(f"/v1/sessions/{quote(session_id, safe='')}").status_code == 404
+        finally:
+            if session_id is not None and not deleted:
+                cleanup = client.delete(
+                    f"/v1/sessions/{quote(session_id, safe='')}",
+                    timeout=120.0,
+                )
+                assert cleanup.status_code in {200, 404}, (
+                    f"cleanup failed for session {session_id!r}: HTTP {cleanup.status_code}"
+                )

--- a/tests/onboarding/sandboxes/test_gensee.py
+++ b/tests/onboarding/sandboxes/test_gensee.py
@@ -1,0 +1,872 @@
+"""Tests for the built-in Gensee sandbox provider."""
+
+from __future__ import annotations
+
+import json
+import traceback
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from omnigent.onboarding.sandboxes.gensee import (
+    GenseeControlError,
+    GenseeSandboxLauncher,
+    _allocation_id,
+)
+from omnigent.onboarding.sandboxes.types import RepoWorkspace
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _launcher(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+    **kwargs: object,
+) -> GenseeSandboxLauncher:
+    monkeypatch.setenv("GENSEE_CONTROLLER_API_TOKEN", "controller-secret")
+    options: dict[str, object] = {
+        "endpoint": "https://sandbox.example.com/control",
+        "retry_timeout_s": 0,
+        "_transport": httpx.MockTransport(handler),
+    }
+    options.update(kwargs)
+    return GenseeSandboxLauncher(
+        **options,
+    )
+
+
+def _json(request: httpx.Request) -> dict[str, object]:
+    value = json.loads(request.content)
+    assert isinstance(value, dict)
+    return value
+
+
+def test_capabilities_are_managed_only() -> None:
+    capabilities = GenseeSandboxLauncher().capabilities
+
+    assert capabilities.managed_launch is True
+    assert capabilities.programmatic_terminate is True
+    assert capabilities.cli_bootstrap is False
+    assert capabilities.resume_stopped is False
+    assert capabilities.file_copy is False
+
+
+def test_prepare_checks_credentials_and_public_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url == "https://sandbox.example.com/control/readyz"
+        assert "authorization" not in request.headers
+        return httpx.Response(200, json={"ok": True})
+
+    _launcher(monkeypatch, handler).prepare()
+
+
+def test_prepare_rejects_missing_api_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GENSEE_CONTROLLER_API_TOKEN", raising=False)
+    launcher = GenseeSandboxLauncher(
+        _transport=httpx.MockTransport(lambda _request: pytest.fail("unexpected request"))
+    )
+
+    with pytest.raises(GenseeControlError, match="GENSEE_CONTROLLER_API_TOKEN"):
+        launcher.prepare()
+
+
+def test_prepare_rejects_unready_controller(monkeypatch: pytest.MonkeyPatch) -> None:
+    launcher = _launcher(
+        monkeypatch,
+        lambda _request: httpx.Response(200, json={"ok": False}),
+    )
+
+    with pytest.raises(GenseeControlError, match="controller is not ready"):
+        launcher.prepare()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"endpoint": "http://sandbox.example.com"}, "HTTPS URL"),
+        ({"endpoint": "https://user@sandbox.example.com"}, "without credentials"),
+        ({"endpoint": "https://sandbox.example.com:0"}, "port is out of range"),
+        ({"endpoint": "https://sandbox.example.com:not-a-port"}, "invalid.*endpoint"),
+        ({"api_token_env": "NOT-AN-ENV"}, "environment variable name"),
+        ({"workspace_root": "relative"}, "absolute non-root"),
+        ({"workspace_root": "/tmp/../workspace"}, "absolute non-root"),
+        ({"workspace_root": "/workspace\0suffix"}, "NUL bytes"),
+        ({"operation_timeout_s": 0}, "positive number"),
+        ({"retry_timeout_s": -1}, "non-negative number"),
+        ({"env": ["GOOD", "NOT-GOOD"]}, "environment variable name"),
+        ({"env": ["DUPLICATE", "DUPLICATE"]}, "duplicate"),
+    ],
+)
+def test_configuration_rejects_unsafe_values(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        GenseeSandboxLauncher(**kwargs)
+
+
+def test_provision_uses_unique_ascii_allocation_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payloads: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["authorization"] == "Bearer controller-secret"
+        payload = _json(request)
+        payloads.append(payload)
+        return httpx.Response(
+            200,
+            json={"allocation": {"allocation_id": payload["allocation_id"]}},
+        )
+
+    launcher = _launcher(monkeypatch, handler)
+    first = launcher.provision("Managed Session 日本語")
+    second = launcher.provision("Managed Session 日本語")
+
+    assert first != second
+    first_id = _allocation_id(first)
+    assert first_id.isascii()
+    assert len(first_id) <= 33
+    assert payloads[0]["user_id"] == first_id
+    assert payloads[0]["idempotency_key"] == f"allocate-{first_id}"
+
+
+def test_start_host_uses_secret_store_and_waits_for_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "model-secret")
+    requests: list[tuple[str, dict[str, object]]] = []
+    operation_polls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal operation_polls
+        payload = _json(request) if request.content else {}
+        requests.append((request.url.path, payload))
+        if request.url.path.endswith("/v1/sandbox-secrets:put"):
+            return httpx.Response(200, json={"accepted": True})
+        if request.url.path.endswith("/v1/sandbox-operations:submit"):
+            return httpx.Response(200, json={"operation": {"state": "running"}})
+        operation_polls += 1
+        return httpx.Response(
+            200,
+            json={
+                "operation": {
+                    "state": "succeeded",
+                    "response": {"result": {"runtime": {"workspace": "/workspace/repo"}}},
+                }
+            },
+        )
+
+    stages: list[str] = []
+    launcher = _launcher(
+        monkeypatch,
+        handler,
+        poll_interval_s=0.001,
+        env=["OPENAI_API_KEY"],
+    )
+    workspace = launcher.start_host(
+        "gensee+controller:///managed-1",
+        token="host-secret",
+        host_id="host-1",
+        host_name="managed-1",
+        server_url="https://omnigent.example.com",
+        repos=[
+            RepoWorkspace(
+                url="https://github.com/example/repo.git",
+                branch="main",
+                repo_name="repo",
+            )
+        ],
+        host_config={"providers": {}},
+        on_stage=stages.append,
+    )
+
+    assert workspace == "/workspace/repo"
+    assert stages == ["cloning", "starting"]
+    assert operation_polls == 1
+    secret_payload = requests[0][1]
+    secret = json.loads(str(secret_payload["token"]))
+    assert secret == {
+        "environment": {"OPENAI_API_KEY": "model-secret"},
+        "host_token": "host-secret",
+        "version": 1,
+    }
+    assert all("host-secret" not in json.dumps(payload) for _, payload in requests[1:])
+    operation_payload = requests[1][1]
+    operation_id = operation_payload["operation_id"]
+    assert isinstance(operation_id, str)
+    assert operation_id.startswith("operation-")
+    assert operation_payload == {
+        "protocol_version": 1,
+        "allocation_id": "managed-1",
+        "operation_id": operation_id,
+        "idempotency_key": operation_id,
+        "action": "start_omnigent_host",
+        "parameters": operation_payload["parameters"],
+    }
+    parameters = operation_payload["parameters"]
+    assert isinstance(parameters, dict)
+    assert parameters == {
+        "secret_id": secret_payload["secret_id"],
+        "workspace": "/mnt/gensee-tclone/workspaces/managed-1",
+        "host_id": "host-1",
+        "host_name": "managed-1",
+        "server_url": "https://omnigent.example.com",
+        "repo_url": "https://github.com/example/repo.git",
+        "repo_branch": "main",
+        "repo_name": "repo",
+        "host_config": {"providers": {}},
+    }
+
+
+def test_start_host_rejects_multiple_repositories_before_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launcher = _launcher(
+        monkeypatch,
+        lambda _request: pytest.fail("multiple repositories must fail before a request"),
+    )
+
+    with pytest.raises(GenseeControlError, match="at most one repository"):
+        launcher.start_host(
+            "gensee+controller:///managed-1",
+            token="host-secret",
+            host_id="host-1",
+            host_name="managed-1",
+            server_url="https://omnigent.example.com",
+            repos=[
+                RepoWorkspace(url="https://github.com/example/a.git", branch=None, repo_name="a"),
+                RepoWorkspace(url="https://github.com/example/b.git", branch=None, repo_name="b"),
+            ],
+        )
+
+
+def test_start_host_rejects_missing_configured_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launcher = _launcher(
+        monkeypatch,
+        lambda _request: pytest.fail("missing environment must fail before a request"),
+        env=["MISSING_MODEL_API_KEY"],
+    )
+
+    with pytest.raises(GenseeControlError, match="MISSING_MODEL_API_KEY"):
+        launcher.start_host(
+            "gensee+controller:///managed-1",
+            token="host-secret",
+            host_id="host-1",
+            host_name="managed-1",
+            server_url="https://omnigent.example.com",
+        )
+
+
+def test_start_host_surfaces_controller_operation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/v1/sandbox-secrets:put"):
+            return httpx.Response(200, json={"accepted": True})
+        return httpx.Response(
+            200,
+            json={
+                "operation": {
+                    "state": "failed",
+                    "response": {"error": {"message": "image unavailable"}},
+                }
+            },
+        )
+
+    launcher = _launcher(monkeypatch, handler)
+    with pytest.raises(GenseeControlError, match="image unavailable"):
+        launcher.start_host(
+            "gensee+controller:///managed-1",
+            token="host-secret",
+            host_id="host-1",
+            host_name="managed-1",
+            server_url="https://omnigent.example.com",
+        )
+
+
+def test_start_host_surfaces_cancelled_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/v1/sandbox-secrets:put"):
+            return httpx.Response(200, json={"accepted": True})
+        return httpx.Response(
+            200,
+            json={
+                "operation": {
+                    "state": "cancelled",
+                    "response": {"error": {"message": "allocation released"}},
+                }
+            },
+        )
+
+    launcher = _launcher(monkeypatch, handler)
+    with pytest.raises(GenseeControlError, match="allocation released"):
+        launcher.start_host(
+            "gensee+controller:///managed-1",
+            token="host-secret",
+            host_id="host-1",
+            host_name="managed-1",
+            server_url="https://omnigent.example.com",
+        )
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        {"state": "succeeded"},
+        {"state": "succeeded", "response": {}},
+        {"state": "succeeded", "response": {"result": {}}},
+        {"state": "succeeded", "response": {"result": {"runtime": {}}}},
+    ],
+)
+def test_start_host_rejects_malformed_success_response(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: dict[str, object],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/v1/sandbox-secrets:put"):
+            return httpx.Response(200, json={"accepted": True})
+        return httpx.Response(200, json={"operation": operation})
+
+    launcher = _launcher(monkeypatch, handler)
+    with pytest.raises(GenseeControlError):
+        launcher.start_host(
+            "gensee+controller:///managed-1",
+            token="host-secret",
+            host_id="host-1",
+            host_name="managed-1",
+            server_url="https://omnigent.example.com",
+        )
+
+
+def test_operation_timeout_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        assert request.method == "POST", "must not poll after the deadline"
+        return httpx.Response(200, json={"operation": {"state": "running"}})
+
+    launcher = _launcher(monkeypatch, handler, operation_timeout_s=1, poll_interval_s=2)
+
+    with pytest.raises(GenseeControlError, match=r"operation .* timed out"):
+        launcher._submit_and_wait("managed-1", "start_omnigent_host", {})
+
+    assert clock.now == 1
+    assert requests == ["POST"]
+
+
+@pytest.mark.parametrize("slow_method", ["POST", "GET"])
+def test_operation_rejects_success_received_after_deadline(
+    monkeypatch: pytest.MonkeyPatch, slow_method: str
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        expected_timeout = 1 if request.method == "POST" else 0.75
+        assert request.extensions["timeout"] == dict.fromkeys(
+            ("connect", "read", "write", "pool"), expected_timeout
+        )
+        if request.method == slow_method:
+            clock.sleep(40)
+            return httpx.Response(200, json={"operation": {"state": "succeeded"}})
+        return httpx.Response(200, json={"operation": {"state": "running"}})
+
+    launcher = _launcher(monkeypatch, handler, operation_timeout_s=1, poll_interval_s=0.25)
+    with pytest.raises(GenseeControlError, match=r"operation .* timed out"):
+        launcher._submit_and_wait("managed-1", "start_omnigent_host", {})
+
+
+def test_submission_and_polling_share_one_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.method)
+        assert request.method == "POST", "submission must consume the operation budget"
+        clock.sleep(0.75)
+        return httpx.Response(200, json={"operation": {"state": "running"}})
+
+    launcher = _launcher(monkeypatch, handler, operation_timeout_s=1, poll_interval_s=0.5)
+    with pytest.raises(GenseeControlError, match=r"operation .* timed out"):
+        launcher._submit_and_wait("managed-1", "start_omnigent_host", {})
+    assert clock.now == 1
+    assert requests == ["POST"]
+
+
+@pytest.mark.parametrize("failure", ["transport", "http"])
+def test_operation_deadline_caps_request_retries(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if failure == "transport":
+            raise httpx.ReadTimeout("controller-secret", request=request)
+        return httpx.Response(503, text="unavailable")
+
+    launcher = _launcher(monkeypatch, handler, operation_timeout_s=2, retry_timeout_s=60)
+    with pytest.raises(GenseeControlError, match=r"operation .* timed out") as caught:
+        launcher._submit_and_wait("managed-1", "start_omnigent_host", {})
+
+    assert clock.now == 2
+    assert len(requests) == 2
+    assert requests[0].extensions["timeout"]["read"] == 2
+    assert requests[1].extensions["timeout"]["read"] == 1
+    assert requests[0].content == requests[1].content
+    assert "controller-secret" not in "".join(traceback.format_exception(caught.value))
+
+
+def test_request_can_succeed_within_remaining_operation_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(503)
+        if request.method == "POST":
+            return httpx.Response(200, json={"operation": {"state": "running"}})
+        clock.sleep(0.25)
+        return httpx.Response(200, json={"operation": {"state": "succeeded"}})
+
+    launcher = _launcher(
+        monkeypatch, handler, operation_timeout_s=2, poll_interval_s=0.25, retry_timeout_s=60
+    )
+    operation = launcher._submit_and_wait("managed-1", "start_omnigent_host", {})
+
+    assert operation["state"] == "succeeded"
+    assert clock.now == 1.5
+    assert [request.extensions["timeout"]["read"] for request in requests] == [2, 1, 0.75]
+
+
+@pytest.mark.parametrize(
+    ("allocation_state", "observed_state", "ready", "expected"),
+    [
+        ("active", "running", True, True),
+        ("active", "running", False, None),
+        ("active", "provisioning", False, None),
+        ("active", "stopped", False, False),
+        ("released", "deleted", False, False),
+    ],
+)
+def test_is_running_requires_runtime_agent_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    allocation_state: str,
+    observed_state: str,
+    ready: bool,
+    expected: bool | None,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "allocation": {
+                    "state": allocation_state,
+                    "runtime": {"observed_state": observed_state, "ready": ready},
+                }
+            },
+        )
+
+    launcher = _launcher(monkeypatch, handler)
+    assert launcher.is_running("gensee+controller:///managed-1") is expected
+
+
+def test_terminate_is_repeatable_and_sends_idempotent_release(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(_json(request))
+        return httpx.Response(200, json={"allocation": {"state": "released"}})
+
+    launcher = _launcher(monkeypatch, handler)
+    launcher.terminate("gensee+controller:///managed-1")
+    launcher.terminate("gensee+controller:///managed-1")
+
+    expected = {
+        "protocol_version": 1,
+        "allocation_id": "managed-1",
+        "idempotency_key": "release-managed-1",
+    }
+    assert seen == [expected, expected]
+
+
+def test_terminate_accepts_an_already_absent_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launcher = _launcher(
+        monkeypatch,
+        lambda _request: httpx.Response(404, json={"error": {"message": "not found"}}),
+    )
+    launcher.terminate("gensee+controller:///managed-1")
+
+
+@pytest.mark.parametrize("failure", ["timeout", "http", "invalid-json", "non-object"])
+def test_provision_releases_allocation_after_ambiguous_failure(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    requests: list[tuple[str, dict[str, object]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.url.path, _json(request)))
+        if request.url.path.endswith(":release"):
+            return httpx.Response(200, json={"allocation": {"state": "released"}})
+        if failure == "timeout":
+            raise httpx.ReadTimeout("response lost after creation", request=request)
+        if failure == "http":
+            return httpx.Response(503)
+        if failure == "invalid-json":
+            return httpx.Response(200, text="not-json")
+        return httpx.Response(200, json=[])
+
+    launcher = _launcher(monkeypatch, handler)
+    with pytest.raises(GenseeControlError):
+        launcher.provision("managed-1")
+
+    assert len(requests) == 2
+    allocation_id = requests[0][1]["allocation_id"]
+    assert requests[1] == (
+        "/control/v1/sandbox-allocations:release",
+        {
+            "protocol_version": 1,
+            "allocation_id": allocation_id,
+            "idempotency_key": f"release-{allocation_id}",
+        },
+    )
+
+
+def test_provision_reports_allocation_id_when_cleanup_also_fails(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    allocation_id = ""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal allocation_id
+        allocation_id = str(_json(request)["allocation_id"])
+        if request.url.path.endswith(":allocate"):
+            raise httpx.ReadTimeout("controller-secret", request=request)
+        return httpx.Response(503, json={"error": {"message": "controller-secret"}})
+
+    launcher = _launcher(monkeypatch, handler)
+    with pytest.raises(GenseeControlError, match="cleanup failed") as caught:
+        launcher.provision("managed-1")
+
+    assert allocation_id and allocation_id in caught.value.message
+    assert "request failed" in caught.value.message
+    assert "HTTP 503" in caught.value.message
+    assert allocation_id in caplog.text
+    assert "controller-secret" not in caplog.text
+    assert "controller-secret" not in "".join(traceback.format_exception(caught.value))
+
+
+def test_provision_retry_reuses_allocation_without_releasing_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+    requests: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith(":allocate")
+        payload = _json(request)
+        requests.append(payload)
+        if len(requests) == 1:
+            raise httpx.ReadTimeout("response lost after creation", request=request)
+        return httpx.Response(
+            200, json={"allocation": {"allocation_id": payload["allocation_id"]}}
+        )
+
+    launcher = _launcher(monkeypatch, handler, retry_timeout_s=5)
+    sandbox_id = launcher.provision("managed-1")
+
+    assert len(requests) == 2
+    assert requests[0] == requests[1]
+    assert _allocation_id(sandbox_id) == requests[0]["allocation_id"]
+
+
+@pytest.mark.parametrize("first_failure", ["timeout", "http"])
+@pytest.mark.parametrize("retry_status", [409, 429])
+def test_provision_cleans_up_when_rejected_retry_follows_ambiguous_failure(
+    monkeypatch: pytest.MonkeyPatch, first_failure: str, retry_status: int
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+    requests: list[tuple[str, dict[str, object]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.url.path, _json(request)))
+        if request.url.path.endswith(":release"):
+            return httpx.Response(200, json={"allocation": {"state": "released"}})
+        if len(requests) == 1:
+            if first_failure == "timeout":
+                raise httpx.ReadTimeout("response lost after creation", request=request)
+            return httpx.Response(503)
+        return httpx.Response(retry_status)
+
+    launcher = _launcher(monkeypatch, handler, retry_timeout_s=5)
+    with pytest.raises(GenseeControlError, match=f"HTTP {retry_status}") as caught:
+        launcher.provision("managed-1")
+
+    assert len(requests) == 3
+    assert requests[0] == requests[1]
+    allocation_id = requests[0][1]["allocation_id"]
+    assert requests[2][0] == "/control/v1/sandbox-allocations:release"
+    assert requests[2][1]["allocation_id"] == allocation_id
+    assert str(allocation_id) in caught.value.message
+
+
+def test_provision_releases_requested_allocation_after_mismatched_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[tuple[str, dict[str, object]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _json(request)
+        requests.append((request.url.path, payload))
+        if request.url.path.endswith(":allocate"):
+            return httpx.Response(
+                200,
+                json={"allocation": {"allocation_id": "INVALID_ID"}},
+            )
+        return httpx.Response(200, json={"allocation": {"state": "released"}})
+
+    launcher = _launcher(monkeypatch, handler)
+    with pytest.raises(GenseeControlError, match="unexpected allocation ID"):
+        launcher.provision("managed-1")
+
+    requested_id = requests[0][1]["allocation_id"]
+    assert requests[1] == (
+        "/control/v1/sandbox-allocations:release",
+        {
+            "protocol_version": 1,
+            "allocation_id": requested_id,
+            "idempotency_key": f"release-{requested_id}",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "failure", ["validation", "http-message", "html", "transport", "operation"]
+)
+def test_start_host_errors_do_not_expose_credentials(
+    monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    dummy_api_key = 'model-"secret\\with\nnewline-\u0394'
+    monkeypatch.setenv("OPENAI_API_KEY", dummy_api_key)
+    reflected_input = ""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal reflected_input
+        if request.url.path.endswith(":put"):
+            reflected_input = request.content.decode()
+            if failure == "operation":
+                return httpx.Response(200, json={"accepted": True})
+        detail = f"invalid launch: controller-secret; {dummy_api_key}; {reflected_input}"
+        if failure == "validation":
+            return httpx.Response(422, json={"detail": [{"msg": "bad input", "input": detail}]})
+        if failure == "http-message":
+            return httpx.Response(422, json={"error": {"message": detail, "input": detail}})
+        if failure == "html":
+            return httpx.Response(400, text=f"<html>{detail}</html>")
+        if failure == "transport":
+            raise httpx.ConnectError(detail, request=request)
+        return httpx.Response(
+            200,
+            json={"operation": {"state": "failed", "response": {"error": {"message": detail}}}},
+        )
+
+    launcher = _launcher(monkeypatch, handler, env=["OPENAI_API_KEY"])
+    with pytest.raises(GenseeControlError) as caught:
+        launcher.start_host(
+            "gensee+controller:///managed-1",
+            token="host-secret",
+            host_id="host-1",
+            host_name="managed-1",
+            server_url="https://omnigent.example.com",
+        )
+
+    rendered = "".join(traceback.format_exception(caught.value))
+    for secret in ("controller-secret", "host-secret", dummy_api_key):
+        assert secret not in rendered
+        escaped = json.dumps(secret)[1:-1]
+        assert escaped not in rendered
+        assert json.dumps(escaped)[1:-1] not in rendered
+    if failure in {"http-message", "transport", "operation"}:
+        assert "invalid launch" in caught.value.message
+        assert "[redacted]" in caught.value.message
+    else:
+        assert "invalid launch" not in caught.value.message
+        assert "HTTP" in caught.value.message
+
+
+def test_error_redaction_happens_before_truncation(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy_api_key = "model-secret-" + "s" * 5000
+    monkeypatch.setenv("OPENAI_API_KEY", dummy_api_key)
+    launcher = _launcher(
+        monkeypatch,
+        lambda _request: httpx.Response(
+            400,
+            json={"error": {"message": f"invalid value: {dummy_api_key} trailing diagnostic"}},
+        ),
+        env=["OPENAI_API_KEY"],
+    )
+    with pytest.raises(GenseeControlError) as caught:
+        launcher.start_host(
+            "gensee+controller:///managed-1",
+            token="host-secret",
+            host_id="host-1",
+            host_name="managed-1",
+            server_url="https://omnigent.example.com",
+        )
+    assert "model-secret-" not in caught.value.message
+    assert "[redacted] trailing diagnostic" in caught.value.message
+
+
+def test_transient_response_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(503, text="temporarily unavailable")
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time.sleep", lambda _s: None)
+    launcher = _launcher(monkeypatch, handler, retry_timeout_s=5)
+    launcher.prepare()
+
+    assert attempts == 2
+
+
+def test_transport_error_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.ConnectError("connection reset", request=request)
+        return httpx.Response(200, json={"ok": True})
+
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time.sleep", lambda _s: None)
+    launcher = _launcher(monkeypatch, handler, retry_timeout_s=5)
+    launcher.prepare()
+
+    assert attempts == 2
+
+
+def test_transport_error_is_wrapped_after_retry_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection reset", request=request)
+
+    launcher = _launcher(monkeypatch, handler)
+    with pytest.raises(GenseeControlError, match="request failed: connection reset"):
+        launcher.prepare()
+
+
+def test_nontransient_error_is_not_retried_and_body_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        if request.url.path.endswith(":release"):
+            return httpx.Response(404)
+        attempts += 1
+        return httpx.Response(409, content=b"x" * 5000)
+
+    launcher = _launcher(monkeypatch, handler, retry_timeout_s=5)
+    with pytest.raises(GenseeControlError) as caught:
+        launcher.provision("managed-1")
+
+    assert attempts == 1
+    assert "HTTP 409" in caught.value.message
+    assert len(caught.value.message) < 4200
+
+
+def test_retry_budget_does_not_start_an_attempt_after_its_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = _Clock()
+    monkeypatch.setattr("omnigent.onboarding.sandboxes.gensee.time", clock)
+    attempts = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(503)
+
+    launcher = _launcher(monkeypatch, handler, retry_timeout_s=1)
+    with pytest.raises(GenseeControlError, match="HTTP 503"):
+        launcher.prepare()
+    assert attempts == 1
+    assert clock.now == 1
+
+
+@pytest.mark.parametrize(
+    "sandbox_id",
+    [
+        "not-gensee:///managed-1",
+        "gensee+controller://host/managed-1",
+        "gensee+controller:///../managed-1",
+        "gensee+controller:///managed_1",
+        "gensee+controller:///",
+    ],
+)
+def test_invalid_sandbox_ids_fail_before_request(
+    monkeypatch: pytest.MonkeyPatch, sandbox_id: str
+) -> None:
+    launcher = _launcher(
+        monkeypatch,
+        lambda _request: pytest.fail("invalid IDs must not reach the controller"),
+    )
+
+    with pytest.raises(GenseeControlError, match="invalid Gensee sandbox ID"):
+        launcher.terminate(sandbox_id)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(200, text="not-json"),
+        httpx.Response(200, json=[]),
+        httpx.Response(200, json={"unexpected": {}}),
+        httpx.Response(200, json={"allocation": {"allocation_id": ""}}),
+    ],
+)
+def test_malformed_controller_responses_fail_closed(
+    monkeypatch: pytest.MonkeyPatch, response: httpx.Response
+) -> None:
+    launcher = _launcher(monkeypatch, lambda _request: response)
+
+    with pytest.raises(GenseeControlError):
+        launcher.provision("managed-1")

--- a/tests/onboarding/sandboxes/test_registry.py
+++ b/tests/onboarding/sandboxes/test_registry.py
@@ -68,6 +68,7 @@ def test_plugin_state_loads_builtins() -> None:
     assert isinstance(state, SandboxProviderPluginState)
     assert "modal" in state
     assert "blaxel" in state
+    assert "gensee" in state
     assert "kubernetes" in state
 
 
@@ -94,6 +95,7 @@ def test_available_providers_returns_builtins() -> None:
     names = available_providers()
     assert "modal" in names
     assert "blaxel" in names
+    assert "gensee" in names
     assert "kubernetes" in names
 
 
@@ -131,6 +133,14 @@ def test_instantiate_loads_microsandbox_without_optional_sdk() -> None:
     reset_plugin_state_for_tests()
     launcher = instantiate("microsandbox")
     assert launcher.provider == "microsandbox"
+
+
+def test_instantiate_loads_gensee_from_core() -> None:
+    """Gensee resolves to the built-in launcher without a plugin package."""
+    reset_plugin_state_for_tests()
+    launcher = instantiate("gensee")
+    assert launcher.provider == "gensee"
+    assert launcher.__class__.__module__ == "omnigent.onboarding.sandboxes.gensee"
 
 
 def test_instantiate_unknown_raises() -> None:

--- a/tests/server/test_managed_hosts.py
+++ b/tests/server/test_managed_hosts.py
@@ -4781,6 +4781,96 @@ async def test_concurrent_relaunch_messages_kick_a_single_launch(
     assert calls[0]["agent_id"] == builtin.id
 
 
+# ── Gensee sandbox provider ─────────────────────────────────
+
+
+def test_parse_gensee_builds_core_launcher() -> None:
+    """The built-in Gensee provider receives its validated server config."""
+    from omnigent.onboarding.sandboxes.gensee import GenseeSandboxLauncher
+
+    deployment = parse_sandbox_config(
+        {
+            "provider": "gensee",
+            "server_url": "https://omnigent.example.com",
+            "gensee": {
+                "endpoint": "https://sandbox.example.com/control/",
+                "api_token_env": "CUSTOM_GENSEE_TOKEN",
+                "workspace_root": "/srv/gensee/workspaces",
+                "operation_timeout_s": 600,
+                "poll_interval_s": 1,
+                "request_timeout_s": 30,
+                "retry_timeout_s": 0,
+                "env": ["OPENAI_API_KEY", "GIT_TOKEN"],
+            },
+        }
+    )
+
+    assert deployment is not None
+    config = deployment.default
+    assert config.provider == "gensee"
+    assert config.managed_launch_supported is True
+    assert config.token_ttl_s == 7 * 24 * 3600
+    launcher = config.launcher_factory()
+    assert isinstance(launcher, GenseeSandboxLauncher)
+    assert launcher.endpoint == "https://sandbox.example.com/control"
+    assert launcher.api_token_env == "CUSTOM_GENSEE_TOKEN"
+    assert str(launcher.workspace_root) == "/srv/gensee/workspaces"
+    assert launcher.retry_timeout_s == 0
+    assert launcher.env == ("OPENAI_API_KEY", "GIT_TOKEN")
+
+
+def test_parse_gensee_uses_safe_defaults() -> None:
+    """A minimal Gensee block targets the production control endpoint."""
+    from omnigent.onboarding.sandboxes.gensee import GenseeSandboxLauncher
+
+    deployment = parse_sandbox_config(
+        {
+            "provider": "gensee",
+            "server_url": "https://omnigent.example.com",
+        }
+    )
+
+    assert deployment is not None
+    launcher = deployment.default.launcher_factory()
+    assert isinstance(launcher, GenseeSandboxLauncher)
+    assert launcher.endpoint == "https://sandbox.gensee.ai"
+    assert launcher.api_token_env == "GENSEE_CONTROLLER_API_TOKEN"
+
+
+def test_parse_gensee_rejects_unknown_config_key() -> None:
+    with pytest.raises(ValueError, match=r"sandbox\.gensee.*unknown"):
+        parse_sandbox_config(
+            {
+                "provider": "gensee",
+                "server_url": "https://omnigent.example.com",
+                "gensee": {"project": "not-a-public-provider-setting"},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "gensee",
+    [
+        {"endpoint": "http://sandbox.example.com"},
+        {"api_token_env": "NOT-AN-ENV"},
+        {"workspace_root": "relative"},
+        {"operation_timeout_s": 0},
+        {"retry_timeout_s": -1},
+        {"env": ["NOT-AN-ENV"]},
+        {"env": ["DUPLICATE", "DUPLICATE"]},
+    ],
+)
+def test_parse_gensee_rejects_invalid_config(gensee: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match=r"sandbox\.gensee"):
+        parse_sandbox_config(
+            {
+                "provider": "gensee",
+                "server_url": "https://omnigent.example.com",
+                "gensee": gensee,
+            }
+        )
+
+
 # ── contributed sandbox providers ───────────────────────────
 
 


### PR DESCRIPTION
## Related issue

Closes #7220

## Summary

- Add Gensee as a built-in managed sandbox provider using Omnigent’s existing managed-host lifecycle: allocate a sandbox, deliver a short-lived host secret, start `omnigent host`, wait for readiness, and release the allocation during cleanup.
- Register and configure the provider through the existing sandbox-provider interfaces, including bounded retries, credential redaction, idempotent release, capability reporting, and deployment documentation.
- Add unit coverage and an opt-in live E2E test that creates a managed session, waits for the Gensee host and runner, deletes the session, and verifies that the exact allocation is released.

ELI5: when a user selects Gensee for a managed session, Omnigent asks Gensee for a temporary machine, starts an Omnigent host there, and returns the machine when the session is deleted.

```mermaid
flowchart LR
    User -->|Create managed session| Server[Omnigent server]
    Server -->|Allocate sandbox and submit host start| Gensee[Gensee controller]
    Gensee --> Sandbox[Gensee sandbox runtime]
    Sandbox -->|Host and runner connect| Server
    User -->|Delete session| Server
    Server -->|Release allocation| Gensee
```

This phase does not add workspace fork or merge behavior and does not change existing session semantics.

## Test Plan

- `.venv/bin/python -m pytest -q tests/onboarding/sandboxes/test_gensee.py tests/onboarding/sandboxes/test_registry.py tests/server/test_managed_hosts.py tests/e2e/integrations/deploy/gensee/test_managed_lifecycle.py` — 435 passed, 1 skipped.
- `.venv/bin/pre-commit run --files README.md deploy/README.md deploy/gensee/README.md docs/extending/sandbox_providers.md omnigent/onboarding/sandboxes/base.py omnigent/onboarding/sandboxes/gensee.py omnigent/onboarding/sandboxes/registry.py omnigent/server/managed_hosts.py tests/e2e/integrations/deploy/gensee/test_managed_lifecycle.py tests/onboarding/sandboxes/test_gensee.py tests/onboarding/sandboxes/test_registry.py tests/server/test_managed_hosts.py` — passed.
- `git diff --cached --check` — passed.
- The live Gensee E2E was collected and skipped because `OMNIGENT_E2E_GENSEE=1` and deployment credentials were not provided. Its credential-gated invocation is documented in `deploy/gensee/README.md`.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [x] Docs
- [x] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Controller requests, retries, validation, redaction, lifecycle transitions, configuration, and registry integration are covered with mocked HTTP transport. The opt-in E2E covers the live managed-session lifecycle but was not executed locally because no deployed test server and Gensee credentials were available.

## Changelog

Omnigent servers can now use Gensee as a built-in managed sandbox provider.
