### PR TITLE
fix(web): make native model rate-limit errors retryable

### DIFF
--- a/omnigent/runner/launch_failure.py
+++ b/omnigent/runner/launch_failure.py
@@ -15,6 +15,7 @@ covers them all. A new harness quirk becomes one entry in
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -22,6 +23,7 @@ from omnigent.cli_invocation import cli_invocation
 
 __all__ = [
     "FailureDiagnosis",
+    "classify_native_turn_error",
     "classify_terminal_failure",
     "describe_failure_code",
 ]
@@ -173,6 +175,43 @@ def classify_terminal_failure(
     return None
 
 
+_RATE_LIMIT_ERROR = re.compile(
+    r"\b(?:rate[ _-]limit[ _-](?:error|exceeded|reached)|request_limit_exceeded"
+    r"|too many requests)\b",
+    re.IGNORECASE,
+)
+_NATIVE_ERROR_HTTP_STATUS = re.compile(
+    r"\b(?:http(?:/\d(?:\.\d)?)?|status(?:[ _]code)?|api error|request rejected)"
+    r"\s*[:=(]?\s*(\d{3})\b",
+    re.IGNORECASE,
+)
+_PERMANENT_QUOTA_MARKERS = (
+    "insufficient_quota",
+    "billing_hard_limit_reached",
+    "credit balance is too low",
+)
+
+
+def classify_native_turn_error(code: str, message: str) -> str:
+    """Refine a native turn's generic code when its text identifies a rate limit.
+
+    :param code: Existing error code; specific diagnoses are preserved.
+    :param message: Native harness error text, from its status or transcript.
+    :returns: The semantic rate-limit code, or the existing code if unrecognized.
+    """
+    if code not in {"native_turn_error", "codex_turn_error"}:
+        return code
+    status_match = _NATIVE_ERROR_HTTP_STATUS.search(message)
+    status = status_match.group(1) if status_match else None
+    if status in {"401", "403"}:
+        return code
+    if any(marker in message.lower() for marker in _PERMANENT_QUOTA_MARKERS):
+        return code
+    if status == "429" or _RATE_LIMIT_ERROR.search(message):
+        return "rate_limit_exceeded"
+    return code
+
+
 # --- failure-code English fallbacks -------------------------------------------
 # Every server-emitted failure code, mapped to a one-line human sentence, so
 # even an unclassified failure reads as English instead of a raw enum. Terminal
@@ -198,6 +237,7 @@ _FAILURE_CODE_DESCRIPTIONS: dict[str, str] = {
     ),
     "codex_turn_error": "Codex ran into an error during this turn.",
     "native_turn_error": "The agent ran into an error during this turn.",
+    "rate_limit_exceeded": "The model's rate limit was reached. Wait a moment, then retry.",
 }
 
 

--- a/omnigent/runner/launch_failure.py
+++ b/omnigent/runner/launch_failure.py
@@ -185,11 +185,6 @@ _NATIVE_ERROR_HTTP_STATUS = re.compile(
     r"\s*[:=(]?\s*(\d{3})\b",
     re.IGNORECASE,
 )
-_PERMANENT_QUOTA_MARKERS = (
-    "insufficient_quota",
-    "billing_hard_limit_reached",
-    "credit balance is too low",
-)
 
 
 def classify_native_turn_error(code: str, message: str) -> str:
@@ -204,8 +199,6 @@ def classify_native_turn_error(code: str, message: str) -> str:
     status_match = _NATIVE_ERROR_HTTP_STATUS.search(message)
     status = status_match.group(1) if status_match else None
     if status in {"401", "403"}:
-        return code
-    if any(marker in message.lower() for marker in _PERMANENT_QUOTA_MARKERS):
         return code
     if status == "429" or _RATE_LIMIT_ERROR.search(message):
         return "rate_limit_exceeded"
@@ -237,7 +230,7 @@ _FAILURE_CODE_DESCRIPTIONS: dict[str, str] = {
     ),
     "codex_turn_error": "Codex ran into an error during this turn.",
     "native_turn_error": "The agent ran into an error during this turn.",
-    "rate_limit_exceeded": "The model's rate limit was reached. Wait a moment, then retry.",
+    "rate_limit_exceeded": "The model's rate limit was reached. You can retry this turn.",
 }
 
 

