### PR TITLE
feat(web): show latest-message errors in the sidebar

### DIFF
--- a/tests/e2e_ui/sessions/test_sidebar_session_error.py
+++ b/tests/e2e_ui/sessions/test_sidebar_session_error.py
@@ -1,0 +1,288 @@
+"""Latest-message errors use the error headline's red in the sidebar icon."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+from omnigent.entities import ErrorData, NewConversationItem
+from tests.e2e_ui.conftest import seed_committed_items, seed_committed_turn
+
+_ERROR_MESSAGE = "API Error: Request rejected (429): Exceeded input tokens per minute rate limit."
+_ERROR_RESPONSE_ID = "resp_sidebar_error"
+
+
+def _row(page: Page, session_id: str) -> Locator:
+    """Locate a sidebar row by its session link."""
+    return page.locator("li").filter(has=page.locator(f'a[href="/c/{session_id}"]'))
+
+
+def _error_badge(row: Locator) -> Locator:
+    """Locate the error state in the row's shared trailing indicator slot."""
+    return row.locator('[data-testid="session-state-badge"][data-state="error"]')
+
+
+def _seed_notice(session_id: str) -> None:
+    """Write a neutral notice without changing the session's idle status."""
+    seed_committed_items(
+        session_id,
+        [
+            NewConversationItem(
+                type="error",
+                response_id=_ERROR_RESPONSE_ID,
+                data=ErrorData(
+                    source="execution",
+                    code="codex_thread_reset",
+                    message="Codex could not load this session's saved transcript.",
+                    level="info",
+                ),
+            ),
+        ],
+    )
+
+
+def _publish_status(
+    base_url: str,
+    session_id: str,
+    status: Literal["running", "idle", "failed"],
+    *,
+    response_id: str = _ERROR_RESPONSE_ID,
+) -> None:
+    """Send a native harness status edge without running a real model."""
+    data = {"status": status, "response_id": response_id}
+    if status == "failed":
+        data["output"] = _ERROR_MESSAGE
+    response = httpx.post(
+        f"{base_url}/v1/sessions/{session_id}/events",
+        json={"type": "external_session_status", "data": data},
+        timeout=10.0,
+    )
+    response.raise_for_status()
+
+
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_failed_session_matches_headline_red_and_survives_reading(
+    page: Page,
+    seeded_session: tuple[str, str],
+    theme: Literal["light", "dark"],
+) -> None:
+    """The 14px CircleAlert keeps its error color and outranks the unread dot."""
+    base_url, session_id = seeded_session
+    page.emulate_media(color_scheme=theme)
+    seed_committed_turn(
+        session_id,
+        prompt="Please continue.",
+        reply=_ERROR_MESSAGE,
+        response_id=_ERROR_RESPONSE_ID,
+    )
+    _publish_status(base_url, session_id, "failed")
+
+    page.goto(base_url)
+    row = _row(page, session_id)
+    badge = _error_badge(row)
+    expect(badge).to_be_visible(timeout=30_000)
+    expect(badge).to_have_attribute("aria-label", "Latest message is an error")
+
+    link = row.locator(f'a[href="/c/{session_id}"]')
+    link.click()
+    page.mouse.move(0, 0)
+    headline = page.get_by_test_id("error-headline")
+    expect(headline).to_be_visible(timeout=15_000)
+    expect(badge).to_be_visible()
+    expect(link).not_to_contain_text("(unread)")
+
+    if theme == "dark":
+        expect(page.locator("html")).to_have_class(re.compile(r"\bdark\b"))
+    else:
+        expect(page.locator("html")).not_to_have_class(re.compile(r"\bdark\b"))
+    icon = badge.locator("svg.lucide-circle-alert")
+    headline_color = headline.evaluate("element => getComputedStyle(element).color")
+    expect(icon).to_have_css("color", headline_color)
+    expect(icon).to_have_css("stroke", headline_color)
+    expect(icon).to_have_css("width", "14px")
+    expect(icon).to_have_css("height", "14px")
+
+    link.hover()
+    expect(page.get_by_test_id("session-tooltip-content")).to_contain_text(
+        "Latest message is an error"
+    )
+    row.hover()
+    row.get_by_test_id("conversation-actions").click()
+    page.get_by_test_id("mark-unread-conversation").click()
+    page.mouse.move(0, 0)
+    expect(link).to_contain_text("(unread)")
+    expect(badge).to_be_visible()
+    expect(row.locator('[data-state="unseen"]')).to_have_count(0)
+
+    page.goto(base_url)
+    expect(badge).to_be_visible(timeout=15_000)
+    link.click()
+    page.mouse.move(0, 0)
+    expect(headline).to_be_visible(timeout=15_000)
+    expect(link).not_to_contain_text("(unread)")
+    expect(badge).to_be_visible()
+
+    page.reload()
+    expect(badge).to_be_visible(timeout=15_000)
+    expect(icon).to_have_css("color", headline_color)
+
+
+def test_live_native_failure_flags_an_unopened_session(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A native turn's failed status reaches the sidebar without opening it."""
+    base_url, session_id = seeded_session
+    seed_committed_turn(
+        session_id,
+        prompt="Please continue.",
+        reply="Ready for the next task.",
+        response_id=_ERROR_RESPONSE_ID,
+    )
+    page.goto(base_url)
+    row = _row(page, session_id)
+    expect(row).to_be_visible(timeout=30_000)
+    expect(_error_badge(row)).to_have_count(0)
+
+    _publish_status(base_url, session_id, "running")
+    expect(row.locator('[data-state="running"]')).to_be_visible(timeout=15_000)
+    _publish_status(base_url, session_id, "failed")
+    expect(_error_badge(row)).to_be_visible(timeout=15_000)
+
+    row.locator(f'a[href="/c/{session_id}"]').click()
+    page.mouse.move(0, 0)
+    headline = page.get_by_test_id("error-headline")
+    expect(headline).to_be_visible(timeout=15_000)
+    headline_color = headline.evaluate("element => getComputedStyle(element).color")
+    expect(_error_badge(row).locator("svg")).to_have_css("color", headline_color)
+
+    page.reload()
+    expect(_error_badge(row)).to_be_visible(timeout=15_000)
+    expect(headline).to_be_visible(timeout=15_000)
+
+
+@pytest.mark.parametrize("recovery_status", ["running", "idle"])
+def test_recovered_status_clears_the_session_error(
+    page: Page,
+    seeded_session: tuple[str, str],
+    recovery_status: Literal["running", "idle"],
+) -> None:
+    """Resumed work clears the badge and a later idle status keeps it cleared."""
+    base_url, session_id = seeded_session
+    _publish_status(base_url, session_id, "failed")
+    page.goto(base_url)
+    row = _row(page, session_id)
+    expect(_error_badge(row)).to_be_visible(timeout=30_000)
+
+    recovery_response_id = "resp_sidebar_recovery"
+    _publish_status(base_url, session_id, "running", response_id=recovery_response_id)
+    expect(row.locator('[data-state="running"]')).to_be_visible(timeout=15_000)
+    expect(_error_badge(row)).to_have_count(0, timeout=15_000)
+    seed_committed_turn(
+        session_id,
+        prompt="Please try again.",
+        reply="Recovered successfully.",
+        response_id=recovery_response_id,
+    )
+    if recovery_status == "idle":
+        _publish_status(base_url, session_id, "idle", response_id=recovery_response_id)
+        expect(row.locator('[data-state="running"]')).to_have_count(0, timeout=15_000)
+
+    page.reload()
+    expect(row).to_be_visible(timeout=15_000)
+    expect(_error_badge(row)).to_have_count(0)
+    if recovery_status == "running":
+        expect(row.locator('[data-state="running"]')).to_be_visible(timeout=15_000)
+    else:
+        expect(row.locator('[data-state="running"]')).to_have_count(0)
+
+
+def test_neutral_notice_does_not_flag_the_session_as_an_error(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """An info-level transcript item does not flag an idle session as failed."""
+    base_url, session_id = seeded_session
+    _seed_notice(session_id)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    expect(page.locator('[data-testid="error-pill"][data-level="info"]')).to_be_visible(
+        timeout=15_000
+    )
+    row = _row(page, session_id)
+    expect(row).to_be_visible()
+    expect(_error_badge(row)).to_have_count(0)
+
+
+def test_idle_native_error_is_visible_before_opening_and_after_reload(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """Native API rejection text needs no failed status or last_task_error."""
+    base_url, session_id = seeded_session
+    seed_committed_turn(
+        session_id,
+        prompt="Please continue.",
+        reply=_ERROR_MESSAGE,
+        response_id=_ERROR_RESPONSE_ID,
+    )
+    snapshot = httpx.get(f"{base_url}/v1/sessions/{session_id}?include_items=false", timeout=10.0)
+    snapshot.raise_for_status()
+    assert snapshot.json()["status"] == "idle"
+    assert snapshot.json().get("last_task_error") is None
+
+    page.goto(base_url)
+    row = _row(page, session_id)
+    expect(_error_badge(row)).to_be_visible(timeout=30_000)
+    row.locator(f'a[href="/c/{session_id}"]').click()
+    page.mouse.move(0, 0)
+    expect(page.get_by_text(_ERROR_MESSAGE, exact=True)).to_be_visible(timeout=15_000)
+    expect(_error_badge(row)).to_be_visible()
+
+    page.reload()
+    expect(_error_badge(row)).to_be_visible(timeout=15_000)
+
+    # A newer successful exchange replaces the error; read state does not.
+    seed_committed_turn(
+        session_id,
+        prompt="Please try again.",
+        reply="Recovered successfully.",
+        response_id="resp_sidebar_recovered",
+    )
+    page.reload()
+    expect(page.get_by_text("Recovered successfully.", exact=True)).to_be_visible(timeout=15_000)
+    expect(_error_badge(row)).to_have_count(0, timeout=15_000)
+
+
+def test_idle_structured_error_flags_an_unopened_session(
+    page: Page,
+    seeded_session: tuple[str, str],
+) -> None:
+    """A persisted error item also survives a native session settling to idle."""
+    base_url, session_id = seeded_session
+    seed_committed_items(
+        session_id,
+        [
+            NewConversationItem(
+                type="error",
+                response_id=_ERROR_RESPONSE_ID,
+                data=ErrorData(
+                    source="execution", code="rate_limit_exceeded", message=_ERROR_MESSAGE
+                ),
+            )
+        ],
+    )
+    page.goto(base_url)
+    row = _row(page, session_id)
+    expect(_error_badge(row)).to_be_visible(timeout=30_000)
+    row.locator(f'a[href="/c/{session_id}"]').click()
+    page.mouse.move(0, 0)
+    headline = page.get_by_test_id("error-headline")
+    expect(headline).to_be_visible(timeout=15_000)
+    expect(_error_badge(row).locator("svg")).to_have_css(
+        "color", headline.evaluate("element => getComputedStyle(element).color")
+    )

--- a/web/src/components/SessionStateBadge.test.tsx
+++ b/web/src/components/SessionStateBadge.test.tsx
@@ -70,4 +70,14 @@ describe("SessionStateBadge — per-state rendering", () => {
     expect(dot?.getAttribute("class")).not.toContain("running-pulse-dot");
     expect(container.querySelector(".bg-info")).toBeNull();
   });
+
+  it("renders a static CircleAlert in the same destructive color as error text", () => {
+    const { container } = renderBadge({ kind: "error" });
+    const badge = screen.getByRole("img", { name: "Latest message is an error" });
+    expect(badge).toHaveAttribute("data-state", "error");
+    const icon = container.querySelector("svg.lucide-circle-alert");
+    expect(icon).toHaveClass("size-3.5", "shrink-0", "text-destructive");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon).not.toHaveClass("animate-spin", "animate-pulse", "text-brand-accent");
+  });
 });

