### PR TITLE
fix(server): pin a confirmed Claude permission mode into launch args

### DIFF
--- a/omnigent/harnesses/claude_native/bridge.py
+++ b/omnigent/harnesses/claude_native/bridge.py
@@ -256,11 +256,14 @@ _PERMISSION_MODE_FOOTERS: dict[str, str] = {
     "acceptEdits": "accept edits on",
     "plan": "plan mode on",
     "auto": "auto mode on",
+    # Launch-only, but readable: a pane launched into bypass must report
+    # its own mode so the cycler has a starting point to leave it from.
+    "bypassPermissions": "bypass permissions on",
 }
-# Modes shift+tab can reach. ``dontAsk`` is never in the cycle and
-# ``bypassPermissions`` only joins it when launched into, so both are
-# rejected up front.
-CYCLEABLE_PERMISSION_MODES = frozenset(_PERMISSION_MODE_FOOTERS)
+# Modes shift+tab can reach from any session. ``dontAsk`` is never in the
+# cycle and ``bypassPermissions`` only joins it when launched into, so
+# neither is a switch target.
+CYCLEABLE_PERMISSION_MODES = frozenset(_PERMISSION_MODE_FOOTERS) - {"bypassPermissions"}
 # Cap on shift+tab presses. The cycle is 3-5 modes wide depending on which
 # optional modes are enabled, so a full lap plus slack proves the target is
 # unreachable rather than slow.

--- a/omnigent/server/routes/_sessions/common.py
+++ b/omnigent/server/routes/_sessions/common.py
@@ -237,6 +237,12 @@ _CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY = "omnigent.claude_native.permission_mo
 _CLAUDE_NATIVE_PERMISSION_MODES: frozenset[str] = frozenset(
     {"default", "acceptEdits", "plan", "auto"}
 )
+# Modes the forwarder can read off the pane footer. A session launched into
+# ``bypassPermissions`` reports it so the label and picker show the real mode;
+# it is still not a PATCH target.
+_CLAUDE_NATIVE_READABLE_PERMISSION_MODES: frozenset[str] = _CLAUDE_NATIVE_PERMISSION_MODES | {
+    "bypassPermissions"
+}
 
 
 _CODEX_NATIVE_SUBAGENT_DISPLAY_FALLBACK = "Codex"