--- a/omnigent/runner/launch_failure.py
+++ b/omnigent/runner/launch_failure.py
@@ -177,7 +177,7 @@ def classify_terminal_failure(
 
 _RATE_LIMIT_ERROR = re.compile(
     r"\b(?:rate[ _-]limit[ _-](?:error|exceeded|reached)|request_limit_exceeded"
-    r"|too many requests)\b",
+    r"|rate[ _-]limited|too many requests)\b",
     re.IGNORECASE,
 )
 _NATIVE_ERROR_HTTP_STATUS = re.compile(

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -71,6 +71,7 @@ from omnigent.policies.types import EvaluationContext
 from omnigent.runner.identity import (
     token_bound_runner_id,
 )
+from omnigent.runner.launch_failure import classify_native_turn_error
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runner.subagent_routing import ROUTING_DECISION_LABEL_KEY
 from omnigent.runner.transports.ws_tunnel.registry import TunnelRegistry
@@ -4679,7 +4680,7 @@ def _last_task_error_from_labels(labels: Mapping[str, str]) -> dict[str, str] | 
     raw_error_message = labels.get(_LAST_TASK_ERROR_MESSAGE_LABEL_KEY)
     if raw_error_code and raw_error_message:
         error: dict[str, str] = {
-            "code": raw_error_code,
+            "code": classify_native_turn_error(raw_error_code, raw_error_message),
             "message": raw_error_message,
         }
         for key, label in (

--- a/omnigent/server/routes/sessions/routes_events.py
+++ b/omnigent/server/routes/sessions/routes_events.py
@@ -40,6 +40,7 @@ from omnigent.host.frames import (
     workspace_missing_message as _workspace_missing_message,
 )
 from omnigent.runner.identity import RUNNER_TUNNEL_TOKEN_HEADER, token_bound_runner_id
+from omnigent.runner.launch_failure import classify_native_turn_error
 from omnigent.runner.routing import RunnerRouter
 from omnigent.runtime import (
     session_stream,
@@ -1432,16 +1433,16 @@ def register_events_routes(
             output = data.get("output")
             status_error: ErrorDetail | None = None
             if status == "failed" and isinstance(output, str) and output.strip():
+                if data.get("reauth_required") is True:
+                    error_code = "codex_reauth_required"
+                else:
+                    # Store-enriched failures are harness-neutral; wire output
+                    # retains the Codex fallback unless a rate limit is known.
+                    error_code = (
+                        "codex_turn_error" if body.data.get("output") else "native_turn_error"
+                    )
                 status_error = ErrorDetail(
-                    code=(
-                        "codex_reauth_required"
-                        if data.get("reauth_required") is True
-                        # The store-enriched detail keeps a harness-neutral
-                        # code; a forwarder-sent detail keeps codex's.
-                        else (
-                            "codex_turn_error" if body.data.get("output") else "native_turn_error"
-                        )
-                    ),
+                    code=classify_native_turn_error(error_code, output),
                     message=output.strip(),
                 )
             if status_error is not None:

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -16,6 +16,8 @@ independent of any live turn.
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 
 import httpx
 import pytest
@@ -192,6 +194,94 @@ def test_live_native_failure_status_surfaces_each_turn(
     second_pill = pills.nth(1)
     second_pill.locator('button[aria-expanded="false"]').click()
     expect(second_pill.get_by_test_id("error-message-content")).to_contain_text(message)
+
+
+@pytest.mark.parametrize("status_includes_output", [False, True], ids=["stored", "forwarded"])
+def test_databricks_rate_limit_is_retryable_live_and_after_reload(
+    page: Page,
+    seeded_session: tuple[str, str],
+    status_includes_output: bool,
+) -> None:
+    """A native 429 keeps its Retry action after reloading the failed turn."""
+    base_url, session_id = seeded_session
+    prompt = "Which parts are missing from this today?"
+    response_id = "native_turn_rate_limit"
+    message = (
+        "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded "
+        "workspace input tokens per minute rate limit for databricks-test-model. "
+        "Work with your Databricks account team to request a higher FMAPI rate limit tier."
+    )
+    seed_committed_turn(session_id, prompt=prompt, reply=message, response_id=response_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    composer = page.get_by_role("textbox", name="Message the agent")
+    expect(composer).to_be_visible(timeout=15_000)
+
+    _publish_native_status(base_url, session_id, "running", response_id=response_id)
+    _publish_native_status(
+        base_url,
+        session_id,
+        "failed",
+        response_id=response_id,
+        output=message if status_includes_output else None,
+    )
+    pill = page.get_by_test_id("error-pill")
+    headline = "The model's rate limit was reached. Wait a moment, then retry."
+    expect(pill).to_contain_text(headline, timeout=15_000)
+    expect(pill.get_by_role("button", name="Retry", exact=True)).to_be_visible()
+    pill.get_by_role("button", name=headline, exact=False).click()
+    expect(pill.get_by_test_id("error-message-content")).to_contain_text(message)
+
+    page.reload()
+    expect(pill).to_contain_text(headline, timeout=15_000)
+    expect(pill.get_by_role("button", name="Retry", exact=True)).to_be_visible()
+
+    if screenshot_dir := os.environ.get("E2E_SCREENSHOT_DIR"):
+        Path(screenshot_dir).mkdir(parents=True, exist_ok=True)
+        suffix = "forwarded" if status_includes_output else "stored"
+        page.screenshot(path=str(Path(screenshot_dir) / f"rate-limit-retry-{suffix}.png"))
+
+    retry_payloads: list[dict[str, object]] = []
+
+    def _continue_turn(route: Route) -> None:
+        payload = route.request.post_data_json
+        if not isinstance(payload, dict) or payload.get("type") not in {
+            "message",
+            "retry_session",
+        }:
+            route.continue_()
+            return
+        retry_payloads.append(payload)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"queued": True}),
+        )
+
+    page.route(f"**/v1/sessions/{session_id}/events", _continue_turn)
+    composer.fill("Keep this unsent draft.")
+    pill.get_by_role("button", name="Retry", exact=True).click()
+    expect(pill).to_have_count(0)
+    assert retry_payloads == [
+        {
+            "type": "message",
+            "data": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "Please continue from where you left off before the rate limit error."
+                        ),
+                    }
+                ],
+            },
+        }
+    ]
+    expect(composer).to_have_value("Keep this unsent draft.")
+    expect(
+        page.locator('[data-testid="message-bubble"][data-role="user"]').filter(has_text=prompt)
+    ).to_have_count(1)
 
 
 def test_failed_turn_surfaces_error_as_pill_not_raw_text(

--- a/tests/e2e_ui/chat/test_failure_error_card.py
+++ b/tests/e2e_ui/chat/test_failure_error_card.py
@@ -226,7 +226,7 @@ def test_databricks_rate_limit_is_retryable_live_and_after_reload(
         output=message if status_includes_output else None,
     )
     pill = page.get_by_test_id("error-pill")
-    headline = "The model's rate limit was reached. Wait a moment, then retry."
+    headline = "The model's rate limit was reached. You can retry this turn."
     expect(pill).to_contain_text(headline, timeout=15_000)
     expect(pill.get_by_role("button", name="Retry", exact=True)).to_be_visible()
     pill.get_by_role("button", name=headline, exact=False).click()

--- a/tests/runner/test_launch_failure.py
+++ b/tests/runner/test_launch_failure.py
@@ -115,14 +115,20 @@ def test_command_path_is_matched_by_basename() -> None:
 @pytest.mark.parametrize(
     "message",
     [
-        "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded "
-        "workspace input tokens per minute rate limit for databricks-test-model. "
-        "Work with your Databricks account team to request a higher FMAPI rate limit tier.",
+        (
+            "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded "
+            "workspace input tokens per minute rate limit for databricks-test-model. "
+            "Work with your Databricks account team to request a higher FMAPI rate limit tier."
+        ),
         "API Error: Request rejected (429)",
         'API Error: 429 {"error": {"type": "rate_limit_error"}}',
         "REQUEST_LIMIT_EXCEEDED: request throttled",
         "Rate limit exceeded",
         "rate-limit reached for this model",
+        "rate limited",
+        "Rate limited",
+        "rate-limited",
+        "rate_limited",
         "HTTP 429",
         "HTTP/1.1 429",
         "status_code: 429",
@@ -142,8 +148,10 @@ def test_classifies_native_429_and_rate_limit_errors(code: str, message: str) ->
         "An unexpected error occurred",
         "API Error: Request rejected (401) · UNAUTHENTICATED",
         "API Error: Request rejected (403) · PERMISSION_DENIED",
-        "API Error: Request rejected (403) · PERMISSION_DENIED: "
-        "See rate_limit_error troubleshooting",
+        (
+            "API Error: Request rejected (403) · PERMISSION_DENIED: "
+            "See rate_limit_error troubleshooting"
+        ),
         "API Error: 401 Unauthorized. Previous request: rate limit exceeded.",
         "HTTP/1.1 403: See rate_limit_exceeded troubleshooting",
         "There's an issue with the selected model. It may not exist.",

--- a/tests/runner/test_launch_failure.py
+++ b/tests/runner/test_launch_failure.py
@@ -6,6 +6,7 @@ import pytest
 
 from omnigent.runner.launch_failure import (
     FailureDiagnosis,
+    classify_native_turn_error,
     classify_terminal_failure,
     describe_failure_code,
 )
@@ -110,6 +111,56 @@ def test_command_path_is_matched_by_basename() -> None:
     assert isinstance(diagnosis, FailureDiagnosis)
 
 
+@pytest.mark.parametrize("code", ["native_turn_error", "codex_turn_error"])
+@pytest.mark.parametrize(
+    "message",
+    [
+        "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded "
+        "workspace input tokens per minute rate limit for databricks-test-model. "
+        "Work with your Databricks account team to request a higher FMAPI rate limit tier.",
+        "API Error: Request rejected (429)",
+        'API Error: 429 {"error": {"type": "rate_limit_error"}}',
+        "REQUEST_LIMIT_EXCEEDED: request throttled",
+        "Rate limit exceeded",
+        "rate-limit reached for this model",
+        "HTTP 429",
+        "HTTP/1.1 429",
+        "status_code: 429",
+        "Too Many Requests",
+    ],
+)
+def test_classifies_native_rate_limit_errors(code: str, message: str) -> None:
+    assert classify_native_turn_error(code, message) == "rate_limit_exceeded"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "An unexpected error occurred",
+        "API Error: Request rejected (401) · UNAUTHENTICATED",
+        "API Error: Request rejected (403) · PERMISSION_DENIED",
+        "API Error: Request rejected (403) · PERMISSION_DENIED: "
+        "See rate_limit_error troubleshooting",
+        "API Error: 401 Unauthorized. Previous request: rate limit exceeded.",
+        "HTTP/1.1 403: See rate_limit_exceeded troubleshooting",
+        "There's an issue with the selected model. It may not exist.",
+        "You've hit your usage limit.",
+        'API Error: 429 {"error": {"code": "insufficient_quota"}}',
+        "HTTP 429: billing_hard_limit_reached",
+        "API Error: 429: Your credit balance is too low to access the API.",
+        "Error loading model-429",
+        "Request rejected (4290)",
+    ],
+)
+def test_preserves_unrecognized_and_permanent_native_turn_errors(message: str) -> None:
+    assert classify_native_turn_error("native_turn_error", message) == "native_turn_error"
+
+
+@pytest.mark.parametrize("code", ["codex_reauth_required", "workspace_missing", "invalid_input"])
+def test_rate_limit_text_does_not_override_specific_failure_codes(code: str) -> None:
+    assert classify_native_turn_error(code, "HTTP 429: rate limit exceeded") == code
+
+
 @pytest.mark.parametrize(
     ("code", "expected_substring"),
     [
@@ -119,6 +170,7 @@ def test_command_path_is_matched_by_basename() -> None:
         ("runner_disconnected", "host dropped"),
         ("connection_error", "connection"),
         ("context_length_exceeded", "context window"),
+        ("rate_limit_exceeded", "Wait a moment, then retry"),
     ],
 )
 def test_describe_failure_code_known(code: str, expected_substring: str) -> None:

--- a/tests/runner/test_launch_failure.py
+++ b/tests/runner/test_launch_failure.py
@@ -127,9 +127,12 @@ def test_command_path_is_matched_by_basename() -> None:
         "HTTP/1.1 429",
         "status_code: 429",
         "Too Many Requests",
+        'API Error: 429 {"error": {"code": "insufficient_quota"}}',
+        "HTTP 429: billing_hard_limit_reached",
+        "API Error: 429: Your credit balance is too low to access the API.",
     ],
 )
