### PR TITLE
fix(codex): replay dead letters before resume snapshot

### DIFF
--- a/omnigent/harnesses/codex_native/forwarder.py
+++ b/omnigent/harnesses/codex_native/forwarder.py
@@ -2061,11 +2061,6 @@ async def supervise_forwarder(
         timeout=httpx.Timeout(30.0),
         transport=ap_transport,
     ) as ap_client:
-        # Recover proven-undelivered dead-lettered forwards now that the
-        # server may be reachable again (host/server returned after an
-        # outage or restart). Runs before live forwarding begins, so no
-        # other writer races the dead-letter files (#1579).
-        await _replay_dead_letters_on_startup(ap_client, bridge_dir)
         # Synthesize the thread's MCP startup round (see the comment on
         # _CODEX_MCP_STARTUP_STATUS_METHOD): the fresh-launch forwarder
         # starts right at thread creation, which is when codex boots its
@@ -7093,19 +7088,21 @@ def _note_forward_failure(event_type: str) -> None:
         _forward_health.degraded_logged = True
 
 
-async def _replay_dead_letters_on_startup(
+async def _replay_dead_letters_before_resume(
     ap_client: httpx.AsyncClient,
     bridge_dir: Path,
 ) -> None:
     """
-    Re-POST proven-undelivered dead-lettered forwards on forwarder startup (#1579).
+    Re-POST proven-undelivered dead letters before rebuilding a resume rollout.
 
-    Best-effort recovery for the realistic case — the host/server returned after
-    an outage or a restart. Delegates to the shared
+    Best-effort recovery for the realistic case where the host/server returned
+    after an outage or restart. Running before the authoritative server-history
+    fetch ensures successfully replayed items are included in the rebuilt local
+    rollout. Delegates to the shared
     :func:`replay_dead_letters` drain, supplying a re-POST that routes each
     record to its recorded session via :func:`_post_session_event_inner` (the
     inner so a re-failure does not double dead-letter through the wrapper).
-    Never raises: a replay failure must not block live forwarding.
+    Never raises: a replay failure must not block resume.
 
     :param ap_client: HTTP client for Omnigent event posts.
     :param bridge_dir: Native Codex bridge directory holding the dead-letter files.
@@ -7150,8 +7147,8 @@ async def _replay_dead_letters_on_startup(
             max_records=_REPLAY_MAX_RECORDS,
             deadline_seconds=_REPLAY_DEADLINE_SECONDS,
         )
-    except Exception:  # noqa: BLE001 - replay must never block forwarder startup.
-        _logger.warning("Codex forwarder dead-letter replay failed", exc_info=True)
+    except Exception:  # noqa: BLE001 - replay must never block resume.
+        _logger.warning("Codex dead-letter replay before resume failed", exc_info=True)
 
 
 @dataclass(frozen=True)
@@ -7265,11 +7262,11 @@ async def _post_session_event_inner(
     :param max_attempts: Maximum POST attempts before giving up, e.g. ``3``;
         ``None`` retries transient failures indefinitely and requires an
         idempotent event payload.
-        Startup dead-letter replay passes ``1`` — its natural retry cadence is
-        the next startup, so an in-call retry loop only adds latency (#1579).
+        Cold-resume dead-letter replay passes ``1`` — its natural retry cadence
+        is the next resume, so an in-call retry loop only adds latency (#1579).
     :param timeout: Optional per-request timeout in seconds overriding the
         client default, e.g. ``5.0``. Replay passes a short value so a hung
-        server fails fast instead of stalling startup on the 30s client default.
+        server fails fast instead of stalling resume on the 30s client default.
     :returns: A :class:`_PostResult` carrying the final response, or — for a
         legacy conversation item without ``source_id`` — whether the POST was
         abandoned after an ambiguous transport failure versus a proven-

--- a/omnigent/harnesses/codex_native/main.py
+++ b/omnigent/harnesses/codex_native/main.py
@@ -67,7 +67,10 @@ from omnigent.harnesses.codex_native.bridge import (
     socket_path_for_bridge_dir,
     write_bridge_state,
 )
-from omnigent.harnesses.codex_native.forwarder import supervise_forwarder
+from omnigent.harnesses.codex_native.forwarder import (
+    _replay_dead_letters_before_resume,
+    supervise_forwarder,
+)
 from omnigent.harnesses.codex_native.state import read_launch_state, write_launch_state
 from omnigent.host.daemon_launch import (
     error_text,
@@ -1904,9 +1907,11 @@ async def _ensure_local_codex_resume_rollout(
     ``resume <thread>`` reads that local rollout, so before launching a
     known-thread terminal we rewrite it from committed Omnigent items. This
     keeps the server transcript authoritative when a previous local rollout
-    has diverged. If server history is temporarily unavailable, a valid local
-    rollout remains a best-effort fallback. A successful server fetch wins
-    even when its committed history is empty or shorter than the local file;
+    has diverged. Before fetching that transcript, we best-effort replay any
+    proven-undelivered dead letters so successful recovery is reflected in the
+    same snapshot. If server history is temporarily unavailable, a valid local
+    rollout remains a best-effort fallback. A successful server fetch wins even
+    when its committed history is empty or shorter than the local file;
     local-only records are intentionally discarded.
 
     :param client: HTTP client pointed at the Omnigent server.
@@ -1941,6 +1946,7 @@ async def _ensure_local_codex_resume_rollout(
             f"Cannot resume Codex session {session_id!r}: persisted thread id "
             f"{external_session_id!r} is not a safe Codex rollout id."
         )
+    await _replay_dead_letters_before_resume(client, codex_home.parent)
     try:
         items = await _fetch_all_session_items_for_codex_resume(client, session_id)
     except _CodexResumeHistoryUnavailableError:

--- a/tests/test_codex_native.py
+++ b/tests/test_codex_native.py
@@ -1921,16 +1921,31 @@ def test_wait_for_thread_started_times_out_when_no_thread_event() -> None:
         )
 
 
-def test_supervise_forwarder_subscribes_existing_client_after_thread_discovery(
+def test_supervise_forwarder_subscribes_without_replaying_dead_letters(
     tmp_path: Path,
 ) -> None:
     """
     Fresh Codex sessions pass the listener used to discover
     ``thread/started``. Once the thread id is known, the forwarder
     subscribes that connection so TUI-originated turn/item events are
-    mirrored into the web session.
+    mirrored into the web session. Dead-letter recovery belongs to cold-resume
+    rollout reconstruction, so starting the live forwarder must not replay it
+    again after that snapshot has already been built.
     """
     fake_client = _FakeCodexAppServerClient()
+    codex_native_forwarder.append_dead_letter(
+        tmp_path,
+        session_id="conv_123",
+        event_type="external_conversation_item",
+        payload={"item_type": "message"},
+        reason="http 503",
+        http_status=503,
+    )
+    ap_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        ap_requests.append(request)
+        return httpx.Response(200)
 
     async def run() -> None:
         """
@@ -1946,6 +1961,7 @@ def test_supervise_forwarder_subscribes_existing_client_after_thread_discovery(
             app_server_url=str(tmp_path / "app-server.sock"),
             thread_id="thread_123",
             client=fake_client,  # type: ignore[arg-type]
+            ap_transport=httpx.MockTransport(handler),
         )
 
     asyncio.run(run())
@@ -1954,6 +1970,8 @@ def test_supervise_forwarder_subscribes_existing_client_after_thread_discovery(
         ("thread/resume", {"threadId": "thread_123", "excludeTurns": True})
     ]
     assert fake_client.closed
+    assert ap_requests == []
+    assert (tmp_path / "dead_letter.jsonl").exists()
 
 
 def test_supervise_forwarder_resumes_when_it_opens_client(
@@ -10995,6 +11013,72 @@ def test_clone_codex_rollout_returns_none_for_unsafe_target_id(
     )
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_local_codex_resume_rollout_replays_before_history_fetch(
+    tmp_path: Path,
+) -> None:
+    """A successful dead-letter replay is included in the rebuilt snapshot."""
+    thread_id = "019e96aa-0be2-7343-8d3b-6f914d60936b"
+    codex_home = tmp_path / "codex-home"
+    replay_data = {
+        "item_type": "message",
+        "item_data": {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "recovered reply"}],
+        },
+        "response_id": "turn_recovered",
+        "source_id": "codex:item:recovered",
+    }
+    codex_native_forwarder.append_dead_letter(
+        tmp_path,
+        session_id="conv_codex",
+        event_type="external_conversation_item",
+        payload=replay_data,
+        reason="http 503",
+        http_status=503,
+    )
+    request_order: list[str] = []
+    server_items: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        request_order.append(request.method)
+        if request.method == "POST":
+            body = json.loads(request.content)
+            assert body == {"type": "external_conversation_item", "data": replay_data}
+            server_items.append(
+                {
+                    "id": "msg_recovered",
+                    "response_id": replay_data["response_id"],
+                    "type": "message",
+                    **replay_data["item_data"],
+                }
+            )
+            return httpx.Response(200)
+        assert request.url.path == "/v1/sessions/conv_codex/items"
+        return httpx.Response(200, json={"data": server_items, "has_more": False})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handler), base_url="http://test"
+    ) as client:
+        rollout = await codex_native._ensure_local_codex_resume_rollout(
+            client,
+            session_id="conv_codex",
+            external_session_id=thread_id,
+            codex_home=codex_home,
+            workspace=tmp_path.resolve(),
+            model_provider="omnigent_databricks",
+            codex_path=None,
+        )
+
+    records = [json.loads(line) for line in rollout.read_text().splitlines()]
+    assert request_order == ["POST", "GET"]
+    assert not (tmp_path / "dead_letter.jsonl").exists()
+    assert any(
+        record["type"] == "response_item" and record["payload"].get("id") == "msg_recovered"
+        for record in records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_native_forwarder.py
+++ b/tests/test_codex_native_forwarder.py
@@ -2787,11 +2787,11 @@ async def test_post_session_event_dead_letters_records_http_status(
 
 
 @pytest.mark.asyncio
-async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
+async def test_replay_dead_letters_before_resume_reposts_proven_undelivered(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    On startup, a proven-undelivered record is re-POSTed and removed (#1579).
+    Before resume, a proven-undelivered record is re-POSTed and removed (#1579).
 
     :param tmp_path: Pytest temp dir standing in for the bridge dir.
     :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
@@ -2824,7 +2824,7 @@ async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
         )
 
     monkeypatch.setattr(fwd, "_post_session_event_inner", _ok_inner)
-    await fwd._replay_dead_letters_on_startup(MagicMock(), tmp_path)
+    await fwd._replay_dead_letters_before_resume(MagicMock(), tmp_path)
 
     assert len(posted) == 1
     assert posted[0]["session_id"] == "conv_codex1"
@@ -2839,11 +2839,11 @@ async def test_replay_dead_letters_on_startup_reposts_proven_undelivered(
 
 
 @pytest.mark.asyncio
-async def test_replay_dead_letters_on_startup_skips_ambiguous(
+async def test_replay_dead_letters_before_resume_skips_ambiguous(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """
-    On startup, an ambiguous record is never re-POSTed and is retained (#1579).
+    Before resume, an ambiguous record is never re-POSTed and is retained (#1579).
 
     :param tmp_path: Pytest temp dir standing in for the bridge dir.
     :param monkeypatch: Pytest patcher (auto-restores the stubbed inner).
@@ -2867,7 +2867,7 @@ async def test_replay_dead_letters_on_startup_skips_ambiguous(
         )
 
     monkeypatch.setattr(fwd, "_post_session_event_inner", _inner)
-    await fwd._replay_dead_letters_on_startup(MagicMock(), tmp_path)
+    await fwd._replay_dead_letters_before_resume(MagicMock(), tmp_path)
 
     assert called is False
     # Ambiguous record retained as a forensic record.


### PR DESCRIPTION
## Related issue

Tracks [OMNI-7360](https://linear.app/omnigent/issue/OMNI-7360/codex-server-transcript-dead-letter-should-happen-before-resume).

## Summary

Codex cold resume rebuilt its local rollout from the server transcript, then replayed dead letters when the live forwarder started. If replay succeeded, the server gained recovered items after the local snapshot had already been written, immediately putting the TUI and web UI out of sync.

This PR makes one focused scheduling change:

- Run the existing bounded, best-effort dead-letter replay immediately before fetching server history for rollout reconstruction.
- Remove replay from `supervise_forwarder`, preventing a second attempt after the snapshot is built.
- Keep replay eligibility, deadlines, retention-on-failure, and live completed-item forwarding unchanged.

**ELI5:** We previously photographed the server transcript and then restored missing messages, so Codex opened the old photo. We now restore first and photograph second.

```text
Before: fetch history -> rebuild local rollout -> replay -> server/local can differ
After:  replay -> fetch history -> rebuild local rollout -> start live forwarder
```

## Test Plan

- `uv run --frozen pytest -q tests/test_codex_native_forwarder.py tests/test_codex_native.py` — 445 passed.
- `uv run --frozen pre-commit run --files omnigent/harnesses/codex_native/forwarder.py omnigent/harnesses/codex_native/main.py tests/test_codex_native.py tests/test_codex_native_forwarder.py` — passed.
- Added coverage proving successful replay happens before the server-history fetch and appears in the rebuilt rollout.
- Added coverage proving live forwarder startup does not perform a second replay.
- Existing replay tests continue to cover successful removal and retention of ineligible records.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The tests exercise the real replay and rollout-rebuild path through a mock HTTP transport, including request ordering and the resulting rollout contents.

## Changelog

Codex cold resume now includes successfully recovered transcript items in the rebuilt local session.
