### PR TITLE
fix(claude-native): preserve permission mode across relaunches

### DIFF
--- a/omnigent/harnesses/claude_native/forwarder.py
+++ b/omnigent/harnesses/claude_native/forwarder.py
@@ -742,6 +742,10 @@ class _ForwardDedupeState:
     # mirrors the launch mode and any in-pane shift+tab switch, neither of
     # which the web UI can observe on its own.
     posted_permission_mode: str | None = None
+    # Observation advances even when delivery fails; a pending switch must
+    # survive retries, including a switch back to the last posted mode.
+    observed_permission_mode: str | None = None
+    permission_mode_change_pending: bool = False
     # Monotonic deadline before which the next pane capture is skipped, so the
     # single ``capture-pane`` subprocess (feeding both the permission-mode and
     # /btw signals) spawns at _PANE_POLL_INTERVAL_S, not every poll.
@@ -5070,6 +5074,7 @@ async def _post_external_permission_mode_change(
     *,
     session_id: str,
     mode: str,
+    initial_observation: bool,
 ) -> None:
     """
     Post one ``external_permission_mode_change`` event to the Sessions API.
@@ -5080,11 +5085,15 @@ async def _post_external_permission_mode_change(
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id, e.g. ``"conv_abc123"``.
     :param mode: Permission mode the pane now shows, e.g. ``"auto"``.
+    :param initial_observation: Whether this reports startup rather than an observed switch.
     :raises httpx.HTTPError: If the Omnigent request fails or is rejected.
     """
     resp = await client.post(
         f"/v1/sessions/{session_id}/events",
-        json={"type": "external_permission_mode_change", "data": {"permission_mode": mode}},
+        json={
+            "type": "external_permission_mode_change",
+            "data": {"permission_mode": mode, "initial_observation": initial_observation},
+        },
     )
     resp.raise_for_status()
 