-def test_classifies_native_rate_limit_errors(code: str, message: str) -> None:
+def test_classifies_native_429_and_rate_limit_errors(code: str, message: str) -> None:
     assert classify_native_turn_error(code, message) == "rate_limit_exceeded"
 
 
@@ -145,14 +148,11 @@ def test_classifies_native_rate_limit_errors(code: str, message: str) -> None:
         "HTTP/1.1 403: See rate_limit_exceeded troubleshooting",
         "There's an issue with the selected model. It may not exist.",
         "You've hit your usage limit.",
-        'API Error: 429 {"error": {"code": "insufficient_quota"}}',
-        "HTTP 429: billing_hard_limit_reached",
-        "API Error: 429: Your credit balance is too low to access the API.",
         "Error loading model-429",
         "Request rejected (4290)",
     ],
 )
-def test_preserves_unrecognized_and_permanent_native_turn_errors(message: str) -> None:
+def test_preserves_other_native_turn_errors(message: str) -> None:
     assert classify_native_turn_error("native_turn_error", message) == "native_turn_error"
 
 
@@ -170,7 +170,7 @@ def test_rate_limit_text_does_not_override_specific_failure_codes(code: str) -> 
         ("runner_disconnected", "host dropped"),
         ("connection_error", "connection"),
         ("context_length_exceeded", "context window"),