@@ -915,6 +921,7 @@ __all__ = [
     "_CLAUDE_NATIVE_PERMISSION_HOOK_TIMEOUT_S",
     "_CLAUDE_NATIVE_PERMISSION_MODES",
     "_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY",
+    "_CLAUDE_NATIVE_READABLE_PERMISSION_MODES",
     "_CLAUDE_NATIVE_REMEMBER_INELIGIBLE_TOOLS",
     "_CLAUDE_NATIVE_SUBAGENT_ID_LABEL_KEY",
     "_CLAUDE_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE",

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2739,16 +2739,25 @@ def _merge_codex_permission_launch_args(
 
 def _strip_claude_permission_launch_arg(args: list[str]) -> tuple[list[str], bool]:
     """
-    Drop every ``--permission-mode`` (space- or ``=``-joined) from Claude launch args.
+    Drop every permission-mode selector from Claude launch args.
+
+    Removes ``--permission-mode`` (space- or ``=``-joined) and the standalone
+    ``--dangerously-skip-permissions``, which Claude treats as
+    ``--permission-mode bypassPermissions``; leaving that flag next to a pinned
+    mode would resume the session in bypass under a restricted label.
 
     :param args: Launch args, e.g. ``["--model", "opus", "--permission-mode", "plan"]``.
-    :returns: The remaining args in order, and whether a flag was present.
+    :returns: The remaining args in order, and whether a selector was present.
     """
     stripped: list[str] = []
     had_flag = False
     index = 0
     while index < len(args):
         arg = args[index]
+        if arg == "--dangerously-skip-permissions":
+            had_flag = True
+            index += 1
+            continue
         if arg == "--permission-mode":
             had_flag = True
             index += 2  # drop the flag and its separate value token
@@ -2772,7 +2781,8 @@ def _merge_claude_permission_launch_args(
     launcher restores the mode from ``terminal_launch_args`` — not the label.
     Rewrite the existing ``--permission-mode`` entry (space- or ``=``-joined) to
     the current mode, preserving other args in order, so a cold resume reopens
-    in the mode the user last chose.
+    in the mode the user last chose. A standalone ``--dangerously-skip-permissions``
+    counts as an existing ``--permission-mode bypassPermissions``.
 
     Returns ``existing_args`` unchanged when they carry no ``--permission-mode``:
     a session launched without the flag (manual, or a ``settings.json``

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -136,6 +136,7 @@ from omnigent.server.routes._sessions.common import (  # noqa: F401
     _CLAUDE_NATIVE_HARNESS,
     _CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY,
     _CLAUDE_NATIVE_PERMISSION_MODES,
+    _CLAUDE_NATIVE_READABLE_PERMISSION_MODES,
     _CLAUDE_NATIVE_REMEMBER_INELIGIBLE_TOOLS,
     _CLAUDE_NATIVE_SUBAGENT_ID_LABEL_KEY,
     _CLAUDE_NATIVE_SUBAGENT_WRAPPER_LABEL_VALUE,
@@ -2586,7 +2587,8 @@ async def _persist_external_permission_mode_change(
 
     :param session_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
     :param conv: Conversation row for ``session_id`` at the route boundary.
-    :param body: Event body; ``data.permission_mode`` must be a switchable mode.
+    :param body: Event body; ``data.permission_mode`` must be a mode the pane
+        footer can report (the switchable modes plus ``bypassPermissions``).
     :param conversation_store: Store used to upsert the mode label.
     :returns: None.
     :raises OmnigentError: If ``data.permission_mode`` is missing or unsupported.
@@ -2599,10 +2601,10 @@ async def _persist_external_permission_mode_change(
             code=ErrorCode.INVALID_INPUT,
         )
     mode = raw_mode.strip()
-    if mode not in _CLAUDE_NATIVE_PERMISSION_MODES:
+    if mode not in _CLAUDE_NATIVE_READABLE_PERMISSION_MODES:
         raise OmnigentError(
             "external_permission_mode_change requires data.permission_mode in "
-            f"{sorted(_CLAUDE_NATIVE_PERMISSION_MODES)}; got {mode!r}",
+            f"{sorted(_CLAUDE_NATIVE_READABLE_PERMISSION_MODES)}; got {mode!r}",
             code=ErrorCode.INVALID_INPUT,
         )
     # Reflect the switch into terminal_launch_args so a relaunch reopens in this

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2800,6 +2800,8 @@ def _pin_claude_permission_launch_args(
     created without the flag: the launcher rebuilds Claude's args from
     ``terminal_launch_args`` alone and never reads the mode label, so a
     label-only record reopens the session in Claude's default (manual) mode.
+    Pinning ``"default"`` is a deliberate choice of Claude's manual mode and
+    overrides a ``permissions.defaultMode`` in the user's settings on relaunch.
 
     :param existing_args: Current launch args, e.g. ``["--model", "opus"]`` or ``None``.
     :param mode: Runner-confirmed mode, e.g. ``"auto"``.

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2735,6 +2735,31 @@ def _merge_codex_permission_launch_args(
     return [*merged, *permission_args]
 
 
+def _strip_claude_permission_launch_arg(args: list[str]) -> tuple[list[str], bool]:
+    """
+    Drop every ``--permission-mode`` (space- or ``=``-joined) from Claude launch args.
+
+    :param args: Launch args, e.g. ``["--model", "opus", "--permission-mode", "plan"]``.
+    :returns: The remaining args in order, and whether a flag was present.
+    """
+    stripped: list[str] = []
+    had_flag = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--permission-mode":
+            had_flag = True
+            index += 2  # drop the flag and its separate value token
+            continue
+        if arg.startswith("--permission-mode="):
+            had_flag = True
+            index += 1
+            continue
+        stripped.append(arg)
+        index += 1
+    return stripped, had_flag
+
+
 def _merge_claude_permission_launch_args(
     existing_args: list[str] | None,
     mode: str,
@@ -2755,23 +2780,31 @@ def _merge_claude_permission_launch_args(
     settings default on relaunch. Those sessions surface the live mode through
     the permission-mode label instead.
     """
-    args = list(existing_args or ())
-    if not any(a == "--permission-mode" or a.startswith("--permission-mode=") for a in args):
+    stripped, had_flag = _strip_claude_permission_launch_arg(list(existing_args or ()))
+    if not had_flag:
         return existing_args
-    merged: list[str] = []
-    index = 0
-    while index < len(args):
-        arg = args[index]
-        if arg == "--permission-mode":
-            index += 2  # drop the flag and its separate value token
-            continue
-        if arg.startswith("--permission-mode="):
-            index += 1
-            continue
-        merged.append(arg)
-        index += 1
-    merged.extend(("--permission-mode", mode))
-    return merged
+    return [*stripped, "--permission-mode", mode]
+
+
+def _pin_claude_permission_launch_args(
+    existing_args: list[str] | None,
+    mode: str,
+) -> list[str]:
+    """
+    Set ``--permission-mode`` to ``mode`` in Claude launch args, adding it when absent.
+
+    For a switch the user made deliberately (the web picker, confirmed by the
+    runner) the mode must survive a cold resume even when the session was
+    created without the flag: the launcher rebuilds Claude's args from
+    ``terminal_launch_args`` alone and never reads the mode label, so a
+    label-only record reopens the session in Claude's default (manual) mode.
+
+    :param existing_args: Current launch args, e.g. ``["--model", "opus"]`` or ``None``.
+    :param mode: Runner-confirmed mode, e.g. ``"auto"``.
+    :returns: The args with exactly one trailing ``--permission-mode <mode>``.
+    """
+    stripped, _ = _strip_claude_permission_launch_arg(list(existing_args or ()))
+    return [*stripped, "--permission-mode", mode]
 
 
 def _handle_external_session_todos(
@@ -10792,6 +10825,7 @@ __all__ = [
     "_persist_policy_deny_sentinel",
     "_persist_session_status_error_labels",
     "_persist_stored_session_bundle",
+    "_pin_claude_permission_launch_args",
     "_policy_notice_from_ensure_response",
     "_poll_request_disconnect",
     "_presentation_labels_for_agent",

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -122,12 +122,12 @@ from omnigent.server.routes._sessions.helpers import (
     _forward_session_change_to_runner,
     _get_runner_client,
     _invalidate_runner_backed_snapshot_state,
-    _merge_claude_permission_launch_args,
     _multipart_missing_detail,
     _native_coding_agent_for_agent,
     _notify_runner_of_bundled_child,
     _parse_session_create_metadata,
     _permission_level_from_grants,
+    _pin_claude_permission_launch_args,
     _presentation_labels_for_agent,
     _prune_session_read_state,
     _publish_codex_approval_mode,
@@ -2403,12 +2403,13 @@ def register_core_routes(
             )
             labels_to_set[_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY] = _confirmed_permission_mode
             # The launcher restores the mode from terminal_launch_args, not the
-            # label above, so reflect the confirmed mode there too — otherwise a
-            # relaunch reverts to the launch --permission-mode. Merge against
-            # ``updated`` (the post-write row), not the pre-update snapshot, so a
-            # combined PATCH that also set terminal_launch_args keeps those. Only
-            # rewrites an existing --permission-mode; mirrors the shift+tab path.
-            _merged_permission_args = _merge_claude_permission_launch_args(
+            # label above, so pin the confirmed mode there too — otherwise a
+            # relaunch reopens in the launch mode, which is Claude's default
+            # (manual) for a session created without --permission-mode. Merge
+            # against ``updated`` (the post-write row), not the pre-update
+            # snapshot, so a combined PATCH that also set terminal_launch_args
+            # keeps those.
+            _merged_permission_args = _pin_claude_permission_launch_args(
                 updated.terminal_launch_args,
                 _confirmed_permission_mode,
             )

--- a/tests/runner/test_app_claude_native_launch_args.py
+++ b/tests/runner/test_app_claude_native_launch_args.py
@@ -165,6 +165,32 @@ def test_build_claude_native_base_args_resume_prefix(
     )
 
 
+def test_build_claude_native_base_args_carries_pinned_permission_mode_into_resume() -> None:
+    """
+    A pinned ``--permission-mode`` reaches the cold-resume argv unchanged.
+
+    The server pins a picker-confirmed mode into ``terminal_launch_args``
+    precisely because this builder is the only thing a relaunch consults;
+    the pass-through must land after ``--resume`` and survive the
+    ``--model`` default so the resumed Claude opens in the chosen mode.
+    """
+    args = _build_claude_native_base_args(
+        reasoning_effort=None,
+        model_override="claude-opus-5",
+        terminal_launch_args=["--permission-mode", "auto"],
+        resume_external_session_id="02857840-6362-408f-b41f-309e396ed7c6",
+    )
+
+    assert args == (
+        "--resume",
+        "02857840-6362-408f-b41f-309e396ed7c6",
+        "--permission-mode",
+        "auto",
+        "--model",
+        "claude-opus-5",
+    )
+
+
 def test_claude_terminal_env_unset_masks_key_with_api_key_helper() -> None:
     """An apiKeyHelper launch strips the raw key + nested-session marker.
 

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -7903,7 +7903,7 @@ async def test_post_external_permission_mode_change_is_quiet_when_unchanged(
 @pytest.mark.parametrize(
     "mode",
     [
-        "bypassPermissions",  # real CLI mode, but not one shift+tab can reach
+        "dontAsk",  # real CLI mode, but never rendered as a pane footer
         "turbo",  # not a mode at all
         "",
     ],
@@ -7931,6 +7931,49 @@ async def test_post_external_permission_mode_change_rejects_unsupported_modes(
 
     assert resp.status_code == 400, resp.text
     assert "external_permission_mode_change" in resp.text
+
+
+async def test_post_external_permission_mode_change_accepts_bypass_read_back(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A pane reporting bypass lands on the label and rewrites the launch arg.
+
+    Bypass is launch-only and stays rejected as a PATCH target, but a session
+    launched into it (or cycled back to it inside the TUI) must read back as
+    bypass, or the picker shows a stale mode and a relaunch reopens in the
+    mode last recorded instead of the one the pane is in.
+    """
+    published: list[tuple[str, dict[str, Any]]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda sid, ev: published.append((sid, ev)),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        terminal_launch_args=["--model", "opus", "--permission-mode", "auto"],
+    )
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={
+            "type": "external_permission_mode_change",
+            "data": {"permission_mode": "bypassPermissions"},
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    assert [event["type"] for _, event in published] == ["session.permission_mode"]
+    assert published[0][1]["permission_mode"] == "bypassPermissions"
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["labels"]["omnigent.claude_native.permission_mode"] == "bypassPermissions"
+    assert snapshot["terminal_launch_args"] == [
+        "--model",
+        "opus",
+        "--permission-mode",
+        "bypassPermissions",
+    ]
 
 
 async def test_in_pane_permission_mode_switch_reaches_the_sse_wire_end_to_end(

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -9878,9 +9878,11 @@ async def test_patch_permission_mode_persists_label_and_forwards_event(
 
     assert resp.status_code == 200, resp.text
     assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == "auto"
-    # No launch --permission-mode to rewrite, so none is fabricated (see the
-    # rewrite-existing test below for the persist-to-launch-args case).
-    assert resp.json()["terminal_launch_args"] is None
+    # The session launched without --permission-mode, so the confirmed switch
+    # is pinned into the launch args: the launcher rebuilds Claude's args from
+    # them alone, and without the flag a cold resume would reopen in Claude's
+    # default (manual) mode while the label still claimed "auto".
+    assert resp.json()["terminal_launch_args"] == ["--permission-mode", "auto"]
     forwards = [f for f in captured if f.url.endswith(f"/v1/sessions/{session['id']}/events")]
     assert len(forwards) == 1, f"Expected one runner forward, got {captured!r}"
     assert forwards[0].body == {"type": "permission_mode_change", "permission_mode": "auto"}
@@ -9945,6 +9947,67 @@ async def test_patch_permission_mode_rewrites_launch_arg_and_keeps_other_args(
         "acceptEdits",
     ]
     assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == "acceptEdits"
+
+
+async def test_patch_permission_mode_pins_launch_arg_once_for_flagless_session(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A confirmed switch on a flag-less session appends --permission-mode once.
+
+    A session created with the default preset carries no ``--permission-mode``;
+    switching it to Auto in the web picker used to land only on the label, so
+    every relaunch after the idle pane reaper or a runner restart reopened it in
+    manual mode. The first PATCH must append the flag after the caller's other
+    args, and a later PATCH must rewrite that flag rather than stack a second.
+    """
+    from omnigent.runtime import set_runner_client
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Confirm whatever mode was requested, like the claude-native runner."""
+        if request.method != "POST":
+            return httpx.Response(204)
+        body = json.loads(request.content) if request.content else {}
+        return httpx.Response(200, json={"permission_mode": body.get("permission_mode")})
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+    set_runner_client(fake_runner)
+    try:
+        agent = await create_test_agent(client)
+        session = await _create_session(
+            client,
+            agent["id"],
+            labels={
+                "omnigent.ui": "terminal",
+                "omnigent.wrapper": "claude-code-native-ui",
+            },
+            terminal_launch_args=["--model", "opus"],
+        )
+        first = await client.patch(
+            f"/v1/sessions/{session['id']}",
+            json={"permission_mode": "auto"},
+        )
+        second = await client.patch(
+            f"/v1/sessions/{session['id']}",
+            json={"permission_mode": "plan"},
+        )
+    finally:
+        await fake_runner.aclose()
+        set_runner_client(None)
+
+    assert first.status_code == 200, first.text
+    assert first.json()["terminal_launch_args"] == ["--model", "opus", "--permission-mode", "auto"]
+    assert second.status_code == 200, second.text
+    assert second.json()["terminal_launch_args"] == [
+        "--model",
+        "opus",
+        "--permission-mode",
+        "plan",
+    ]
+    assert second.json()["labels"]["omnigent.claude_native.permission_mode"] == "plan"
 
 
 @pytest.mark.parametrize("runner_status", [None, 503], ids=["no_runner", "runner_rejects"])

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -7866,6 +7866,31 @@ async def test_post_external_permission_mode_change_rewrites_launch_arg(
     ]
 
 
+async def test_post_external_permission_mode_change_rewrites_standalone_bypass_flag(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    A pane switch away from bypass replaces ``--dangerously-skip-permissions``.
+
+    The standalone flag is the other spelling of a bypass launch, so a TUI
+    shift+tab to another mode must rewrite it like an explicit
+    ``--permission-mode``; otherwise a cold resume silently reopens in bypass.
+    """
+    agent = await create_test_agent(client)
+    session = await _create_session(
+        client,
+        agent["id"],
+        terminal_launch_args=["--dangerously-skip-permissions", "--model", "opus"],
+    )
+    resp = await client.post(
+        f"/v1/sessions/{session['id']}/events",
+        json={"type": "external_permission_mode_change", "data": {"permission_mode": "plan"}},
+    )
+    assert resp.status_code == 202, resp.text
+    snapshot = (await client.get(f"/v1/sessions/{session['id']}")).json()
+    assert snapshot["terminal_launch_args"] == ["--model", "opus", "--permission-mode", "plan"]
+
+
 async def test_post_external_permission_mode_change_is_quiet_when_unchanged(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -10051,6 +10076,54 @@ async def test_patch_permission_mode_pins_launch_arg_once_for_flagless_session(
         "plan",
     ]
     assert second.json()["labels"]["omnigent.claude_native.permission_mode"] == "plan"
+
+
+async def test_patch_permission_mode_replaces_standalone_bypass_flag(
+    client: httpx.AsyncClient,
+) -> None:
+    """
+    Leaving bypass drops ``--dangerously-skip-permissions`` from the launch args.
+
+    Claude treats that standalone flag as ``--permission-mode bypassPermissions``,
+    so keeping it next to the pinned mode would make a cold resume reopen
+    unrestricted while the label claims the restricted mode the user chose.
+    """
+    from omnigent.runtime import set_runner_client
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        """Confirm whatever mode was requested, like the claude-native runner."""
+        if request.method != "POST":
+            return httpx.Response(204)
+        body = json.loads(request.content) if request.content else {}
+        return httpx.Response(200, json={"permission_mode": body.get("permission_mode")})
+
+    fake_runner = httpx.AsyncClient(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://runner",
+    )
+    set_runner_client(fake_runner)
+    try:
+        agent = await create_test_agent(client)
+        session = await _create_session(
+            client,
+            agent["id"],
+            labels={
+                "omnigent.ui": "terminal",
+                "omnigent.wrapper": "claude-code-native-ui",
+            },
+            terminal_launch_args=["--model", "opus", "--dangerously-skip-permissions"],
+        )
+        resp = await client.patch(
+            f"/v1/sessions/{session['id']}",
+            json={"permission_mode": "auto"},
+        )
+    finally:
+        await fake_runner.aclose()
+        set_runner_client(None)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["terminal_launch_args"] == ["--model", "opus", "--permission-mode", "auto"]
+    assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == "auto"
 
 
 @pytest.mark.parametrize("runner_status", [None, 503], ids=["no_runner", "runner_rejects"])

--- a/tests/test_claude_native_bridge.py
+++ b/tests/test_claude_native_bridge.py
@@ -4997,6 +4997,44 @@ def test_set_permission_mode_raises_when_target_not_in_cycle(
         claude_native_bridge.set_permission_mode(bridge_dir, mode="auto", timeout_s=5.0)
 
 
+@pytest.mark.parametrize(
+    ("target", "presses"),
+    [("auto", 1), ("acceptEdits", 3)],
+)
+def test_set_permission_mode_leaves_a_bypass_launched_pane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    target: str,
+    presses: int,
+) -> None:
+    """
+    A session launched into bypass can still be switched to a cycle mode.
+
+    Bypass is launch-only, so it is not a switch target, but the pane's
+    ``bypass permissions on`` footer must still read as the current mode:
+    without that the cycler cannot tell where it is starting from and gives
+    up before pressing anything. From bypass the TUI cycles
+    bypass → auto → manual → accept edits → plan, so ``auto`` is one press
+    away and ``acceptEdits`` three.
+    """
+    bridge_dir = tmp_path / "bridge"
+    write_tmux_target(
+        bridge_dir,
+        socket_path=Path("/tmp/example/tmux.sock"),
+        tmux_target="claude:0.0",
+    )
+    fake = _FakeModeCycleTmux(
+        ["bypassPermissions", "auto", "default", "acceptEdits", "plan"],
+        start="bypassPermissions",
+    )
+    monkeypatch.setattr("subprocess.run", fake.run)
+
+    got = claude_native_bridge.set_permission_mode(bridge_dir, mode=target, timeout_s=5.0)
+
+    assert got == target
+    assert fake.presses == presses, f"Expected {presses} presses, got {fake.presses}."
+
+
 @pytest.mark.parametrize("bad_mode", ["dontAsk", "bypassPermissions", "", "nonsense"])
 def test_set_permission_mode_rejects_non_cycleable_modes(
     tmp_path: Path,


### PR DESCRIPTION
## Related issue

No tracking issue. Diagnosed from the managed fleet's debug logs after a user reported that sessions "fall back onto Manual approval from Auto mode".

## Summary

- A claude-native session created with the default permission preset carries no `--permission-mode` in `terminal_launch_args`. When the user later switches it to Auto in the web picker, the runner drives shift+tab, confirms the mode, and the server records it on the `omnigent.claude_native.permission_mode` label. The launch-arg merge (`_merge_claude_permission_launch_args`) only rewrote an existing flag, so nothing was added.
- The runner rebuilds Claude's args from `terminal_launch_args` alone on every cold resume (`_build_claude_native_base_args`) and never reads the label. So after the 1-hour idle pane reaper, a runner idle-timeout exit, or a host reconnect after a server roll, the session reopened in Claude's default (manual) mode, the forwarder mirrored the `manual mode on` footer back into the label, and the next tool call asked for approval.
- Second fix (same picker): a session created with the **Bypass permissions** preset could not be switched from the web picker at all. The runner's shift+tab cycler reads Claude's mode footer to know its starting point, and the footer map had no entry for `bypass permissions on`, so it failed with "did not render a permission-mode footer" before pressing anything. Bypass is now a readable footer (still not a switch target; from bypass the TUI cycles bypass → auto → manual → accept edits → plan), and the server accepts `bypassPermissions` as a forwarder read-back label while PATCH keeps rejecting it as a target.
- The shared strip step also removes the standalone `--dangerously-skip-permissions` spelling, so leaving bypass never keeps that flag next to the pinned mode (a cold resume would otherwise reopen in bypass under a restricted label). Review follow-up.
- Fix: a new `_pin_claude_permission_launch_args` helper (shares the flag-stripping with the merge helper) sets `--permission-mode <mode>` in the launch args on the PATCH path even when the flag is absent. The forwarder's footer-mirror path is unchanged: a first-poll footer report must not override a settings-file `defaultMode`.

**ELI5:** the picker wrote the choice on a sticky note (the label), but the relaunch only ever reads the recipe card (the launch args). Now a confirmed web switch also updates the recipe card.

```
create (default preset) ── launch args: []           label: —
web picker → Auto        ── launch args: []  (before) label: auto
                            launch args: [--permission-mode auto] (after)
pane reaped / runner idle / host reconnect
cold resume              ── before: claude --resume <id>              → manual mode
                            after:  claude --resume <id> --permission-mode auto → auto
```

Fleet impact over 9/9–9/11 (managed workspace): 3,708 cold-resume relaunches across 1,851 sessions and 253 users; 192 sessions from 76 users showed a permission-mode change within 90 s of a relaunch.

## Test Plan

- User-facing note: an explicit picker switch to Manual now pins `--permission-mode default`, which wins over a settings-file `permissions.defaultMode` on later resumes. That follows the deliberate choice; sessions that never switched keep following their settings file.

- `test_patch_permission_mode_persists_label_and_forwards_event` now asserts the flag is pinned (it previously asserted `terminal_launch_args is None`, which encoded the bug).
- New `test_patch_permission_mode_pins_launch_arg_once_for_flagless_session`: append after the caller's other args on the first PATCH, rewrite (not duplicate) on a second PATCH.
- Both fail on main without the source change (`assert None == ['--permission-mode', 'auto']`, `assert ['--model', 'opus'] == [..., '--permission-mode', 'auto']`) and pass with it.
- Bypass: new `test_set_permission_mode_leaves_a_bypass_launched_pane` (bridge, fails on main with the footer error) and `test_post_external_permission_mode_change_accepts_bypass_read_back` (server); the reject test keeps three cases by swapping `bypassPermissions` for `dontAsk`, which is never rendered as a footer.
- Live rig from this branch (sandboxed server + host, Claude via the gateway): a Manual-created session switched to Auto kept Auto across a killed pane and cold resume; a Bypass-created session was read back as bypass by the forwarder relay (label `bypassPermissions` before any PATCH), switched to Accept edits (previously a 503), and kept it across a relaunch. New route tests cover the standalone `--dangerously-skip-permissions` shape on both the PATCH and the mirror path.
- `pytest tests/server/integration/test_sessions_endpoints.py -n 6`: 286 passed; `tests/test_claude_native_bridge.py`: 372 passed. `pre-commit` clean on the touched files.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Observed on a live rig built from this branch (server + host, Claude through the gateway):

```
Manual-created session:  footer "manual mode on" → PATCH auto → launch args [--permission-mode auto],
                         footer "auto mode on" → pane killed → cold resume → footer "⏵⏵ auto mode on"
Bypass-created session:  label read back "bypassPermissions" (forwarder relay) → PATCH acceptEdits (was 503) →
                         launch args [--permission-mode acceptEdits], footer "accept edits on" → relaunch → same
```

Manual check after deploy: create a claude-native session with the default permission preset, switch it to Auto in the picker, wait for the idle pane reaper (or restart the runner), send a message, and confirm the picker still shows Auto and the first tool call does not prompt.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The route tests exercise the real PATCH path with a fake runner confirming the switch; the relaunch consumer (`_build_claude_native_base_args`) already has coverage for pass-through launch args.

## Changelog

A Claude Code session switched to Auto (or any other permission mode) in the web picker keeps that mode after its terminal is relaunched, and a session started in Bypass permissions can now be switched from the picker.