--- a/web/src/components/SessionStateBadge.tsx
+++ b/web/src/components/SessionStateBadge.tsx
@@ -1,5 +1,5 @@
 // Sidebar status indicator. Approval surfaces as a "Needs response" tag so
-// it reads at a glance; running/unseen stay as compact dots. Verbose copy
+// it reads at a glance; other states stay compact. Verbose copy
 // (incl. the approval count) lives in the tooltip.
 
 import { RunningDot } from "@/components/RunningDot";
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import type { SessionState } from "@/hooks/useSessionState";
 import { cn } from "@/lib/utils";
 import type { ReactElement } from "react";
+import { CircleAlertIcon } from "lucide-react";
 
 export interface SessionStateBadgeProps {
   state: SessionState;
@@ -50,6 +51,15 @@ function describe(state: SessionState): Visual {
         ariaLabel: "Session starting up",
         tooltip: "Session starting up",
         render: () => <RunningDot className="size-3" />,
+      };
+    case "error":
+      return {
+        kind: state.kind,
+        ariaLabel: "Latest message is an error",
+        tooltip: "Latest message is an error",
+        render: () => (
+          <CircleAlertIcon aria-hidden className="size-3.5 shrink-0 text-destructive" />
+        ),
       };
     case "unseen":
       // Solid brand-pink dot — distinguished from the running indicator,

--- a/web/src/hooks/useSessionErrors.test.tsx
+++ b/web/src/hooks/useSessionErrors.test.tsx
@@ -132,6 +132,43 @@ describe("useSessionErrors", () => {
     expect(fetchPage).not.toHaveBeenCalled();
   });
 
+  it("waits for an in-flight history load instead of requesting a redundant tail", async () => {
+    const entry = conversationRegistry.acquire(session.id);
+    entry.setState({ loadingConversation: true });
+    const { wrapper } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    await act(async () => {});
+    expect(fetchPage).not.toHaveBeenCalled();
+
+    await act(async () => entry.setState({ abortController: new AbortController() }));
+    expect(fetchPage).not.toHaveBeenCalled();
+
+    await act(async () =>
+      entry.setState({ blocks: itemsToBlocks(errorPage.items), loadingConversation: false }),
+    );
+    expect(hook.result.current).toEqual([true]);
+    expect(fetchPage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a tail if the in-flight history load fails", async () => {
+    const entry = conversationRegistry.acquire(session.id);
+    entry.setState({ loadingConversation: true, abortController: new AbortController() });
+    fetchPage.mockResolvedValue(errorPage);
+    const { wrapper } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    await act(async () => {});
+    expect(fetchPage).not.toHaveBeenCalled();
+
+    act(() =>
+      entry.setState({
+        loadingConversation: false,
+        conversationLoadError: new Error("history unavailable"),
+      }),
+    );
+    await waitFor(() => expect(hook.result.current).toEqual([true]));
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to the latest item after a live transcript is evicted", async () => {
     const entry = conversationRegistry.acquire(session.id);
     entry.setState({

--- a/web/src/hooks/useSessionErrors.test.tsx
+++ b/web/src/hooks/useSessionErrors.test.tsx
@@ -1,0 +1,249 @@
+import type { ReactNode } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageItem } from "@/lib/conversationItems";
+import { itemsToBlocks } from "@/lib/itemsToBlocks";
+import { fetchSessionItemsPage, type SessionItemsPage } from "@/lib/sessionsApi";
+import { conversationRegistry } from "@/store/conversationRegistry";
+import { useSessionErrors } from "./useSessionErrors";
+
+vi.mock("@/lib/sessionsApi", () => ({ fetchSessionItemsPage: vi.fn() }));
+const fetchPage = vi.mocked(fetchSessionItemsPage);
+const session = { id: "session1", updated_at: 100, status: "idle" as const };
+const message = (text: string): MessageItem => ({
+  id: "message1",
+  response_id: "response1",
+  type: "message",
+  status: "completed",
+  role: "assistant",
+  content: [{ type: "output_text", text }],
+});
+const errorPage: SessionItemsPage = {
+  items: [
+    message(
+      "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded workspace input tokens per minute rate limit.",
+    ),
+  ],
+  hasMore: true,
+};
+const normalPage: SessionItemsPage = { items: [message("Recovered.")], hasMore: true };
+
+function harness() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, wrapper };
+}
+
+function deferredPage() {
+  let resolve!: (page: SessionItemsPage) => void;
+  const promise = new Promise<SessionItemsPage>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  fetchPage.mockReset();
+  fetchPage.mockResolvedValue(normalPage);
+  conversationRegistry.clear();
+});
+afterEach(() => {
+  cleanup();
+  conversationRegistry.clear();
+});
+
+describe("useSessionErrors", () => {
+  it("flags an unopened idle session from its latest native message and reuses the cache", async () => {
+    fetchPage.mockResolvedValue(errorPage);
+    const { wrapper } = harness();
+    const first = renderHook(() => useSessionErrors([session]), { wrapper });
+    await waitFor(() => expect(first.result.current).toEqual([true]));
+    expect(fetchPage).toHaveBeenCalledWith(session.id, {
+      limit: 1,
+      signal: expect.any(AbortSignal),
+    });
+    first.unmount();
+
+    const reopened = renderHook(() => useSessionErrors([session]), { wrapper });
+    expect(reopened.result.current).toEqual([true]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches and clears the error when the existing updated_at signal advances", async () => {
+    fetchPage.mockResolvedValueOnce(errorPage).mockResolvedValueOnce(normalPage);
+    const { wrapper } = harness();
+    const hook = renderHook(({ updated_at }) => useSessionErrors([{ ...session, updated_at }]), {
+      wrapper,
+      initialProps: { updated_at: 100 },
+    });
+    await waitFor(() => expect(hook.result.current).toEqual([true]));
+    hook.rerender({ updated_at: 101 });
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(hook.result.current).toEqual([false]));
+  });
+
+  it("does not let an older tail request resurrect an error after a newer message", async () => {
+    const old = deferredPage();
+    fetchPage.mockReturnValueOnce(old.promise).mockResolvedValueOnce(normalPage);
+    const { wrapper, client } = harness();
+    const hook = renderHook(({ updated_at }) => useSessionErrors([{ ...session, updated_at }]), {
+      wrapper,
+      initialProps: { updated_at: 100 },
+    });
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(1));
+    hook.rerender({ updated_at: 101 });
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(2));
+    await act(async () => old.resolve(errorPage));
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(hook.result.current).toEqual([false]);
+  });
+
+  it("shares one request between a row and its collapsed project marker", async () => {
+    fetchPage.mockResolvedValue(errorPage);
+    const { wrapper } = harness();
+    const hook = renderHook(() => [useSessionErrors([session]), useSessionErrors([session])], {
+      wrapper,
+    });
+    await waitFor(() => expect(hook.result.current).toEqual([[true], [true]]));
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads and subscribes to an already-loaded transcript without extra HTTP or streams", () => {
+    const entry = conversationRegistry.acquire(session.id);
+    entry.setState({
+      blocks: itemsToBlocks(errorPage.items),
+      loadingConversation: false,
+      abortController: new AbortController(),
+    });
+    const { wrapper } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    expect(hook.result.current).toEqual([true]);
+    act(() => entry.setState({ blocks: itemsToBlocks(normalPage.items) }));
+    expect(hook.result.current).toEqual([false]);
+    act(() => entry.setState({ blocks: itemsToBlocks(errorPage.items) }));
+    expect(hook.result.current).toEqual([true]);
+    act(() => entry.setState({ status: "streaming" }));
+    expect(hook.result.current).toEqual([false]);
+    expect(fetchPage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the latest item after a live transcript is evicted", async () => {
+    const entry = conversationRegistry.acquire(session.id);
+    entry.setState({
+      blocks: itemsToBlocks(errorPage.items),
+      loadingConversation: false,
+      abortController: new AbortController(),
+    });
+    const { wrapper, client } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    expect(hook.result.current).toEqual([true]);
+    act(() => conversationRegistry.release(session.id));
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(hook.result.current).toEqual([false]);
+  });
+
+  it("does not treat a dead stream's retained transcript as current", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    conversationRegistry.acquire(session.id).setState({
+      blocks: itemsToBlocks(normalPage.items),
+      loadingConversation: false,
+      abortController: controller,
+    });
+    fetchPage.mockResolvedValue(errorPage);
+    const { wrapper } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    await waitFor(() => expect(hook.result.current).toEqual([true]));
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("revalidates a superseded tail cache when the live transcript is evicted", async () => {
+    fetchPage.mockResolvedValueOnce(errorPage).mockResolvedValueOnce(normalPage);
+    const { wrapper, client } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    await waitFor(() => expect(hook.result.current).toEqual([true]));
+    act(() =>
+      conversationRegistry.acquire(session.id).setState({
+        blocks: itemsToBlocks(normalPage.items),
+        loadingConversation: false,
+        abortController: new AbortController(),
+      }),
+    );
+    expect(hook.result.current).toEqual([false]);
+    act(() => conversationRegistry.release(session.id));
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(hook.result.current).toEqual([false]);
+  });
+
+  it("does not request tails for running, failed, awaiting, or provisional rows", async () => {
+    const { wrapper } = harness();
+    renderHook(
+      () =>
+        useSessionErrors([
+          { ...session, id: "running", status: "running" },
+          { ...session, id: "failed", status: "failed" },
+          { ...session, id: "awaiting", pending_elicitations_count: 1 },
+          { ...session, id: "temp:pending" },
+          { ...session, id: "provisional", provisional: true },
+        ]),
+      { wrapper },
+    );
+    await act(async () => {});
+    expect(fetchPage).not.toHaveBeenCalled();
+  });
+
+  it("does not turn an HTTP failure into a conversation error", async () => {
+    fetchPage.mockRejectedValue(new Error("offline"));
+    const { wrapper, client } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+    expect(hook.result.current).toEqual([false]);
+  });
+
+  it("skips trailing hidden metadata with a bounded fallback", async () => {
+    fetchPage
+      .mockResolvedValueOnce({
+        items: [{ ...message("Hidden context"), is_meta: true }],
+        hasMore: true,
+      })
+      .mockResolvedValueOnce(errorPage);
+    const { wrapper } = harness();
+    const hook = renderHook(() => useSessionErrors([session]), { wrapper });
+    await waitFor(() => expect(hook.result.current).toEqual([true]));
+    expect(fetchPage).toHaveBeenLastCalledWith(session.id, {
+      olderThan: "message1",
+      limit: 8,
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("limits simultaneous unopened-session reads to two", async () => {
+    const pages = Array.from({ length: 5 }, () => deferredPage());
+    pages.forEach((page) => fetchPage.mockReturnValueOnce(page.promise));
+    const { wrapper, client } = harness();
+    renderHook(() => useSessionErrors(pages.map((_, i) => ({ ...session, id: `session${i}` }))), {
+      wrapper,
+    });
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      pages[0].resolve(normalPage);
+      pages[1].resolve(normalPage);
+    });
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(4));
+    await act(async () => {
+      pages[2].resolve(normalPage);
+      pages[3].resolve(normalPage);
+    });
+    await waitFor(() => expect(fetchPage).toHaveBeenCalledTimes(5));
+    await act(async () => pages[4].resolve(normalPage));
+    await waitFor(() => expect(client.isFetching()).toBe(0));
+  });
+});

--- a/web/src/hooks/useSessionErrors.ts
+++ b/web/src/hooks/useSessionErrors.ts
@@ -1,0 +1,123 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { useQueries, useQueryClient } from "@tanstack/react-query";
+import type { Conversation } from "./useConversations";
+import { itemsToBlocks } from "@/lib/itemsToBlocks";
+import { latestActivityIsError } from "@/lib/sessionError";
+import { fetchSessionItemsPage } from "@/lib/sessionsApi";
+import { isTempConvId } from "@/lib/tempConversationId";
+import { conversationRegistry } from "@/store/conversationRegistry";
+
+type ErrorConversation = Pick<
+  Conversation,
+  "id" | "updated_at" | "status" | "pending_elicitations_count" | "provisional"
+>;
+
+// Leave connections available for navigation and the existing chat streams.
+let activeReads = 0;
+const waitingReads: (() => void)[] = [];
+
+async function fetchLatestError(id: string, signal: AbortSignal): Promise<boolean> {
+  await new Promise<void>((resolve) => {
+    if (activeReads < 2) {
+      activeReads += 1;
+      resolve();
+    } else {
+      waitingReads.push(resolve);
+    }
+  });
+  try {
+    signal.throwIfAborted();
+    const page = await fetchSessionItemsPage(id, { limit: 1, signal });
+    const error = latestActivityIsError(itemsToBlocks(page.items));
+    if (error !== undefined || !page.hasMore) return error ?? false;
+    // A hidden metadata item may trail the last visible message. Bound the
+    // fallback instead of hydrating a whole transcript just for its badge.
+    const older = await fetchSessionItemsPage(id, {
+      olderThan: page.items[0]?.id,
+      limit: 8,
+      signal,
+    });
+    return latestActivityIsError(itemsToBlocks(older.items)) ?? false;
+  } finally {
+    const next = waitingReads.shift();
+    if (next) next();
+    else activeReads -= 1;
+  }
+}
+
+function liveError(id: string): boolean | undefined {
+  const entry = conversationRegistry.peek(id);
+  const state = entry?.getState();
+  if (
+    entry?.disposed ||
+    !state ||
+    state.loadingConversation ||
+    state.conversationLoadError !== null ||
+    state.abortController === null ||
+    state.abortController.signal.aborted
+  ) {
+    return undefined;
+  }
+  if (state.status === "streaming" || state.terminalPending) return false;
+  return latestActivityIsError(state.blocks) ?? false;
+}
+
+/** Reuse live transcripts; unopened rows share a cached, bounded tail read. */
+export function useSessionErrors(conversations: readonly ErrorConversation[]): boolean[] {
+  const queryClient = useQueryClient();
+  const subscribe = useCallback(
+    (notify: () => void) => {
+      const ids = new Set(conversations.map((c) => c.id));
+      const changed = (id: string) => {
+        if (!ids.has(id)) return;
+        if (liveError(id) === undefined) {
+          // A disposed/dead stream may have superseded a cached tail while
+          // live. Revalidate before relying on that old cache again.
+          void queryClient.invalidateQueries({
+            queryKey: ["session-latest-error", id],
+            refetchType: "none",
+          });
+        }
+        notify();
+      };
+      const unsubscribe = conversationRegistry.subscribe(changed);
+      const unsubscribeDisposed = conversationRegistry.subscribeDisposed(changed);
+      return () => {
+        unsubscribe();
+        unsubscribeDisposed();
+      };
+    },
+    [conversations, queryClient],
+  );
+  // A primitive snapshot only notifies React when an error actually changes,
+  // not on every streamed token or unrelated chat-store update.
+  const getSnapshot = useCallback(
+    () =>
+      conversations
+        .map((c) => {
+          const error = liveError(c.id);
+          return error === undefined ? "?" : error ? "1" : "0";
+        })
+        .join(""),
+    [conversations],
+  );
+  const live = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const queries = useQueries({
+    queries: conversations.map((c, i) => ({
+      // updated_at is the same freshness signal used by the unread dot and
+      // refreshed by the shared session-updates socket/list reconciliation.
+      queryKey: ["session-latest-error", c.id, c.updated_at, c.status],
+      queryFn: ({ signal }: { signal: AbortSignal }) => fetchLatestError(c.id, signal),
+      enabled:
+        live[i] === "?" &&
+        !isTempConvId(c.id) &&
+        !c.provisional &&
+        c.status !== "running" &&
+        c.status !== "failed" &&
+        (c.pending_elicitations_count ?? 0) === 0,
+      staleTime: Infinity,
+      retry: false,
+    })),
+  });
+  return queries.map((query, i) => (live[i] === "?" ? (query.data ?? false) : live[i] === "1"));
+}

--- a/web/src/hooks/useSessionErrors.ts
+++ b/web/src/hooks/useSessionErrors.ts
@@ -48,14 +48,11 @@ async function fetchLatestError(id: string, signal: AbortSignal): Promise<boolea
 function liveError(id: string): boolean | undefined {
   const entry = conversationRegistry.peek(id);
   const state = entry?.getState();
-  if (
-    entry?.disposed ||
-    !state ||
-    state.loadingConversation ||
-    state.conversationLoadError !== null ||
-    state.abortController === null ||
-    state.abortController.signal.aborted
-  ) {
+  if (entry?.disposed || !state || state.conversationLoadError !== null) return undefined;
+  // The initial history request will supply the latest message. Wait for it
+  // even before the stream controller is installed, without a second read.
+  if (state.loadingConversation) return false;
+  if (state.abortController === null || state.abortController.signal.aborted) {
     return undefined;
   }
   if (state.status === "streaming" || state.terminalPending) return false;

--- a/web/src/hooks/useSessionState.test.ts
+++ b/web/src/hooks/useSessionState.test.ts
@@ -34,11 +34,29 @@ describe("getSessionState — priority composition", () => {
     expect(getSessionState(conv({ status: "idle" }))).toBeNull();
   });
 
-  it("falls through to null when status is failed (no longer a sidebar state)", () => {
-    // status="failed" is a server-side concept that the chat surfaces
-    // with its own error UI; the sidebar deliberately does not render
-    // it. See useSessionState.ts header for rationale.
-    expect(getSessionState(conv({ status: "failed" }))).toBeNull();
+  it("flags a latest-message error even when the session has settled to idle", () => {
+    expect(getSessionState(conv({ status: "idle" }), true)).toEqual({ kind: "error" });
+  });
+
+  it("keeps running and approval states ahead of a previous message error", () => {
+    expect(getSessionState(conv({ status: "running" }), true)).toEqual({ kind: "running" });
+    expect(getSessionState(conv({ status: "idle", pending_elicitations_count: 1 }), true)).toEqual({
+      kind: "awaiting",
+      count: 1,
+    });
+  });
+
+  it("returns error from the existing failed session status", () => {
+    expect(getSessionState(conv({ status: "failed" }))).toEqual({ kind: "error" });
+  });
+
+  it("follows status updates without retaining an old error", () => {
+    const conversation = conv({ status: "failed" });
+    expect(getSessionState(conversation)).toEqual({ kind: "error" });
+    conversation.status = "running";
+    expect(getSessionState(conversation)).toEqual({ kind: "running" });
+    conversation.status = "idle";
+    expect(getSessionState(conversation)).toBeNull();
   });
 
   it("treats failed + pending elicitation as awaiting (the actionable signal)", () => {

--- a/web/src/hooks/useSessionState.ts
+++ b/web/src/hooks/useSessionState.ts
@@ -1,21 +1,20 @@
 // Per-row state derivation for the sidebar badge.
-// Priority: awaiting > running > no badge.
+// Priority: awaiting > running > error > no badge.
 //
 // Liveness (runner / host reachability) is no longer a sidebar state:
 // it surfaces in the open-session view (see `useSessionLiveness`), so the
 // sidebar no longer renders a "disconnected" badge and `getSessionState`
 // no longer reads runner liveness.
 //
-// "failed" is intentionally not a sidebar state either — the chat surface
-// is the right place to read what failed. Conflating it into the same red
-// badge also led to a stale-cache bug where a prior turn's
-// `_session_status_cache["failed"]` would mask a fresh elicitation.
+// Errors are independent of read state. Native sessions can settle to idle
+// after an error, so callers also inspect the latest conversation message.
 
 import type { Conversation } from "@/hooks/useConversations";
 
 export type SessionState =
   | { kind: "awaiting"; count: number }
   | { kind: "running" }
+  | { kind: "error" }
   | { kind: "unseen" }
   // The open session's launch/relaunch window — a send in flight or the PTY
   // being created before the server confirms `running`. Not derivable from a
@@ -25,9 +24,11 @@ export type SessionState =
 
 export function getSessionState(
   conversation: Pick<Conversation, "status" | "pending_elicitations_count"> | undefined | null,
+  latestMessageIsError = false,
 ): SessionState | null {
   const pending = conversation?.pending_elicitations_count ?? 0;
   if (pending > 0) return { kind: "awaiting", count: pending };
   if (conversation?.status === "running") return { kind: "running" };
+  if (conversation?.status === "failed" || latestMessageIsError) return { kind: "error" };
   return null;
 }

--- a/web/src/lib/sessionError.test.ts
+++ b/web/src/lib/sessionError.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { AnyBlock, BlockContext, ErrorBlock, TextDone } from "./blocks";
+import { latestActivityIsError } from "./sessionError";
+
+const ctx: BlockContext = {
+  agent: null,
+  depth: 0,
+  turn: 0,
+  timestamp: 0,
+  responseId: "r1",
+  itemId: "i1",
+};
+const error: ErrorBlock = {
+  type: "error",
+  ctx,
+  source: "execution",
+  code: "rate_limit_exceeded",
+  message: "Rate limited",
+};
+const text = (fullText: string): TextDone => ({
+  type: "text_done",
+  ctx,
+  fullText,
+  hasCodeBlocks: false,
+});
+
+describe("latestActivityIsError", () => {
+  it("recognizes structured errors and ignores info-level notices", () => {
+    expect(latestActivityIsError([error])).toBe(true);
+    expect(latestActivityIsError([{ ...error, level: "info" }])).toBe(false);
+  });
+
+  it("recognizes the native idle-session API rejection text", () => {
+    expect(
+      latestActivityIsError([
+        text(
+          "API Error: Request rejected (429) · REQUEST_LIMIT_EXCEEDED: Exceeded workspace input tokens per minute rate limit.",
+        ),
+      ]),
+    ).toBe(true);
+  });
+
+  it.each([
+    "The API Error: Request rejected (429) has been fixed.",
+    "Here is an example:\nAPI Error: Request rejected (429)",
+    "```\nAPI Error: Request rejected (429)\n```",
+    "All done.",
+  ])("does not flag normal assistant prose: %s", (message) => {
+    expect(latestActivityIsError([text(message)])).toBe(false);
+  });
+
+  it.each([
+    text("Recovered."),
+    { type: "user_message", ctx, content: [{ type: "input_text", text: "API Error: please fix" }] },
+    { type: "tool_result", ctx, callId: "call1", name: "test", output: "done", agentName: "" },
+    { ...error, level: "info" },
+  ] satisfies AnyBlock[])("clears an old error after newer $type activity", (newer) => {
+    expect(latestActivityIsError([error, newer])).toBe(false);
+  });
+
+  it("does not let a completed lifecycle marker hide the latest error", () => {
+    expect(
+      latestActivityIsError([
+        error,
+        { type: "response_end", ctx, status: "completed", response: null },
+      ]),
+    ).toBe(true);
+  });
+
+  it("detects failed response lifecycle markers", () => {
+    expect(
+      latestActivityIsError([
+        text("Partial reply"),
+        { type: "response_end", ctx, status: "failed", response: null },
+      ]),
+    ).toBe(true);
+  });
+
+  it("leaves empty/metadata-only windows unknown", () => {
+    expect(latestActivityIsError([])).toBeUndefined();
+    expect(latestActivityIsError([{ type: "compaction", ctx }])).toBeUndefined();
+  });
+});

--- a/web/src/lib/sessionError.test.ts
+++ b/web/src/lib/sessionError.test.ts
@@ -53,6 +53,20 @@ describe("latestActivityIsError", () => {
     text("Recovered."),
     { type: "user_message", ctx, content: [{ type: "input_text", text: "API Error: please fix" }] },
     { type: "tool_result", ctx, callId: "call1", name: "test", output: "done", agentName: "" },
+    { type: "policy_denied", ctx, reason: "Approval required", phase: "request" },
+    { type: "routing_decision", ctx, model: "test-model", applied: true, rationale: "Selected" },
+    {
+      type: "elicitation",
+      ctx,
+      elicitationId: "approval1",
+      message: "Continue?",
+      phase: "tool_call",
+      policyName: "approval",
+      contentPreview: "",
+      requestedSchema: {},
+      status: "responded",
+      response: { action: "accept" },
+    },
     { ...error, level: "info" },
   ] satisfies AnyBlock[])("clears an old error after newer $type activity", (newer) => {
     expect(latestActivityIsError([error, newer])).toBe(false);
@@ -76,8 +90,16 @@ describe("latestActivityIsError", () => {
     ).toBe(true);
   });
 
-  it("leaves empty/metadata-only windows unknown", () => {
+  it("leaves an empty window unknown", () => {
     expect(latestActivityIsError([])).toBeUndefined();
-    expect(latestActivityIsError([{ type: "compaction", ctx }])).toBeUndefined();
+  });
+
+  it.each([
+    { type: "compaction", ctx },
+    { type: "compaction_loading", ctx },
+    { type: "retry", ctx, source: "llm", attempt: 1, maxAttempts: 2, delaySeconds: 1 },
+  ] satisfies AnyBlock[])("skips $type bookkeeping without hiding an earlier error", (metadata) => {
+    expect(latestActivityIsError([metadata])).toBeUndefined();
+    expect(latestActivityIsError([error, metadata])).toBe(true);
   });
 });

--- a/web/src/lib/sessionError.ts
+++ b/web/src/lib/sessionError.ts
@@ -1,0 +1,33 @@
+import type { AnyBlock } from "./blocks";
+
+/** The latest visible activity, ignoring transcript bookkeeping. */
+export function latestActivityIsError(blocks: readonly AnyBlock[]): boolean | undefined {
+  for (let i = blocks.length - 1; i >= 0; i -= 1) {
+    const block = blocks[i];
+    switch (block.type) {
+      case "error":
+        return block.level !== "info";
+      case "text_done":
+        // Claude's native transcript can persist an API rejection as ordinary
+        // assistant text, without an error item or a failed session status.
+        return /^API Error:\s*\S/.test(block.fullText.trimStart());
+      case "response_end":
+        if (block.status === "failed") return true;
+        break;
+      case "response_start":
+      case "user_message":
+      case "text_chunk":
+      case "tool_group":
+      case "tool_result":
+      case "native_tool":
+      case "reasoning_start":
+      case "reasoning_chunk":
+      case "reasoning_block":
+      case "slash_command":
+      case "terminal_command":
+      case "file":
+        return false;
+    }
+  }
+  return undefined;
+}

--- a/web/src/lib/sessionError.ts
+++ b/web/src/lib/sessionError.ts
@@ -26,7 +26,18 @@ export function latestActivityIsError(blocks: readonly AnyBlock[]): boolean | un
       case "slash_command":
       case "terminal_command":
       case "file":
+      case "policy_denied":
+      case "routing_decision":
+      case "elicitation":
         return false;
+      case "retry":
+      case "compaction_loading":
+      case "compaction":
+        break;
+      default: {
+        const exhaustive: never = block;
+        return exhaustive;
+      }
     }
   }
   return undefined;

--- a/web/src/lib/sessionsApi.ts
+++ b/web/src/lib/sessionsApi.ts
@@ -1159,13 +1159,18 @@ export interface SessionItemsPage {
  */
 export async function fetchSessionItemsPage(
   sessionId: string,
-  { olderThan, limit = SESSION_HISTORY_PAGE_SIZE }: { olderThan?: string; limit?: number } = {},
+  {
+    olderThan,
+    limit = SESSION_HISTORY_PAGE_SIZE,
+    signal,
+  }: { olderThan?: string; limit?: number; signal?: AbortSignal } = {},
 ): Promise<SessionItemsPage> {
   const params = new URLSearchParams({ limit: String(limit), order: "desc" });
   // "Older than the cursor" within a descending scan = items after it.
   if (olderThan) params.set("after", olderThan);
   const res = await authenticatedFetch(
     `/v1/sessions/${encodeURIComponent(sessionId)}/items?${params}`,
+    { signal },
   );
   const page = await readJsonOrThrow<SessionItemsResponseWire>(res);
   // Server returns newest-first; reverse to chronological for rendering.

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -12,9 +12,15 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Conversation } from "@/hooks/useConversations";
+import {
+  markConversationSeen,
+  resetReadStateForTests,
+  seedReadState,
+} from "@/hooks/useUnseenConversations";
 import { FALLBACK_SERVER_INFO, type ServerInfo } from "@/lib/capabilities";
 import { clearOptimisticTitles, recordOptimisticTitle } from "@/lib/optimisticTitles";
 import { clearSessionDrafts, setSessionDraft } from "@/lib/sessionDrafts";
+import * as sessionsApi from "@/lib/sessionsApi";
 import { CapabilitiesProvider } from "@/lib/CapabilitiesContext";
 import { ExtensionCatalogProvider } from "@/extensions/ExtensionProvider";
 import type { ExtensionCatalogItem } from "@/extensions/types";
@@ -24,6 +30,7 @@ import type { ExtensionCatalogItem } from "@/extensions/types";
 // sections; moveToProjectSpy captures kebab-menu "Change project" calls.
 const {
   projectsMock,
+  projectRowsRef,
   moveToProjectSpy,
   deleteProjectSpy,
   renameProjectSpy,
@@ -35,6 +42,7 @@ const {
   useHostsMock,
 } = vi.hoisted(() => ({
   projectsMock: [] as string[],
+  projectRowsRef: { current: undefined as { id: string; name: string }[] | undefined },
   moveToProjectSpy: vi.fn(),
   deleteProjectSpy: vi.fn(),
   renameProjectSpy: vi.fn(),
@@ -114,7 +122,7 @@ vi.mock("@/hooks/useConversations", () => ({
   // Tests push project NAMES into projectsMock; expose them as first-class
   // {id, name} folders (synthetic id per name) to match useProjects' shape.
   useProjects: () => ({
-    data: projectsMock.map((name: string) => ({ id: `p_${name}`, name })),
+    data: projectRowsRef.current ?? projectsMock.map((name: string) => ({ id: `p_${name}`, name })),
   }),
   // Each project folder fetches its own sessions (server-side ?project=). Derive
   // them from the global-list fixture by label so existing tests keep seeding
@@ -280,9 +288,11 @@ beforeEach(() => {
   useHostsMock.mockReset();
   useHostsMock.mockReturnValue({ data: [] });
   localStorage.clear();
+  resetReadStateForTests();
   clearSessionDrafts();
   clearOptimisticTitles();
   projectsMock.length = 0;
+  projectRowsRef.current = undefined;
   moveToProjectSpy.mockReset();
   deleteProjectSpy.mockReset();
   fetchProjectSessionIdsMock.mockReset();
@@ -1247,6 +1257,253 @@ describe("Sidebar session list", () => {
   });
 });
 
+describe("Sidebar failed session indicator", () => {
+  function renderSessionSidebar(initialEntry = "/") {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const tree = () => {
+      const sidebar = <Sidebar open onClose={vi.fn()} />;
+      return (
+        <QueryClientProvider client={qc}>
+          <TooltipProvider>
+            <MemoryRouter initialEntries={[initialEntry]}>
+              <Routes>
+                <Route path="/c/:conversationId" element={sidebar} />
+                <Route path="*" element={sidebar} />
+              </Routes>
+            </MemoryRouter>
+          </TooltipProvider>
+        </QueryClientProvider>
+      );
+    };
+    const result = render(tree());
+    return { ...result, refresh: () => result.rerender(tree()) };
+  }
+
+  it("replaces an unread dot with the error icon and keeps it after marking read", () => {
+    const session = conv("conv_error", "Codex", {
+      status: "failed",
+      updated_at: 200,
+    });
+    seedReadState([{ id: session.id, viewer_last_seen: 199 }]);
+    mockConversations([session]);
+    renderSidebar();
+
+    const row = screen.getByRole("link", { name: /conv_error/ }).closest("li")!;
+    const badge = within(row).getByRole("img", { name: "Latest message is an error" });
+    expect(badge).toHaveAttribute("data-state", "error");
+    expect(badge.parentElement).toHaveClass("right-1", "w-6", "justify-center");
+    expect(within(row).getByText("(unread)")).toBeInTheDocument();
+    expect(within(row).queryByRole("img", { name: "New messages" })).toBeNull();
+
+    act(() => markConversationSeen(session.id, session.updated_at));
+
+    expect(within(row).queryByText("(unread)")).toBeNull();
+    expect(within(row).getByRole("img", { name: "Latest message is an error" })).toBe(badge);
+  });
+
+  it("keeps the error icon on the active, already-read session", () => {
+    const session = conv("conv_error", "Codex", {
+      status: "failed",
+      updated_at: 200,
+    });
+    seedReadState([{ id: session.id, viewer_last_seen: session.updated_at }]);
+    mockConversations([session]);
+    renderSessionSidebar(`/c/${session.id}`);
+
+    const row = screen.getByRole("link", { name: "conv_error" }).closest("li")!;
+    expect(within(row).queryByText("(unread)")).toBeNull();
+    expect(within(row).getByRole("img", { name: "Latest message is an error" })).toHaveAttribute(
+      "data-state",
+      "error",
+    );
+  });
+
+  it("updates a mounted row when only the session status changes", () => {
+    // Stable project contexts keep unrelated context updates from bypassing
+    // the row's render-field comparator.
+    projectRowsRef.current = [];
+    const session = conv("conv_error", "Codex", {
+      status: "failed",
+      updated_at: 200,
+    });
+    mockConversations([session]);
+    const { refresh } = renderSessionSidebar();
+    const row = screen.getByRole("link", { name: "conv_error" }).closest("li")!;
+    expect(within(row).getByTestId("session-state-badge")).toHaveAttribute("data-state", "error");
+
+    mockConversations([{ ...session, status: "idle" }]);
+    refresh();
+
+    expect(screen.getByRole("link", { name: "conv_error" }).closest("li")).toBe(row);
+    expect(within(row).queryByTestId("session-state-badge")).toBeNull();
+
+    mockConversations([{ ...session, status: "failed" }]);
+    refresh();
+
+    expect(screen.getByRole("link", { name: "conv_error" }).closest("li")).toBe(row);
+    expect(within(row).getByTestId("session-state-badge")).toHaveAttribute("data-state", "error");
+  });
+
+  it.each([
+    { status: "running" as const, pending: 0, expected: "running" },
+    { status: "failed" as const, pending: 2, expected: "awaiting" },
+  ])("lets $expected take precedence over a previous error", ({ status, pending, expected }) => {
+    const session = conv("conv_error", "Codex", { status: "failed" });
+    mockConversations([session]);
+    const { refresh } = renderSessionSidebar();
+    const row = screen.getByRole("link", { name: "conv_error" }).closest("li")!;
+    expect(within(row).getByTestId("session-state-badge")).toHaveAttribute("data-state", "error");
+
+    mockConversations([{ ...session, status, pending_elicitations_count: pending }]);
+    refresh();
+
+    expect(within(row).getByTestId("session-state-badge")).toHaveAttribute("data-state", expected);
+    expect(within(row).queryByRole("img", { name: "Latest message is an error" })).toBeNull();
+  });
+
+  it.each([
+    { status: "streaming" as const, terminalPending: false },
+    { status: "idle" as const, terminalPending: true },
+  ])("shows startup over a previous error for $status/$terminalPending", (startup) => {
+    const wakingId = `conv_error_retry_${startup.status}_${startup.terminalPending}`;
+    mockConversations([
+      conv(wakingId, "Codex", {
+        status: "failed",
+        updated_at: 200,
+      }),
+      conv("conv_other", "Codex", { status: "failed" }),
+    ]);
+    seedReadState([{ id: wakingId, viewer_last_seen: 199 }]);
+    useChatStore.setState({ conversationId: wakingId, ...startup });
+    renderSidebar();
+
+    const wakingRow = screen.getByRole("link", { name: new RegExp(wakingId) }).closest("li")!;
+    expect(within(wakingRow).getByTestId("session-state-badge")).toHaveAttribute(
+      "data-state",
+      "starting",
+    );
+    const otherRow = screen.getByRole("link", { name: "conv_other" }).closest("li")!;
+    expect(within(otherRow).getByTestId("session-state-badge")).toHaveAttribute(
+      "data-state",
+      "error",
+    );
+  });
+
+  it("shows the error icon on a pinned session", () => {
+    seedPins(["conv_error"]);
+    mockConversations([conv("conv_error", "Codex", { status: "failed" })]);
+    renderSidebar();
+
+    const pinnedSection = screen.getByRole("button", { name: /^Pinned/ }).closest("section")!;
+    const row = within(pinnedSection).getByRole("link", { name: "conv_error" }).closest("li")!;
+    expect(within(row).getByRole("img", { name: "Latest message is an error" })).toHaveAttribute(
+      "data-state",
+      "error",
+    );
+  });
+
+  describe.each(["regular", "pinned"] as const)("%s session error explanation", (surface) => {
+    async function openExplanation(state: "error" | "running" | "awaiting" | "starting") {
+      const id = `conv_hint_${surface}_${state}`;
+      const pinned = surface === "pinned";
+      if (pinned) {
+        projectsMock.push("Customer X");
+        seedPins([id]);
+      }
+      mockConversations([
+        conv(id, "Codex", {
+          status: state === "running" ? "running" : "failed",
+          pending_elicitations_count: state === "awaiting" ? 1 : 0,
+          labels: pinned ? { omni_project: "Customer X" } : {},
+        }),
+      ]);
+      if (state === "starting") {
+        useChatStore.setState({ conversationId: id, status: "streaming" });
+      }
+      renderSidebar();
+
+      const row = screen.getByRole("link", { name: id });
+      expect(within(row.closest("li")!).getByTestId("session-state-badge")).toHaveAttribute(
+        "data-state",
+        state,
+      );
+      if (pinned) fireEvent.focus(row);
+      else fireEvent.pointerMove(row, { pointerType: "mouse" });
+      return screen.findByTestId(pinned ? "pinned-project-flyout" : "session-tooltip-content");
+    }
+
+    it("explains the error through the row's existing hover surface", async () => {
+      const content = await openExplanation("error");
+      expect(content).toHaveTextContent("Latest message is an error");
+      const hint = content.querySelector("p.text-destructive");
+      expect(hint).toHaveTextContent("Latest message is an error");
+      expect(hint?.querySelector("svg.lucide-circle-alert")).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it.each(["running", "awaiting", "starting"] as const)(
+      "omits an old error explanation while the session is %s",
+      async (state) => {
+        const content = await openExplanation(state);
+        expect(content).not.toHaveTextContent("Latest message is an error");
+      },
+    );
+  });
+});
+
+describe("Sidebar idle latest-message error", () => {
+  beforeEach(() => {
+    vi.spyOn(sessionsApi, "fetchSessionItemsPage").mockResolvedValue({
+      items: [
+        {
+          id: "native_error",
+          response_id: "response1",
+          type: "message",
+          status: "completed",
+          role: "assistant",
+          content: [{ type: "output_text", text: "API Error: Request rejected (429)" }],
+        },
+      ],
+      hasMore: true,
+    });
+  });
+  afterEach(() => vi.mocked(sessionsApi.fetchSessionItemsPage).mockRestore());
+
+  it("shows the icon for an unopened idle session and keeps it after marking read", async () => {
+    const session = conv("conv_idle_error", "Claude Code", { status: "idle", updated_at: 200 });
+    seedReadState([{ id: session.id, viewer_last_seen: 199 }]);
+    mockConversations([session]);
+    renderSidebar();
+    const row = screen.getByRole("link", { name: /conv_idle_error/ }).closest("li")!;
+    const badge = await within(row).findByRole("img", { name: "Latest message is an error" });
+    expect(badge).toHaveAttribute("data-state", "error");
+    expect(badge.querySelector("svg")).toHaveClass("text-destructive", "size-3.5");
+    expect(within(row).getByText("(unread)")).toBeInTheDocument();
+    act(() => markConversationSeen(session.id, session.updated_at));
+    expect(within(row).queryByText("(unread)")).toBeNull();
+    expect(within(row).getByRole("img", { name: "Latest message is an error" })).toBe(badge);
+    expect(sessionsApi.fetchSessionItemsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an idle message error on a collapsed project's marker", async () => {
+    projectsMock.push("Customer X");
+    mockConversations([
+      conv("conv_idle_error", "Claude Code", {
+        status: "idle",
+        labels: { omni_project: "Customer X" },
+      }),
+    ]);
+    renderSidebar();
+    const header = screen.getByRole("button", { name: /^Customer X/ });
+    await within(header).findByRole("img", { name: "Latest message is an error" });
+    fireEvent.click(header);
+    const row = screen.getByRole("link", { name: "conv_idle_error" }).closest("li")!;
+    expect(
+      within(row).getByRole("img", { name: "Latest message is an error" }),
+    ).toBeInTheDocument();
+    expect(sessionsApi.fetchSessionItemsPage).toHaveBeenCalledTimes(1);
+  });
+});
+
 // Sidebar grouping: the viewer's own sessions ("My sessions" tab) keep the
 // Pinned / Projects / Sessions structure; sessions shared with the viewer live
 // on a separate "Shared with me" tab. "Shared" = sessions whose `owner` is
@@ -2132,6 +2389,64 @@ describe("Sidebar project sections", () => {
 // A collapsed project bubbles up its hidden rows' marker, using the same
 // SessionStateBadge a row shows. Only while collapsed.
 describe("Sidebar collapsed project marker", () => {
+  it("surfaces an error ahead of unread messages and moves it to the expanded row", () => {
+    projectsMock.push("Customer X");
+    seedReadState([{ id: "conv_unread", viewer_last_seen: 199 }]);
+    mockConversations([
+      conv("conv_error", "Codex", {
+        labels: { omni_project: "Customer X" },
+        status: "failed",
+      }),
+      conv("conv_unread", "Codex", {
+        labels: { omni_project: "Customer X" },
+        status: "idle",
+        updated_at: 200,
+      }),
+    ]);
+    renderSidebar();
+
+    const header = screen.getByRole("button", { name: /^Customer X/ });
+    expect(header).toHaveAttribute("aria-expanded", "false");
+    expect(within(header).getByRole("img", { name: "Latest message is an error" })).toHaveAttribute(
+      "data-state",
+      "error",
+    );
+
+    fireEvent.click(header);
+
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    expect(within(header).queryByTestId("session-state-badge")).toBeNull();
+    const row = screen.getByRole("link", { name: "conv_error" }).closest("li")!;
+    expect(
+      within(row).getByRole("img", { name: "Latest message is an error" }),
+    ).toBeInTheDocument();
+  });
+
+  it("prioritizes a pending approval over another session's error", () => {
+    projectsMock.push("Customer X");
+    mockConversations([
+      conv("conv_error", "Codex", {
+        labels: { omni_project: "Customer X" },
+        status: "failed",
+      }),
+      conv("conv_awaiting", "Codex", {
+        labels: { omni_project: "Customer X" },
+        pending_elicitations_count: 2,
+      }),
+    ]);
+    renderSidebar();
+
+    const header = screen.getByRole("button", { name: /^Customer X/ });
+    expect(within(header).getByTestId("session-state-badge")).toHaveAttribute(
+      "data-state",
+      "awaiting",
+    );
+    expect(
+      within(header).getByRole("img", { name: "2 approval prompts waiting" }),
+    ).toBeInTheDocument();
+    expect(within(header).queryByRole("img", { name: "Latest message is an error" })).toBeNull();
+  });
+
   it("shows the row's session-state badge on a collapsed project", () => {
     projectsMock.push("Customer X");
     mockConversations([

--- a/web/src/shell/Sidebar.test.tsx
+++ b/web/src/shell/Sidebar.test.tsx
@@ -2422,7 +2422,65 @@ describe("Sidebar collapsed project marker", () => {
     ).toBeInTheDocument();
   });
 
-  it("prioritizes a pending approval over another session's error", () => {
+  it.each(["failed", "idle"] as const)(
+    "prioritizes a running session over an unread $0 sibling",
+    (status) => {
+      projectsMock.push("Customer X");
+      seedReadState([
+        { id: "conv_other", viewer_last_seen: 199 },
+        { id: "conv_running", viewer_last_seen: 199 },
+      ]);
+      mockConversations([
+        conv("conv_other", "Codex", {
+          labels: { omni_project: "Customer X" },
+          status,
+          updated_at: 200,
+        }),
+        conv("conv_running", "Codex", {
+          labels: { omni_project: "Customer X" },
+          status: "running",
+          updated_at: 200,
+        }),
+      ]);
+      renderSidebar();
+
+      const header = screen.getByRole("button", { name: /^Customer X/ });
+      expect(within(header).getByTestId("session-state-badge")).toHaveAttribute(
+        "data-state",
+        "running",
+      );
+      expect(within(header).queryByRole("img", { name: "Latest message is an error" })).toBeNull();
+    },
+  );
+
+  it.each([
+    { status: "streaming" as const, terminalPending: false },
+    { status: "idle" as const, terminalPending: true },
+  ])("prioritizes startup over a previous error for $status/$terminalPending", (startup) => {
+    projectsMock.push("Customer X");
+    mockConversations([
+      conv("conv_error", "Codex", {
+        labels: { omni_project: "Customer X" },
+        status: "failed",
+      }),
+    ]);
+    useChatStore.setState({ conversationId: "conv_error", ...startup });
+    renderSidebar();
+
+    const header = screen.getByRole("button", { name: /^Customer X/ });
+    expect(within(header).getByTestId("session-state-badge")).toHaveAttribute(
+      "data-state",
+      "starting",
+    );
+
+    act(() => useChatStore.setState({ status: "idle", terminalPending: false }));
+    expect(within(header).getByTestId("session-state-badge")).toHaveAttribute(
+      "data-state",
+      "error",
+    );
+  });
+
+  it("prioritizes a pending approval over running and errored sessions", () => {
     projectsMock.push("Customer X");
     mockConversations([
       conv("conv_error", "Codex", {
@@ -2432,6 +2490,10 @@ describe("Sidebar collapsed project marker", () => {
       conv("conv_awaiting", "Codex", {
         labels: { omni_project: "Customer X" },
         pending_elicitations_count: 2,
+      }),
+      conv("conv_running", "Codex", {
+        labels: { omni_project: "Customer X" },
+        status: "running",
       }),
     ]);
     renderSidebar();

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -1422,7 +1422,10 @@ function ProjectFolder({
     );
   }, [query.data, windowConversations, pinnedSet, activeOverride, frozenSortKeys]);
   const errors = useSessionErrors(conversations);
-  const marker = projectMarkerState(conversations, errors);
+  const startingConversationId = useChatStore((s) =>
+    s.status === "streaming" || s.terminalPending ? s.conversationId : null,
+  );
+  const marker = projectMarkerState(conversations, errors, startingConversationId);
 
   // Publish the folder's rendered rows upward so projects-scope bulk selection
   // resolves them (the parent sources its action set from these, not the global
@@ -2462,27 +2465,32 @@ function UngroupDropZone() {
 function projectMarkerState(
   conversations: Conversation[],
   errors: readonly boolean[],
+  startingConversationId: string | null,
 ): SessionState | null {
   let awaiting = 0;
+  let running = false;
+  let starting = false;
   let error = false;
   let unseen = false;
-  let running = false;
   for (const [i, c] of conversations.entries()) {
     const state = getSessionState(c, errors[i]);
     if (state?.kind === "awaiting") {
       awaiting += state.count;
+    } else if (state?.kind === "running") {
+      running = true;
+    } else if (c.id === startingConversationId) {
+      starting = true;
     } else if (state?.kind === "error") {
       error = true;
     } else if (isConversationUnseen(c.id, c.updated_at, c.status)) {
       unseen = true;
-    } else if (state?.kind === "running") {
-      running = true;
     }
   }
   if (awaiting > 0) return { kind: "awaiting", count: awaiting };
+  if (running) return { kind: "running" };
+  if (starting) return { kind: "starting" };
   if (error) return { kind: "error" };
   if (unseen) return { kind: "unseen" };
-  if (running) return { kind: "running" };
   return null;
 }
 

--- a/web/src/shell/Sidebar.tsx
+++ b/web/src/shell/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   ClockIcon,
+  CircleAlertIcon,
   CircleStopIcon,
   FolderIcon,
   FolderInputIcon,
@@ -158,6 +159,7 @@ import { isImeCompositionKeyEvent } from "@/lib/ime";
 import { useHasSessionDraft } from "@/lib/sessionDrafts";
 import { useOptimisticTitle } from "@/lib/optimisticTitles";
 import { getSessionState, type SessionState } from "@/hooks/useSessionState";
+import { useSessionErrors } from "@/hooks/useSessionErrors";
 import { useChatStore } from "@/store/chatStore";
 import {
   isConversationUnseen,
@@ -1353,7 +1355,6 @@ function ProjectFolder({
   activeConversationId,
   expanded,
   active,
-  marker,
   onToggleCollapsed,
   pinnedConversationIds,
   activeOverride,
@@ -1383,7 +1384,6 @@ function ProjectFolder({
   expanded: boolean;
   /** Whether the new-session composer is currently scoped to this project. */
   active: boolean;
-  marker: SessionState | null;
   onToggleCollapsed: () => void;
   pinnedConversationIds: string[];
   activeOverride: ActiveChatOverride | null;
@@ -1421,6 +1421,8 @@ function ProjectFolder({
       frozenSortKeys,
     );
   }, [query.data, windowConversations, pinnedSet, activeOverride, frozenSortKeys]);
+  const errors = useSessionErrors(conversations);
+  const marker = projectMarkerState(conversations, errors);
 
   // Publish the folder's rendered rows upward so projects-scope bulk selection
   // resolves them (the parent sources its action set from these, not the global
@@ -2247,9 +2249,6 @@ function ConversationList({
                       activeConversationId={displayedActiveId}
                       expanded={expandedProjects.includes(group.name)}
                       active={newSessionProjectName === group.name}
-                      // Best-effort marker from the globally-loaded window: a
-                      // collapsed folder hasn't fetched its own sessions yet.
-                      marker={projectMarkerState(group.conversations)}
                       onToggleCollapsed={() => toggleProjectExpanded(group.name)}
                       pinnedConversationIds={pinnedConversationIds}
                       activeOverride={activeOverride}
@@ -2459,27 +2458,29 @@ function UngroupDropZone() {
   );
 }
 
-/**
- * Aggregate the sidebar marker for a project from its conversations, using
- * the same precedence a row uses (awaiting > unseen > running). Returned as a
- * {@link SessionState} so a collapsed project header can render the exact
- * same {@link SessionStateBadge} the rows do. ``null`` = no marker.
- */
-function projectMarkerState(conversations: Conversation[]): SessionState | null {
+/** Surface the most actionable state across a collapsed project's loaded rows. */
+function projectMarkerState(
+  conversations: Conversation[],
+  errors: readonly boolean[],
+): SessionState | null {
   let awaiting = 0;
+  let error = false;
   let unseen = false;
   let running = false;
-  for (const c of conversations) {
-    const pending = c.pending_elicitations_count ?? 0;
-    if (pending > 0) {
-      awaiting += pending;
+  for (const [i, c] of conversations.entries()) {
+    const state = getSessionState(c, errors[i]);
+    if (state?.kind === "awaiting") {
+      awaiting += state.count;
+    } else if (state?.kind === "error") {
+      error = true;
     } else if (isConversationUnseen(c.id, c.updated_at, c.status)) {
       unseen = true;
-    } else if (c.status === "running") {
+    } else if (state?.kind === "running") {
       running = true;
     }
   }
   if (awaiting > 0) return { kind: "awaiting", count: awaiting };
+  if (error) return { kind: "error" };
   if (unseen) return { kind: "unseen" };
   if (running) return { kind: "running" };
   return null;
@@ -3434,12 +3435,23 @@ function ConversationMenuItems({
   );
 }
 
+function SessionErrorHint() {
+  return (
+    <p className="mt-1 flex items-center gap-1.5 text-sm text-destructive">
+      <CircleAlertIcon aria-hidden className="size-3.5 shrink-0" />
+      <span>Latest message is an error</span>
+    </p>
+  );
+}
+
 function SessionTooltipContent({
   conversation,
   hostsById,
+  hasError,
 }: {
   conversation: Conversation;
   hostsById: ReadonlyMap<string, Host>;
+  hasError: boolean;
 }) {
   const host = conversation.host_id ? hostsById.get(conversation.host_id) : undefined;
   const locationLabel = !conversation.host_id
@@ -3481,6 +3493,7 @@ function SessionTooltipContent({
           <span className="truncate">{conversation.git_branch}</span>
         </p>
       )}
+      {hasError && <SessionErrorHint />}
     </TooltipContent>
   );
 }
@@ -3661,11 +3674,10 @@ function ConversationRowImpl({
   const hasUnseenMessages = readState.unseen && (!isActive || readState.explicitlyUnread);
   // "Mark as unread" is offered on any row not already showing the dot.
   const canMarkUnread = !hasUnseenMessages;
-  // Badge precedence: a pending approval ("Needs response") outranks the
-  // unread dot — a session that's both unread and awaiting input should
-  // surface the actionable approval tag. The row still renders bold (the
-  // unread signal) via `hasUnseenMessages` below.
-  const derivedState = getSessionState(conversation);
+  // Approvals and failures outrank the unread dot without clearing read state.
+  const errorConversations = useMemo(() => [conversation], [conversation]);
+  const [latestMessageIsError] = useSessionErrors(errorConversations);
+  const derivedState = getSessionState(conversation, latestMessageIsError);
   // The bound session's launch/relaunch window: a send is in flight (local
   // status "streaming") or the runner is auto-creating the PTY
   // (`terminalPending`), but the server hasn't confirmed `running` yet — a
@@ -3677,11 +3689,11 @@ function ConversationRowImpl({
     (s) => s.conversationId === conversation.id && (s.status === "streaming" || s.terminalPending),
   );
   const sessionState =
-    derivedState?.kind === "awaiting"
+    derivedState?.kind === "awaiting" || derivedState?.kind === "running"
       ? derivedState
-      : hasUnseenMessages
-        ? { kind: "unseen" as const }
-        : (derivedState ?? (isStartingUp ? { kind: "starting" as const } : null));
+      : isStartingUp
+        ? { kind: "starting" as const }
+        : (derivedState ?? (hasUnseenMessages ? { kind: "unseen" as const } : null));
   // Drafts share the row's trailing indicator slot, but the active session's
   // composer already makes its draft visible. Live session state wins while
   // present; otherwise only an inactive row needs the draft marker.
@@ -3985,6 +3997,7 @@ function ConversationRowImpl({
               projectName={projectFlyoutName}
               projectIcon={projectFlyoutIcon}
               gitBranch={gitBranch}
+              hasError={sessionState?.kind === "error"}
             />
           </HoverCard>
         ) : isMobile ? (
@@ -3992,7 +4005,11 @@ function ConversationRowImpl({
         ) : (
           <Tooltip>
             <TooltipTrigger asChild>{rowLink}</TooltipTrigger>
-            <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
+            <SessionTooltipContent
+              conversation={conversation}
+              hostsById={hostsById}
+              hasError={sessionState?.kind === "error"}
+            />
           </Tooltip>
         )
       ) : projectFlyoutName ? (
@@ -4014,6 +4031,7 @@ function ConversationRowImpl({
             projectName={projectFlyoutName}
             projectIcon={projectFlyoutIcon}
             gitBranch={gitBranch}
+            hasError={sessionState?.kind === "error"}
           />
         </HoverCard>
       ) : isMobile ? (
@@ -4043,7 +4061,11 @@ function ConversationRowImpl({
               />
             </ContextMenuContent>
           </ContextMenu>
-          <SessionTooltipContent conversation={conversation} hostsById={hostsById} />
+          <SessionTooltipContent
+            conversation={conversation}
+            hostsById={hostsById}
+            hasError={sessionState?.kind === "error"}
+          />
         </Tooltip>
       )}
       {selectionMode ? (
@@ -4466,11 +4488,13 @@ function PinnedProjectFlyoutContent({
   projectName,
   projectIcon,
   gitBranch,
+  hasError,
 }: {
   title: string;
   projectName: string;
   projectIcon: string | null;
   gitBranch: string | null;
+  hasError: boolean;
 }) {
   return (
     <HoverCardContent
@@ -4497,6 +4521,7 @@ function PinnedProjectFlyoutContent({
           <span className="truncate">{gitBranch}</span>
         </p>
       )}
+      {hasError && <SessionErrorHint />}
     </HoverCardContent>
   );
 }


### PR DESCRIPTION
## Related issue

Closes #7250

## Summary

- Show a 14px Lucide CircleAlert in the sidebar's existing status slot, using the same theme-aware red as the chat error text.
- Detect structured errors and native API-rejection replies even when the session is idle. Reuse live chat state and cached, bounded reads from the existing items API, refreshed by the existing session-update timestamp. No backend or schema changes.
- Preserve the error after reading/reloading; prioritize approvals, running, and startup over old errors, and errors over the unread dot. Include collapsed project markers and hover explanations.

ELI5: “Idle” means the agent stopped working, not that its last reply succeeded. The sidebar now distinguishes a failed reply from an ordinary unread message.

```mermaid
flowchart LR
  Updates[Existing session updates] --> Tail[Cached latest-item check]
  Chat[Loaded chat transcript] --> Badge[Sidebar status badge]
  Tail --> Badge
```

## Test Plan

- Pre-commit passed, including TypeScript, oxlint, formatting, and test-quality checks; production build passed.
- 291 focused frontend tests passed, covering sidebar integration, collapsed-project priority, message classification (including policy/routing activity and bookkeeping), live updates, cache reuse/eviction, request races/concurrency, read state, and session-update wiring.
- All 11 targeted browser tests passed: `uv run --no-sync python -m pytest tests/e2e_ui/sessions/test_sidebar_session_error.py tests/e2e_ui/chat/test_initial_history_loading.py tests/e2e_ui/mobile/test_touch_drag_bounded_history_paging.py -q`. Opening a session still issues exactly one history request; scrolling and touch paging remain bounded.
- Manual check: open a session whose latest reply is an error (including an idle native session). Confirm its red sidebar icon survives opening, marking read, and reloading; newer normal activity clears it. Check light/dark colors and precedence over the unread dot.
- Collapse a project containing both running and errored sessions: its running indicator takes priority. A pending approval still wins; startup also takes priority over an old error.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Synthetic sessions: “Weekly report” is idle with a latest-message error (red CircleAlert); “Release notes” has an ordinary unread reply (pink dot).

Light theme:

![Light theme: error icon matches the chat error text](https://github.com/user-attachments/assets/46a0da3c-62a5-49b6-9320-6ac3a8dc3d61)

Dark theme:

![Dark theme: error icon matches the chat error text](https://github.com/user-attachments/assets/3088152d-4780-4c4b-bac8-28019ddb7881)

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Verified two real idle native sessions through the local frontend proxy, both before opening and after reload, in light and dark mode. Browser tests also verify exact icon/error-headline color equality, read-state independence, neutral notices, and successful recovery. Demo images use synthetic test sessions and contain no real session details.

## Changelog

Sessions whose latest message is an error now show a red alert icon in the sidebar.