-        ("rate_limit_exceeded", "Wait a moment, then retry"),
+        ("rate_limit_exceeded", "You can retry this turn"),
     ],
 )
 def test_describe_failure_code_known(code: str, expected_substring: str) -> None:

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -4995,6 +4995,66 @@ async def test_post_external_session_status_failed_keeps_wire_output_and_codex_c
     assert error["message"] == "You've hit your usage limit."
 
 
+@pytest.mark.parametrize("wire_output", [False, True])
+async def test_native_rate_limit_failure_is_classified_live_and_after_reload(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    wire_output: bool,
+) -> None:
+    """Native 429 reports retain a retryable code on the stream and snapshot."""
+    detail = (
+        "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded "
+        "workspace input tokens per minute rate limit for databricks-test-model. "
+        "Work with your Databricks account team to request a higher FMAPI rate limit tier."
+    )
+    published: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "omnigent.server.routes.sessions.session_stream.publish",
+        lambda _session_id, event: published.append(event),
+    )
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    session_id = session["id"]
+    response_id = "resp_native_rate_limit"
+    item_resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={
+            "type": "external_conversation_item",
+            "data": {
+                "item_type": "message",
+                "response_id": response_id,
+                "source_id": "src_native_rate_limit",
+                "item_data": {
+                    "role": "assistant",
+                    "agent": "claude-native-ui",
+                    "content": [{"type": "output_text", "text": detail}],
+                },
+            },
+        },
+    )
+    assert item_resp.status_code == 202, item_resp.text
+
+    data: dict[str, Any] = {"status": "failed", "response_id": response_id}
+    if wire_output:
+        data["output"] = detail
+    status_resp = await client.post(
+        f"/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+    )
+    assert status_resp.status_code == 202, status_resp.text
+    failed_events = [event for event in published if event.get("status") == "failed"]
+    assert len(failed_events) == 1
+    expected = {"code": "rate_limit_exceeded", "message": detail}
+    error = failed_events[0]["error"]
+    assert error is not None
+    assert error["code"] == expected["code"]
+    assert error["message"] == expected["message"]
+
+    snapshot_resp = await client.get(f"/v1/sessions/{session_id}")
+    assert snapshot_resp.status_code == 200, snapshot_resp.text
+    assert snapshot_resp.json()["last_task_error"] == expected
+
+
 async def test_post_external_session_status_propagates_runner_delivery_failure(
     client: httpx.AsyncClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -562,6 +562,44 @@ async def test_session_snapshot_surfaces_status_error_labels_as_last_task_error(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stored_code", "expected_code"),
+    [
+        ("native_turn_error", "rate_limit_exceeded"),
+        ("codex_turn_error", "rate_limit_exceeded"),
+        ("codex_reauth_required", "codex_reauth_required"),
+    ],
+)
+async def test_session_snapshot_classifies_preexisting_native_rate_limit_errors(
+    stored_code: str,
+    expected_code: str,
+) -> None:
+    """Failures saved without a rate-limit code become retryable on reload."""
+    session_id = "319c3d34a4ab4e6d983872bf898a19b4"
+    message = "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED"
+    conv = Conversation(
+        id=session_id,
+        created_at=1,
+        updated_at=1,
+        root_conversation_id=session_id,
+        agent_id="087b7cb7ac30abf4debfaa578d052ec6",
+        labels={
+            "omnigent.last_task_error_code": stored_code,
+            "omnigent.last_task_error_message": message,
+        },
+    )
+    conv_store = _ConversationStore(
+        [_message_item("item_rate_limit", message)],
+        conversations={session_id: conv},
+    )
+
+    snapshot = await _get_session_snapshot(conv_store, session_id)  # type: ignore[arg-type]
+
+    assert snapshot.last_task_error == {"code": expected_code, "message": message}
+    assert conv.labels["omnigent.last_task_error_code"] == stored_code
+
+
+@pytest.mark.asyncio
 async def test_session_snapshot_no_exit_report_stays_unfailed() -> None:
     """A session whose runner has no exit report is not marked failed.
 

--- a/tests/server/routes/test_sessions_snapshot.py
+++ b/tests/server/routes/test_sessions_snapshot.py
@@ -563,6 +563,15 @@ async def test_session_snapshot_surfaces_status_error_labels_as_last_task_error(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "message",
+    [
+        "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED",
+        'API Error: 429 {"error": {"code": "insufficient_quota"}}',
+        "HTTP 429: billing_hard_limit_reached",
+        "API Error: 429: Your credit balance is too low to access the API.",
+    ],
+)
+@pytest.mark.parametrize(
     ("stored_code", "expected_code"),
     [
         ("native_turn_error", "rate_limit_exceeded"),
@@ -571,12 +580,12 @@ async def test_session_snapshot_surfaces_status_error_labels_as_last_task_error(
     ],
 )
 async def test_session_snapshot_classifies_preexisting_native_rate_limit_errors(
+    message: str,
     stored_code: str,
     expected_code: str,
 ) -> None:
     """Failures saved without a rate-limit code become retryable on reload."""
     session_id = "319c3d34a4ab4e6d983872bf898a19b4"
-    message = "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED"
     conv = Conversation(
         id=session_id,
         created_at=1,

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -30,6 +30,12 @@ const TERMINAL_ERROR = [
   "Pane is dead (status 0, Tue Aug 11 17:00:46 2026)",
 ].join("\n");
 
+const RATE_LIMIT_ERROR = [
+  "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded workspace",
+  "input tokens per minute rate limit for databricks-test-model. Work with your",
+  "Databricks account team to request a higher FMAPI rate limit tier.",
+].join(" ");
+
 describe("ErrorBanner", () => {
   beforeEach(() => vi.mocked(copyText).mockClear());
 
@@ -403,6 +409,58 @@ describe("ErrorBanner", () => {
     );
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
+
+  it("retries classified rate-limit errors and preserves the provider's details", async () => {
+    let resolveRetry: (() => void) | undefined;
+    const onRetry = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRetry = resolve;
+        }),
+    );
+    render(
+      <ErrorBanner
+        message={RATE_LIMIT_ERROR}
+        source="llm"
+        code="rate_limit_exceeded"
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(screen.getByTestId("error-headline")).toHaveTextContent(
+      "The model's rate limit was reached. Wait a moment, then retry.",
+    );
+    fireEvent.click(screen.getByRole("button", { name: /model's rate limit was reached/i }));
+    expect(screen.getByTestId("error-message-content")).toHaveTextContent(RATE_LIMIT_ERROR);
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    act(() => {
+      retry.click();
+      retry.click();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("status")).toHaveTextContent(/^Retrying$/);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+
+    await act(async () => resolveRetry?.());
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByTestId("error-headline")).toBeNull();
+  });
+
+  it("does not offer rate-limit retry without a handler", () => {
+    render(<ErrorBanner message={RATE_LIMIT_ERROR} source="llm" code="rate_limit_exceeded" />);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it.each(["native_turn_error", "codex_turn_error", "codex_reauth_required", "unauthorized"])(
+    "does not infer rate-limit retry from the message for code %s",
+    (code) => {
+      render(
+        <ErrorBanner message={RATE_LIMIT_ERROR} source="execution" code={code} onRetry={vi.fn()} />,
+      );
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    },
+  );
 
   it.each(["executor_error", "connection_error", "runner_error", "wrong_replica"])(
     "does not offer reconnect for live-runner code %s",

--- a/web/src/components/blocks/StatusBlocks.test.tsx
+++ b/web/src/components/blocks/StatusBlocks.test.tsx
@@ -428,7 +428,7 @@ describe("ErrorBanner", () => {
     );
 
     expect(screen.getByTestId("error-headline")).toHaveTextContent(
-      "The model's rate limit was reached. Wait a moment, then retry.",
+      "The model's rate limit was reached. You can retry this turn.",
     );
     fireEvent.click(screen.getByRole("button", { name: /model's rate limit was reached/i }));
     expect(screen.getByTestId("error-message-content")).toHaveTextContent(RATE_LIMIT_ERROR);

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -50,7 +50,7 @@ interface ErrorBannerProps {
   remediation?: string;
   /** `"info"` renders a neutral notice (no failure tone) instead of a destructive error. */
   level?: "error" | "info";
-  /** Reconnect the existing session without replaying or duplicating user input. */
+  /** Recover the existing session or continue after a retryable turn failure. */
   onRetry?: () => Promise<void>;
 }
 
@@ -75,6 +75,7 @@ const FAILURE_CODE_DESCRIPTIONS: Record<string, string> = {
     "Codex hit an error reloading the earlier transcript, so it started a fresh thread.",
   codex_turn_error: "Codex ran into an error during this turn.",
   native_turn_error: "The agent ran into an error during this turn.",
+  rate_limit_exceeded: "The model's rate limit was reached. Wait a moment, then retry.",
 };
 
 const RETRYABLE_ERROR_CODES = new Set([
@@ -83,6 +84,7 @@ const RETRYABLE_ERROR_CODES = new Set([
   "runner_disconnected",
   "runner_failed_to_start",
   "runner_unavailable",
+  "rate_limit_exceeded",
 ]);
 
 interface ParsedErrorMessage {
@@ -224,7 +226,7 @@ export function ErrorBanner({
           className="relative z-10 h-auto rounded-xl border-border bg-background px-4 py-2 text-sm font-normal text-muted-foreground shadow-xs"
         >
           <Loader2Icon aria-hidden="true" className="animate-spin" />
-          Reconnecting
+          {code === "rate_limit_exceeded" ? "Retrying" : "Reconnecting"}
         </Badge>
       </div>
     );

--- a/web/src/components/blocks/StatusBlocks.tsx
+++ b/web/src/components/blocks/StatusBlocks.tsx
@@ -75,7 +75,7 @@ const FAILURE_CODE_DESCRIPTIONS: Record<string, string> = {
     "Codex hit an error reloading the earlier transcript, so it started a fresh thread.",
   codex_turn_error: "Codex ran into an error during this turn.",
   native_turn_error: "The agent ran into an error during this turn.",
-  rate_limit_exceeded: "The model's rate limit was reached. Wait a moment, then retry.",
+  rate_limit_exceeded: "The model's rate limit was reached. You can retry this turn.",
 };
 
 const RETRYABLE_ERROR_CODES = new Set([

--- a/web/src/components/chat/chatBubbleParts.test.tsx
+++ b/web/src/components/chat/chatBubbleParts.test.tsx
@@ -1,0 +1,220 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Bubble } from "@/lib/renderItems";
+import { useChatStore, type ChatState } from "@/store/chatStore";
+import { BubbleView } from "./chatBubbleParts";
+
+const fetchMock = vi.fn();
+const initialStoreState = useChatStore.getState();
+const continuation = "Please continue from where you left off before the rate limit error.";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function errorBubble(code = "rate_limit_exceeded"): Extract<Bubble, { kind: "assistant" }> {
+  return {
+    kind: "assistant",
+    responseId: "resp_failed",
+    stableId: "error_failed",
+    lifecycle: "failed",
+    error: null,
+    items: [
+      {
+        kind: "error",
+        itemId: "error_failed",
+        message: "API Error: Request rejected (429): workspace input tokens per minute rate limit",
+        source: "execution",
+        code,
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  useChatStore.setState({
+    conversationId: "conv_retry",
+    sessionStatus: "failed",
+    status: "idle",
+    activeResponse: null,
+    blocks: [],
+    pendingUserMessages: [],
+    failedSendDraft: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  useChatStore.setState(initialStoreState);
+});
+
+describe("AssistantBubble error retry", () => {
+  it("submits one continuation for a rate limit without replaying the original input", async () => {
+    let finishRetry: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishRetry = resolve;
+        }),
+    );
+    const draft = { conversationId: "conv_retry", text: "My unsent draft", files: [] };
+    useChatStore.setState({ failedSendDraft: draft });
+    render(<BubbleView bubble={errorBubble()} isLastAssistant />);
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(retry);
+    fireEvent.click(retry);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_retry/events");
+    expect(JSON.parse(init.body as string)).toEqual({
+      type: "message",
+      data: { role: "user", content: [{ type: "input_text", text: continuation }] },
+    });
+    expect(useChatStore.getState().failedSendDraft).toBe(draft);
+
+    await act(async () => {
+      finishRetry?.(jsonResponse({ queued: true, pending_id: "pending_retry" }));
+    });
+
+    expect(screen.queryByTestId("error-pill")).toBeNull();
+    expect(useChatStore.getState().failedSendDraft).toBe(draft);
+  });
+
+  it("coalesces retry clicks from separate rate-limit cards in the same turn", async () => {
+    let finishRetry: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishRetry = resolve;
+        }),
+    );
+    const bubble = errorBubble();
+    bubble.items.push({
+      kind: "error",
+      itemId: "error_second",
+      code: "rate_limit_exceeded",
+      source: "execution",
+      message: "Too many requests: request rate limit exceeded",
+    });
+    render(<BubbleView bubble={bubble} isLastAssistant />);
+
+    const retryButtons = screen.getAllByRole("button", { name: "Retry" });
+    expect(retryButtons).toHaveLength(2);
+    fireEvent.click(retryButtons[0]!);
+    fireEvent.click(retryButtons[1]!);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      finishRetry?.(jsonResponse({ queued: true, pending_id: "pending_retry" }));
+    });
+
+    expect(screen.queryAllByTestId("error-pill")).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      response: () =>
+        jsonResponse({ error: { code: "runner_unavailable", message: "Host is offline" } }, 503),
+      message: "Host is offline",
+    },
+    {
+      response: () => jsonResponse({ queued: false, denied: true }),
+      message: "The retry was blocked by a policy",
+    },
+  ])("preserves the card and composer draft when retry fails: $message", async (testCase) => {
+    fetchMock.mockResolvedValueOnce(testCase.response());
+    const draft = { conversationId: "conv_retry", text: "Keep this draft", files: [] };
+    useChatStore.setState({ failedSendDraft: draft });
+    render(<BubbleView bubble={errorBubble()} isLastAssistant />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(`Retry failed: ${testCase.message}`),
+    );
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+    expect(useChatStore.getState().failedSendDraft).toBe(draft);
+  });
+
+  it.each<Partial<ChatState>>([
+    { sessionStatus: "launching" },
+    { sessionStatus: "running" },
+    { sessionStatus: "waiting" },
+    { status: "streaming" },
+    {
+      pendingUserMessages: [
+        {
+          tempId: "pending_user",
+          content: [{ type: "input_text", text: "A new request" }],
+          createdAtS: 1,
+        },
+      ],
+    },
+  ])("does not queue a continuation while the session is busy: %o", async (state) => {
+    useChatStore.setState(state);
+    render(<BubbleView bubble={errorBubble()} isLastAssistant />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Wait for the current turn to finish before retrying",
+      ),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not continue an old failed turn after a newer assistant response", async () => {
+    render(<BubbleView bubble={errorBubble()} isLastAssistant={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Only the latest failed turn can be retried",
+      ),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not send a stale click to a newly selected session", async () => {
+    render(<BubbleView bubble={errorBubble()} isLastAssistant />);
+    const current = useChatStore.getState();
+    vi.spyOn(useChatStore, "getState").mockReturnValue({
+      ...current,
+      conversationId: "conv_other",
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("The selected session has changed"),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps infrastructure-error retry on the runner recovery path", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ queued: false, recovered: true, recovery: "native_terminal_ready" }),
+    );
+    render(<BubbleView bubble={errorBubble("required_terminal_exited")} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.queryByTestId("error-pill")).toBeNull());
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_retry/events");
+    expect(JSON.parse(init.body as string)).toEqual({ type: "retry_session", data: {} });
+  });
+});

--- a/web/src/components/chat/chatBubbleParts.tsx
+++ b/web/src/components/chat/chatBubbleParts.tsx
@@ -60,7 +60,7 @@ import {
 } from "@/lib/blocks";
 import { type Bubble, type RenderItem, bubblesEqual } from "@/lib/renderItems";
 import { getCurrentAuthorId } from "@/lib/identity";
-import { retrySession } from "@/lib/sessionsApi";
+import { retryRateLimitedTurn, retrySession } from "@/lib/sessionsApi";
 import { useChatStore, type PendingUserMessage } from "@/store/chatStore";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 import { UserMessageNav } from "@/components/UserMessageNav";
@@ -812,13 +812,35 @@ function AssistantBubble({
   const { isCopied, handleCopy } = useCopyMessage(() => collectBubbleMarkdown(bubble.items));
   // null outside AppShell's provider (isolated tests) → hide the action.
   const forkDialog = useForkDialog();
-  const handleRetryError = useCallback(async () => {
-    if (!conversationId) throw new Error("Session is not available");
-    const result = await retrySession(conversationId);
-    if (!result.recovered) {
-      throw new Error("The session is already connected; no recovery was performed");
-    }
-  }, [conversationId]);
+  const handleRetryError = useCallback(
+    async (item: Extract<RenderItem, { kind: "error" }>) => {
+      if (!conversationId) throw new Error("Session is not available");
+      if (item.code === "rate_limit_exceeded") {
+        const current = useChatStore.getState();
+        if (current.conversationId !== conversationId) {
+          throw new Error("The selected session has changed");
+        }
+        if (!isLastAssistant) throw new Error("Only the latest failed turn can be retried");
+        if (
+          current.status === "streaming" ||
+          current.sessionStatus === "launching" ||
+          current.sessionStatus === "running" ||
+          current.sessionStatus === "waiting" ||
+          current.pendingUserMessages.length > 0 ||
+          current.blocks.some((block) => block.type === "elicitation" && block.status === "pending")
+        ) {
+          throw new Error("Wait for the current turn to finish before retrying");
+        }
+        await retryRateLimitedTurn(conversationId);
+        return;
+      }
+      const result = await retrySession(conversationId);
+      if (!result.recovered) {
+        throw new Error("The session is already connected; no recovery was performed");
+      }
+    },
+    [conversationId, isLastAssistant],
+  );
 
   if (bubble.items.length === 0) return null;
 

--- a/web/src/lib/sessionsApi.test.ts
+++ b/web/src/lib/sessionsApi.test.ts
@@ -22,6 +22,7 @@ import {
   listRunners,
   openSessionStream,
   postEvent,
+  retryRateLimitedTurn,
   SESSION_HISTORY_PAGE_SIZE,
   stopSession,
   updateSession,
@@ -1142,6 +1143,132 @@ describe("stopSession", () => {
     expect(url).toBe("/v1/sessions/conv_abc/events");
     expect(JSON.parse(init.body as string)).toEqual({ type: "stop_session", data: {} });
     expect(out.queued).toBe(false);
+  });
+});
+
+describe("retryRateLimitedTurn", () => {
+  it.each([
+    { queued: true, item_id: "ci_retry" },
+    { queued: true, pending_id: "pending_retry" },
+  ])("submits a continuation for an accepted retry: %o", async (response) => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse(response));
+
+    await retryRateLimitedTurn("conv_retry");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/v1/sessions/conv_retry/events");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      type: "message",
+      data: {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Please continue from where you left off before the rate limit error.",
+          },
+        ],
+      },
+    });
+  });
+
+  it("shares one in-flight continuation across error cards in the same session", async () => {
+    let finishRetry: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishRetry = resolve;
+        }),
+    );
+
+    const first = retryRateLimitedTurn("conv_retry");
+    const second = retryRateLimitedTurn("conv_retry");
+
+    expect(second).toBe(first);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    finishRetry?.(mockJsonResponse({ queued: true }));
+    await Promise.all([first, second]);
+
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ queued: true }));
+    await retryRateLimitedTurn("conv_retry");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases a shared failed attempt so a later retry can succeed", async () => {
+    let finishRetry: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishRetry = resolve;
+        }),
+    );
+
+    const first = retryRateLimitedTurn("conv_retry");
+    const second = retryRateLimitedTurn("conv_retry");
+    const outcomes = Promise.allSettled([first, second]);
+    finishRetry?.(mockJsonResponse({ queued: false, denied: true }));
+
+    expect(await outcomes).toEqual([
+      { status: "rejected", reason: new Error("The retry was blocked by a policy") },
+      { status: "rejected", reason: new Error("The retry was blocked by a policy") },
+    ]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ queued: true }));
+    await retryRateLimitedTurn("conv_retry");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows different sessions to retry independently", async () => {
+    let finishFirst: ((response: Response) => void) | undefined;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          finishFirst = resolve;
+        }),
+    );
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ queued: true }));
+
+    const first = retryRateLimitedTurn("conv_first");
+    await retryRateLimitedTurn("conv_second");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/v1/sessions/conv_first/events",
+      "/v1/sessions/conv_second/events",
+    ]);
+    finishFirst?.(mockJsonResponse({ queued: true }));
+    await first;
+  });
+
+  it("rejects policy denials so the error card remains actionable", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ queued: false, denied: true }));
+
+    await expect(retryRateLimitedTurn("conv_retry")).rejects.toThrow(
+      "The retry was blocked by a policy",
+    );
+  });
+
+  it("rejects a response that did not queue a continuation", async () => {
+    fetchMock.mockResolvedValueOnce(mockJsonResponse({ queued: false }));
+
+    await expect(retryRateLimitedTurn("conv_retry")).rejects.toThrow("The retry was not accepted");
+  });
+
+  it("propagates the server's dispatch error", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockJsonResponse(
+        { error: { code: "runner_unavailable", message: "The host is offline" } },
+        { ok: false, status: 503 },
+      ),
+    );
+
+    await expect(retryRateLimitedTurn("conv_retry")).rejects.toMatchObject({
+      code: "runner_unavailable",
+      message: "The host is offline",
+      status: 503,
+    });
   });
 });
 

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -1300,6 +1300,37 @@ export function retrySession(sessionId: string): Promise<PostEventResponse> {
   return postEvent(sessionId, { type: "retry_session", data: {} });
 }
 
+// Multiple error cards can describe the same failed turn.
+const rateLimitedTurnRetries = new Map<string, Promise<void>>();
+
+/** Continue a rate-limited turn without replaying the original prompt or tools. */
+export function retryRateLimitedTurn(sessionId: string): Promise<void> {
+  const pending = rateLimitedTurnRetries.get(sessionId);
+  if (pending) return pending;
+
+  const retry = postEvent(sessionId, {
+    type: "message",
+    data: {
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "Please continue from where you left off before the rate limit error.",
+        },
+      ],
+    },
+  })
+    .then((result) => {
+      if (result.denied) throw new Error("The retry was blocked by a policy");
+      if (!result.queued) throw new Error("The retry was not accepted");
+    })
+    .finally(() => {
+      rateLimitedTurnRetries.delete(sessionId);
+    });
+  rateLimitedTurnRetries.set(sessionId, retry);
+  return retry;
+}
+
 /**
  * Resolve an outstanding elicitation via its dedicated URL endpoint
  * (URL-based elicitation): `POST /v1/sessions/{id}/elicitations/{eid}/resolve`


### PR DESCRIPTION
## Related issue

Closes #7234

## Summary

Native model 429s currently leave users at a generic failure card with no Retry action. Recognize 429s in live native status and saved errors, then offer an in-place continuation. A 429 enables Retry regardless of quota, billing, or credit-balance details. Authentication failures and specific diagnoses keep their existing behavior.

Retry sends one continuation without resending the original prompt or changing the composer draft. Concurrent clicks share one request; busy sessions, historical turns, and stale session clicks are rejected. Infrastructure-error Retry remains reconnect-only.

ELI5: when the model returns 429, the error card lets you ask it to pick up where it stopped.

```text
native 429 → rate-limit error card → Retry → one continuation in the same session
```

## Test Plan

- 203 focused frontend tests passed: `pnpm --dir web test src/components/blocks/StatusBlocks.test.tsx src/components/blocks/BlockRenderer.test.tsx src/components/chat/chatBubbleParts.test.tsx src/lib/sessionsApi.test.ts`.
- Initial full backend validation: 396 tests passed across `tests/runner/test_launch_failure.py`, `tests/server/routes/test_sessions_snapshot.py`, and `tests/server/integration/test_sessions_endpoints.py`. Follow-up verification for quota/billing 429s and bare `rate limited` variants: all 131 tests passed with `uv run --no-sync pytest tests/runner/test_launch_failure.py tests/server/routes/test_sessions_snapshot.py tests/server/integration/test_sessions_endpoints.py::test_native_rate_limit_failure_is_classified_live_and_after_reload`.
- All 10 Playwright failure-card tests passed after building the UI: `uv run --no-sync pytest tests/e2e_ui/chat/test_failure_error_card.py --ui-skip-build -v`.
- `pre-commit run` passed for the complete change, including Pyrefly, TypeScript, lint, formatting, and file checks. Before/after production UI builds passed.
- Human check: open a native session with a model 429, including a quota/billing 429, expand its details, and reload. Retry should remain visible. Type an unsent draft, then click Retry when ready. One continuation should appear in the same session, the original prompt should not be resent, and the draft should remain untouched. Retry availability does not guarantee the provider will accept the next request.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

https://github.com/user-attachments/assets/ce063ccd-0f87-434b-b53b-6172b941600d

36-second before/after recording. Before: generic failure without Retry. After: rate-limit explanation, retained Retry after reload, and continuation with the draft preserved.

This is a sanitized, isolated local replay of a Databricks 429. The browser talks to the real local server and runner; the successful model response comes from a local mock. Live provider throttling was not induced.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Regression coverage includes stored and forwarded native 429s, quota/billing/credit-balance 429s, bare `rate limited` variants, old generic error labels on reload, auth-code preservation, successful continuation, duplicate in-flight clicks, busy/stale/historical click guards, rejected retries, draft preservation, and unchanged infrastructure recovery. The committed browser regression intercepts only the continuation response to verify its exact payload; the separate demo uses the real server/runner path with a local mocked provider. Live native-provider recovery was not exercised.

## Changelog

Retry native model rate-limit errors directly from the chat.