@@ -5143,18 +5152,28 @@ async def _relay_permission_mode(
     hides itself. Best-effort and idempotent — an unchanged or unreadable
     (``None``) mode is a no-op, and a failed POST is retried next poll.
 
+    Only a change between readable observations establishes a selection.
+    A switch before the first readable footer is indistinguishable from a
+    settings-derived startup mode and remains a passive observation.
+
     :param client: Omnigent HTTP client.
     :param session_id: Omnigent session/conversation id.
     :param mode: The permission-mode footer parsed from the pane, or ``None``.
     :param dedupe: Shared per-session dedupe state; mutated in place.
     """
-    if mode is None or mode == dedupe.posted_permission_mode:
+    if mode is None:
+        return
+    if dedupe.observed_permission_mode is not None and mode != dedupe.observed_permission_mode:
+        dedupe.permission_mode_change_pending = True
+    dedupe.observed_permission_mode = mode
+    if mode == dedupe.posted_permission_mode and not dedupe.permission_mode_change_pending:
         return
     try:
         await _post_external_permission_mode_change(
             client,
             session_id=session_id,
             mode=mode,
+            initial_observation=not dedupe.permission_mode_change_pending,
         )
     except httpx.HTTPError:
         _logger.debug(
@@ -5166,6 +5185,7 @@ async def _relay_permission_mode(
         )
         return
     dedupe.posted_permission_mode = mode
+    dedupe.permission_mode_change_pending = False
 
 
 async def _relay_btw_overlay(

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2579,10 +2579,9 @@ async def _persist_external_permission_mode_change(
     """
     Persist a pane-observed claude-native permission mode as a session label.
 
-    The forwarder posts this when the pane's mode footer differs from what it
-    last reported — i.e. the user pressed shift+tab in the TUI. Unlike the
-    PATCH path this needs no runner confirmation: the pane IS the source, so
-    the mode is already in effect.
+    The forwarder reports startup and observed shifts separately: a saved
+    label can outlive the process that observed it. Unlike the PATCH path,
+    this needs no runner confirmation because the pane is the source.
 
     :param session_id: Session/conversation identifier, e.g. ``"conv_abc123"``.
     :param conv: Conversation row for ``session_id`` at the route boundary.
@@ -2605,13 +2604,18 @@ async def _persist_external_permission_mode_change(
             f"{sorted(_CLAUDE_NATIVE_PERMISSION_MODES)}; got {mode!r}",
             code=ErrorCode.INVALID_INPUT,
         )
-    # Persist live transitions for relaunch, but leave the initial observation
-    # of a settings-derived mode unpinned when no launch flag was supplied.
-    previous_mode = conv.labels.get(_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY)
+    # Legacy forwarders omit provenance; their reports may be passive startup
+    # observations, so only explicitly observed transitions add a launch flag.
+    initial_observation = body.data.get("initial_observation", True)
+    if not isinstance(initial_observation, bool):
+        raise OmnigentError(
+            "external_permission_mode_change requires data.initial_observation to be a boolean",
+            code=ErrorCode.INVALID_INPUT,
+        )
     merged_args = _merge_claude_permission_launch_args(
         conv.terminal_launch_args,
         mode,
-        add_if_missing=previous_mode in _CLAUDE_NATIVE_PERMISSION_MODES and previous_mode != mode,
+        add_if_missing=not initial_observation,
     )
     if conv.terminal_launch_args != merged_args:
         await asyncio.to_thread(
@@ -2748,6 +2752,7 @@ def _merge_claude_permission_launch_args(
     Explicit selections and observed live transitions add the flag even if
     launch used a settings default. An initial footer observation only updates
     an existing flag, so merely observing startup does not pin that default.
+    Selecting Manual pins ``default`` too: a selection overrides later settings edits.
 
     :param existing_args: Current launch args, or ``None``.
     :param mode: Confirmed permission mode, e.g. ``"auto"``.
@@ -2764,7 +2769,9 @@ def _merge_claude_permission_launch_args(
     while index < len(args):
         arg = args[index]
         if arg == "--permission-mode":
-            index += 2  # drop the flag and its separate value token
+            index += 1
+            if index < len(args) and not args[index].startswith("-"):
+                index += 1
             continue
         if arg.startswith("--permission-mode="):
             index += 1

--- a/omnigent/server/routes/_sessions/helpers.py
+++ b/omnigent/server/routes/_sessions/helpers.py
@@ -2605,12 +2605,14 @@ async def _persist_external_permission_mode_change(
             f"{sorted(_CLAUDE_NATIVE_PERMISSION_MODES)}; got {mode!r}",
             code=ErrorCode.INVALID_INPUT,
         )
-    # Reflect the switch into terminal_launch_args so a relaunch reopens in this
-    # mode — the launcher reads the mode from launch args, while the label below
-    # is only the web UI's read-back. Rewrites an existing --permission-mode only
-    # (a no-op for a session launched without one); kept ahead of the label
-    # short-circuit so a stale launch arg is fixed even when the label matches.
-    merged_args = _merge_claude_permission_launch_args(conv.terminal_launch_args, mode)
+    # Persist live transitions for relaunch, but leave the initial observation
+    # of a settings-derived mode unpinned when no launch flag was supplied.
+    previous_mode = conv.labels.get(_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY)
+    merged_args = _merge_claude_permission_launch_args(
+        conv.terminal_launch_args,
+        mode,
+        add_if_missing=previous_mode in _CLAUDE_NATIVE_PERMISSION_MODES and previous_mode != mode,
+    )
     if conv.terminal_launch_args != merged_args:
         await asyncio.to_thread(
             conversation_store.update_conversation,
@@ -2738,25 +2740,24 @@ def _merge_codex_permission_launch_args(
 def _merge_claude_permission_launch_args(
     existing_args: list[str] | None,
     mode: str,
+    *,
+    add_if_missing: bool = False,
 ) -> list[str] | None:
-    """Rewrite an existing ``--permission-mode`` in Claude launch args to ``mode``.
+    """Persist a Claude permission mode in the args used for relaunch.
 
-    A runtime mode switch (shift+tab or PATCH) must survive relaunch, and the
-    launcher restores the mode from ``terminal_launch_args`` — not the label.
-    Rewrite the existing ``--permission-mode`` entry (space- or ``=``-joined) to
-    the current mode, preserving other args in order, so a cold resume reopens
-    in the mode the user last chose.
+    Explicit selections and observed live transitions add the flag even if
+    launch used a settings default. An initial footer observation only updates
+    an existing flag, so merely observing startup does not pin that default.
 
-    Returns ``existing_args`` unchanged when they carry no ``--permission-mode``:
-    a session launched without the flag (manual, or a ``settings.json``
-    ``defaultMode``) must NOT be pinned to an explicit mode by a footer report —
-    the forwarder posts the launch mode on its first poll (see
-    ``claude_native_forwarder``), and pinning it would override the session's
-    settings default on relaunch. Those sessions surface the live mode through
-    the permission-mode label instead.
+    :param existing_args: Current launch args, or ``None``.
+    :param mode: Confirmed permission mode, e.g. ``"auto"``.
+    :param add_if_missing: Whether a mode selection requires adding the flag.
+    :returns: Updated args preserving other flags, or the unchanged input.
     """
     args = list(existing_args or ())
-    if not any(a == "--permission-mode" or a.startswith("--permission-mode=") for a in args):
+    if not add_if_missing and not any(
+        a == "--permission-mode" or a.startswith("--permission-mode=") for a in args
+    ):
         return existing_args
     merged: list[str] = []
     index = 0

--- a/omnigent/server/routes/sessions/routes_core.py
+++ b/omnigent/server/routes/sessions/routes_core.py
@@ -2402,15 +2402,12 @@ def register_core_routes(
                 _mode_result,
             )
             labels_to_set[_CLAUDE_NATIVE_PERMISSION_MODE_LABEL_KEY] = _confirmed_permission_mode
-            # The launcher restores the mode from terminal_launch_args, not the
-            # label above, so reflect the confirmed mode there too — otherwise a
-            # relaunch reverts to the launch --permission-mode. Merge against
-            # ``updated`` (the post-write row), not the pre-update snapshot, so a
-            # combined PATCH that also set terminal_launch_args keeps those. Only
-            # rewrites an existing --permission-mode; mirrors the shift+tab path.
+            # Persist explicit selections for relaunch even without a launch
+            # flag. Use the updated row to preserve other args in this PATCH.
             _merged_permission_args = _merge_claude_permission_launch_args(
                 updated.terminal_launch_args,
                 _confirmed_permission_mode,
+                add_if_missing=True,
             )
             if updated.terminal_launch_args != _merged_permission_args:
                 await asyncio.to_thread(

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -7843,7 +7843,10 @@ async def test_post_external_permission_mode_transition_persists_for_relaunch(
     for index, mode in enumerate(("default", "auto", "default")):
         response = await client.post(
             f"{endpoint}/events",
-            json={"type": "external_permission_mode_change", "data": {"permission_mode": mode}},
+            json={
+                "type": "external_permission_mode_change",
+                "data": {"permission_mode": mode, "initial_observation": index == 0},
+            },
         )
         assert response.status_code == 202, response.text
         snapshot = (await client.get(endpoint)).json()
@@ -7859,8 +7862,18 @@ async def test_post_external_permission_mode_transition_persists_for_relaunch(
         ]
 
 
+@pytest.mark.parametrize(
+    "mode_args",
+    [
+        ["--permission-mode", "plan"],
+        ["--permission-mode=plan"],
+        ["--permission-mode"],
+        ["--permission-mode", "plan", "--permission-mode=auto"],
+    ],
+)
 async def test_post_external_permission_mode_change_rewrites_launch_arg(
     client: httpx.AsyncClient,
+    mode_args: list[str],
 ) -> None:
     """
     A pane switch replaces the create-time ``--permission-mode`` launch arg.
@@ -7874,7 +7887,7 @@ async def test_post_external_permission_mode_change_rewrites_launch_arg(
     session = await _create_session(
         client,
         agent["id"],
-        terminal_launch_args=["--model", "opus", "--permission-mode", "plan"],
+        terminal_launch_args=[*mode_args, "--model", "opus"],
     )
 
     resp = await client.post(
@@ -7893,6 +7906,56 @@ async def test_post_external_permission_mode_change_rewrites_launch_arg(
         "--permission-mode",
         "acceptEdits",
     ]
+
+
+@pytest.mark.parametrize("previous_mode", [None, "auto", "default"])
+@pytest.mark.parametrize("initial_observation", [None, True, False])
+async def test_permission_mode_persistence_uses_provenance_not_saved_label(
+    client: httpx.AsyncClient,
+    previous_mode: str | None,
+    initial_observation: bool | None,
+) -> None:
+    """Only explicit transitions pin a mode, including when the label already matches."""
+    agent = await create_test_agent(client)
+    label_key = "omnigent.claude_native.permission_mode"
+    session = await _create_session(
+        client, agent["id"], labels={label_key: previous_mode} if previous_mode else {}
+    )
+    endpoint = f"/v1/sessions/{session['id']}"
+    data: dict[str, Any] = {"permission_mode": "auto"}
+    if initial_observation is not None:
+        data["initial_observation"] = initial_observation
+    response = await client.post(
+        f"{endpoint}/events", json={"type": "external_permission_mode_change", "data": data}
+    )
+    assert response.status_code == 202, response.text
+    snapshot = (await client.get(endpoint)).json()
+    assert snapshot["labels"][label_key] == "auto"
+    assert snapshot["terminal_launch_args"] == (
+        ["--permission-mode", "auto"] if initial_observation is False else None
+    )
+
+
+@pytest.mark.parametrize("initial_observation", [None, "false", 0])
+async def test_permission_mode_rejects_invalid_observation_provenance(
+    client: httpx.AsyncClient,
+    initial_observation: Any,
+) -> None:
+    """Malformed provenance cannot silently turn a passive observation into a selection."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"])
+    endpoint = f"/v1/sessions/{session['id']}"
+    response = await client.post(
+        f"{endpoint}/events",
+        json={
+            "type": "external_permission_mode_change",
+            "data": {"permission_mode": "auto", "initial_observation": initial_observation},
+        },
+    )
+    assert response.status_code == 400, response.text
+    snapshot = (await client.get(endpoint)).json()
+    assert "omnigent.claude_native.permission_mode" not in snapshot["labels"]
+    assert snapshot["terminal_launch_args"] is None
 
 
 async def test_post_external_permission_mode_change_is_quiet_when_unchanged(
@@ -8027,6 +8090,48 @@ async def test_in_pane_permission_mode_switch_reaches_the_sse_wire_end_to_end(
     # And it is durable: a reloading client restores the mode from the label.
     snapshot = (await client.get(f"/v1/sessions/{session_id}")).json()
     assert snapshot["labels"]["omnigent.claude_native.permission_mode"] == "auto"
+    assert snapshot["terminal_launch_args"] == ["--permission-mode", "auto"]
+
+
+@pytest.mark.parametrize("initial_args", [None, [], ["--model", "opus"]])
+async def test_permission_mode_restart_keeps_settings_defaults_unpinned(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    initial_args: list[str] | None,
+) -> None:
+    """Fresh forwarders must not mistake a previous run's label for a live switch."""
+    from omnigent.harnesses.claude_native import forwarder as fwd
+    from omnigent.harnesses.claude_native.bridge import PaneSignals
+
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], terminal_launch_args=initial_args)
+    endpoint = f"/v1/sessions/{session['id']}"
+    monkeypatch.setattr(fwd, "_PANE_POLL_INTERVAL_S", 0.0)
+    pane_mode = "default"
+    monkeypatch.setattr(fwd, "read_pane_signals", lambda _: PaneSignals(permission_mode=pane_mode))
+
+    async def poll(dedupe: fwd._ForwardDedupeState) -> dict[str, Any]:
+        await fwd._forward_pane_signals(
+            client=client,
+            session_id=session["id"],
+            bridge_dir=Path("/tmp/omnigent/claude-native/restart"),
+            dedupe=dedupe,
+        )
+        snapshot = (await client.get(endpoint)).json()
+        assert snapshot["labels"]["omnigent.claude_native.permission_mode"] == pane_mode
+        return snapshot
+
+    # Each launch reads a different settings default against the same saved row.
+    for pane_mode in ("default", "auto", "default"):
+        dedupe = fwd._ForwardDedupeState()
+        assert (await poll(dedupe))["terminal_launch_args"] == initial_args
+
+    # Explicit in-pane selections, including Manual, survive subsequent launches.
+    for pane_mode in ("auto", "default"):
+        expected_args = [*(initial_args or []), "--permission-mode", pane_mode]
+        assert (await poll(dedupe))["terminal_launch_args"] == expected_args
+        dedupe = fwd._ForwardDedupeState()
+        assert (await poll(dedupe))["terminal_launch_args"] == expected_args
 
 
 async def test_post_external_codex_approval_mode_change_persists_terminal_args(
@@ -9854,8 +9959,14 @@ async def test_post_external_codex_approval_mode_change_requires_a_field(
     assert resp.status_code == 400, resp.text
 
 
+@pytest.mark.parametrize(
+    ("requested_mode", "confirmed_mode"),
+    [("auto", "auto"), ("default", "default"), ("auto", "acceptEdits")],
+)
 async def test_patch_permission_mode_persists_label_and_forwards_event(
     client: httpx.AsyncClient,
+    requested_mode: str,
+    confirmed_mode: str,
 ) -> None:
     """
     PATCH ``permission_mode`` forwards the switch and persists what landed.
@@ -9878,7 +9989,7 @@ async def test_patch_permission_mode_persists_label_and_forwards_event(
         if request.content:
             body = json.loads(request.content)
         captured.append(_ForwardedEffort(url=str(request.url), body=body))
-        return httpx.Response(200, json={"permission_mode": "auto"})
+        return httpx.Response(200, json={"permission_mode": confirmed_mode})
 
     fake_runner = httpx.AsyncClient(
         transport=httpx.MockTransport(_handler),
@@ -9899,19 +10010,22 @@ async def test_patch_permission_mode_persists_label_and_forwards_event(
 
         resp = await client.patch(
             f"/v1/sessions/{session['id']}",
-            json={"permission_mode": "auto"},
+            json={"permission_mode": requested_mode},
         )
     finally:
         await fake_runner.aclose()
         set_runner_client(None)
 
     assert resp.status_code == 200, resp.text
-    assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == "auto"
+    assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == confirmed_mode
     # An explicit selection must survive relaunch even without a launch flag.
-    assert resp.json()["terminal_launch_args"] == ["--permission-mode", "auto"]
+    assert resp.json()["terminal_launch_args"] == ["--permission-mode", confirmed_mode]
     forwards = [f for f in captured if f.url.endswith(f"/v1/sessions/{session['id']}/events")]
     assert len(forwards) == 1, f"Expected one runner forward, got {captured!r}"
-    assert forwards[0].body == {"type": "permission_mode_change", "permission_mode": "auto"}
+    assert forwards[0].body == {
+        "type": "permission_mode_change",
+        "permission_mode": requested_mode,
+    }
 
 
 async def test_patch_permission_mode_rewrites_launch_arg_and_keeps_other_args(
@@ -10033,6 +10147,7 @@ async def test_patch_permission_mode_requires_live_runner_before_persisting(
     assert resp.status_code == 503, resp.text
     assert "Could not switch to auto mode" in resp.text
     assert "omnigent.claude_native.permission_mode" not in snapshot["labels"]
+    assert snapshot["terminal_launch_args"] is None
 
 
 async def test_patch_permission_mode_silent_skips_the_switch_without_crashing(

--- a/tests/server/integration/test_sessions_endpoints.py
+++ b/tests/server/integration/test_sessions_endpoints.py
@@ -7830,6 +7830,35 @@ async def test_post_external_permission_mode_change_persists_label_and_publishes
     assert snapshot["terminal_launch_args"] is None
 
 
+@pytest.mark.parametrize("initial_args", [None, [], ["--model", "opus"]])
+async def test_post_external_permission_mode_transition_persists_for_relaunch(
+    client: httpx.AsyncClient,
+    initial_args: list[str] | None,
+) -> None:
+    """A live mode change survives relaunch when no mode flag was supplied."""
+    agent = await create_test_agent(client)
+    session = await _create_session(client, agent["id"], terminal_launch_args=initial_args)
+    endpoint = f"/v1/sessions/{session['id']}"
+
+    for index, mode in enumerate(("default", "auto", "default")):
+        response = await client.post(
+            f"{endpoint}/events",
+            json={"type": "external_permission_mode_change", "data": {"permission_mode": mode}},
+        )
+        assert response.status_code == 202, response.text
+        snapshot = (await client.get(endpoint)).json()
+        assert snapshot["labels"]["omnigent.claude_native.permission_mode"] == mode
+        if index == 0:
+            # The initial observation leaves the settings default unpinned.
+            assert snapshot["terminal_launch_args"] == initial_args
+            continue
+        assert snapshot["terminal_launch_args"] == [
+            *(initial_args or []),
+            "--permission-mode",
+            mode,
+        ]
+
+
 async def test_post_external_permission_mode_change_rewrites_launch_arg(
     client: httpx.AsyncClient,
 ) -> None:
@@ -9878,9 +9907,8 @@ async def test_patch_permission_mode_persists_label_and_forwards_event(
 
     assert resp.status_code == 200, resp.text
     assert resp.json()["labels"]["omnigent.claude_native.permission_mode"] == "auto"
-    # No launch --permission-mode to rewrite, so none is fabricated (see the
-    # rewrite-existing test below for the persist-to-launch-args case).
-    assert resp.json()["terminal_launch_args"] is None
+    # An explicit selection must survive relaunch even without a launch flag.
+    assert resp.json()["terminal_launch_args"] == ["--permission-mode", "auto"]
     forwards = [f for f in captured if f.url.endswith(f"/v1/sessions/{session['id']}/events")]
     assert len(forwards) == 1, f"Expected one runner forward, got {captured!r}"
     assert forwards[0].body == {"type": "permission_mode_change", "permission_mode": "auto"}

--- a/tests/test_claude_native_forwarder.py
+++ b/tests/test_claude_native_forwarder.py
@@ -4180,7 +4180,7 @@ async def test_relay_permission_mode_mirrors_switch_and_dedupes() -> None:
         # The launch mode is posted, so the picker has a mode to show.
         await _relay("default")
         assert [p["type"] for p in posts] == ["external_permission_mode_change"]
-        assert posts[0]["data"] == {"permission_mode": "default"}
+        assert posts[0]["data"] == {"permission_mode": "default", "initial_observation": True}
         assert dedupe.posted_permission_mode == "default"
 
         # Unchanged footer is a no-op, not a repeat POST.
@@ -4189,7 +4189,7 @@ async def test_relay_permission_mode_mirrors_switch_and_dedupes() -> None:
 
         # The user presses shift+tab into auto mode.
         await _relay("auto")
-        assert posts[-1]["data"] == {"permission_mode": "auto"}
+        assert posts[-1]["data"] == {"permission_mode": "auto", "initial_observation": False}
         assert dedupe.posted_permission_mode == "auto"
 
         # Still auto — the switch isn't re-posted every poll.
@@ -4230,7 +4230,10 @@ async def test_relay_permission_mode_posts_manual_launch_mode() -> None:
         )
 
     assert posts == [
-        {"type": "external_permission_mode_change", "data": {"permission_mode": "default"}}
+        {
+            "type": "external_permission_mode_change",
+            "data": {"permission_mode": "default", "initial_observation": True},
+        }
     ]
     assert dedupe.posted_permission_mode == "default"
 
@@ -4279,11 +4282,62 @@ async def test_relay_permission_mode_retries_after_transient_failure() -> None:
 
         await _relay("plan")
         assert [p["data"] for p in posts] == [
-            {"permission_mode": "default"},
-            {"permission_mode": "plan"},
-            {"permission_mode": "plan"},
+            {"permission_mode": "default", "initial_observation": True},
+            {"permission_mode": "plan", "initial_observation": False},
+            {"permission_mode": "plan", "initial_observation": False},
         ]
         assert dedupe.posted_permission_mode == "plan"  # now committed
+
+
+@pytest.mark.parametrize(
+    ("modes", "statuses", "expected"),
+    [
+        pytest.param(
+            [None, "auto", None, "auto", "auto"],
+            [503, 202],
+            [("auto", True), ("auto", True)],
+            id="startup-retry-remains-passive",
+        ),
+        pytest.param(
+            ["default", "auto", "auto"],
+            [503, 503, 202],
+            [("default", True), ("auto", False), ("auto", False)],
+            id="switch-before-first-successful-post",
+        ),
+        pytest.param(
+            ["default", "auto", None, "default", "default"],
+            [202, 503, 503, 202],
+            [("default", True), ("auto", False), ("default", False), ("default", False)],
+            id="switch-back-to-posted-mode-is-still-a-selection",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_relay_permission_mode_provenance_survives_delivery_failures(
+    modes: list[str | None],
+    statuses: list[int],
+    expected: list[tuple[str, bool]],
+) -> None:
+    """Unreadable panes and failed POSTs must not erase an observed selection."""
+    dedupe = forwarder._ForwardDedupeState()
+    posts: list[dict[str, Any]] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        posts.append(json.loads(request.content)["data"])
+        return httpx.Response(statuses[len(posts) - 1], json={})
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://test"
+    ) as client:
+        for mode in modes:
+            await forwarder._relay_permission_mode(
+                client, session_id="conv_abc", mode=mode, dedupe=dedupe
+            )
+
+    assert posts == [
+        {"permission_mode": mode, "initial_observation": initial} for mode, initial in expected
+    ]
+    assert dedupe.posted_permission_mode == expected[-1][0]
 
 
 def test_validated_transcript_state_resets_legacy_byte_cursor_without_fingerprint(


### PR DESCRIPTION
## Related issue

No linked issue.

## Summary

Claude sessions launched without `--permission-mode` forgot later mode selections on relaunch. Save runner-confirmed selections and observed terminal switches, while leaving settings-derived startup modes unpinned.

The forwarder explicitly identifies startup observations instead of inferring them from a saved label that survives restarts. Observations advance independently of successful delivery, preserving real switches through failed POSTs and switches back to the last posted mode. Older forwarders without this metadata can still update existing mode flags but do not create one. Argument merging also preserves the following option when an existing mode flag is missing its value.

In plain language: remember the user's choice, and keep following settings until the user makes one.

```text
Settings default → startup observation → no new launch flag
User selection   → observed/confirmed mode → saved flag → retained on relaunch
```

Selecting Manual explicitly saves `--permission-mode default`, so that selection takes precedence over future settings edits, just like Auto.

## Test Plan

- Reproduced the restart regression on the original PR: after a passive `default` observation, a fresh forwarder observing settings-derived `auto` incorrectly created `--permission-mode auto`.
- `python -m pytest tests/test_claude_native_forwarder.py tests/server/integration/test_sessions_endpoints.py -q -k permission_mode` — 45 passed.
- `python -m pytest tests/test_claude_native_forwarder.py tests/server/integration/test_sessions_endpoints.py -q -n 4` — 494 passed.
- `python -m pytest tests/runner/test_app_sessions_native_events_options.py tests/runner/test_app_sessions_native_terminals_autocreate.py -q -k 'permission_mode or (claude and (resume or effort or metadata))'` — 9 passed.
- `python -m pre_commit run` — all applicable hooks passed, including Pyrefly.

Manual verification:

1. Start a Claude-native session without a permission-mode launch override. Select Auto, restart the session, and confirm Auto remains selected. Repeat with Manual.
2. In a fresh session without a mode override, leave the picker untouched. Stop it, change `permissions.defaultMode` in Claude's settings, and relaunch. Confirm it follows the new default. Repeat with another default to confirm no launch override was silently added.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

N/A for visual media; backend persistence change. The restart regression drives the real forwarder, Sessions API, and database against a saved session, with controlled pane readings. Existing SSE coverage also verifies live picker updates and saved launch arguments.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Tests cover fresh forwarders with stale labels, missing/empty launch args, failed initial delivery, retries after switches, switching back to Manual, legacy event payloads, malformed/duplicate flags, and runner confirmation. A live Claude restart was not performed.

A terminal switch before the first readable footer cannot be distinguished from the settings default, so it remains a passive observation. Web-picker selections are explicitly confirmed by the runner and persist even before the first footer report.

## Changelog

Claude sessions retain selected permission modes across relaunches while continuing to follow settings defaults until a mode is selected.
