### PR TITLE
fix(web): stabilize the composer model label spelling

### DIFF
--- a/web/src/lib/codexNativeModels.ts
+++ b/web/src/lib/codexNativeModels.ts
@@ -30,6 +30,29 @@ function comparableModelId(model: string | null | undefined): string {
 }
 
 /**
+ * Display fold: drop the gateway catalog prefix (`system.ai.` / `databricks-`)
+ * and the `[1m]` context-variant suffix, keeping the rest of the id verbatim.
+ *
+ * Unlike {@link comparableModelId} this preserves dots and case, so it stays a
+ * readable label (`gpt-5.6`, not `gpt-5-6`). The composer's model chip folds
+ * through here so a model's two spellings (the fully-qualified launch id
+ * `system.ai.claude-opus-5[1m]` and the harness's bare report `claude-opus-5`)
+ * render as one stable label instead of flickering as the events carrying each
+ * interleave. The `[1m]` capacity still shows in the context ring, which reads
+ * the stable `contextWindow` field, so folding it off the label hides nothing.
+ */
+export function displayModelId(model: string): string {
+  let bare = model.trim();
+  for (const prefix of CATALOG_PREFIXES) {
+    if (bare.toLowerCase().startsWith(prefix)) {
+      bare = bare.slice(prefix.length);
+      break;
+    }
+  }
+  return bare.toLowerCase().endsWith("[1m]") ? bare.slice(0, -"[1m]".length) : bare;
+}
+
+/**
  * Find a native picker option by its UI alias or provider-facing model id.
  *
  * Falls back to comparing folded spellings so a session bound to a catalog id

--- a/web/src/pages/ChatPage.statusLine.test.tsx
+++ b/web/src/pages/ChatPage.statusLine.test.tsx
@@ -76,7 +76,12 @@ vi.mock("@/lib/agentLabels", async (importOriginal) => ({
 }));
 
 import { BRAIN_HARNESS_LABELS } from "@/lib/agentLabels";
-import { Composer, composerHarnessLabel, formatModelEffortStatusLabel } from "./ChatPage";
+import {
+  Composer,
+  composerHarnessLabel,
+  formatModelEffortStatusLabel,
+  formatStatusModelLabel,
+} from "./ChatPage";
 
 // Pins the visibility rules for the status-line tray under the composer:
 // it shows the worktree branch (truncated so the tray never wraps), current
@@ -486,11 +491,17 @@ describe("formatModelEffortStatusLabel", () => {
     ).toBe("codex says GPT-5.5 xHigh");
   });
 
-  it("leaves unknown model ids raw", () => {
+  it("leaves an unprefixed unknown id as-is", () => {
     expect(formatModelEffortStatusLabel("gpt-5.5", "xhigh")).toBe("gpt-5.5 xHigh");
-    expect(formatModelEffortStatusLabel("databricks-gpt-5-5", "xhigh")).toBe(
-      "databricks-gpt-5-5 xHigh",
-    );
+  });
+
+  it("folds a catalog id's gateway prefix and [1m] suffix so the chip can't flicker", () => {
+    // The fully-qualified launch id and the harness's bare report are the same
+    // model in two spellings; both must render identically or the composer chip
+    // flickers between them as the events carrying each interleave.
+    expect(formatStatusModelLabel("system.ai.claude-opus-5[1m]")).toBe("claude-opus-5");
+    expect(formatStatusModelLabel("claude-opus-5")).toBe("claude-opus-5");
+    expect(formatModelEffortStatusLabel("databricks-gpt-5-5", "xhigh")).toBe("gpt-5-5 xHigh");
   });
 
   it("prefers the catalog display name for a Claude [1m] alias", () => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -89,7 +89,11 @@ import {
 } from "@/lib/permissionsApi";
 import { getCurrentAuthorId } from "@/lib/identity";
 import { retrySession } from "@/lib/sessionsApi";
-import { codexEffortLevelsForModel, findNativeModelOption } from "@/lib/codexNativeModels";
+import {
+  codexEffortLevelsForModel,
+  displayModelId,
+  findNativeModelOption,
+} from "@/lib/codexNativeModels";
 import { modelConfigurationSourceRows } from "@/lib/modelConfigurationSource";
 import {
   composerAttachmentKey,
@@ -2083,8 +2087,8 @@ function ContextRing({ contextWindow, tokensUsed }: { contextWindow: number; tok
  * @param codexModelOptions - Native model metadata, when available.
  * @returns The advertised display label for known native models, a
  *   version-agnostic friendly form for an alias-shaped id the catalog
- *   doesn't list, the raw model id otherwise, or ``null`` when no model
- *   is known.
+ *   doesn't list, the catalog-folded id (gateway prefix and ``[1m]`` suffix
+ *   dropped) otherwise, or ``null`` when no model is known.
  */
 export function formatStatusModelLabel(
   model: string | null,
@@ -2108,7 +2112,13 @@ export function formatStatusModelLabel(
     if (alias[3]) label += " (1M context)";
     return label;
   }
-  return raw;
+  // A catalog-shaped id with no catalog row (an SDK/bundle session, or the
+  // pre-catalog window): fold off the gateway prefix and `[1m]` suffix so the
+  // chip is spelling-stable no matter which field or event fed it. The launch
+  // id `system.ai.claude-opus-5[1m]` and the harness's bare report
+  // `claude-opus-5` then collapse to one label instead of flickering between
+  // them.
+  return displayModelId(raw) || raw;
 }
 
 function formatStatusEffortLabel(effort: string | null): string | null {


### PR DESCRIPTION
## Related issue

<!-- No tracking issue; reported directly. This is a self-contained UI bug fix. -->

Closes #

## Summary

The read-only model label under the composer flickered between two spellings of
the *same* model, e.g. `system.ai.claude-opus-5[1m]` and `claude-opus-5`.

- The label reads `sessionModelOverride ?? llmModel` (via `formatStatusModelLabel`),
  and those store fields are written by two different event streams that each
  keep the model's spelling verbatim: the fully-qualified launch / override id
  (`system.ai.claude-opus-5[1m]`) and the harness's own bare report
  (`claude-opus-5`). Whichever event landed most recently won the render, so as
  session snapshots and live model reports interleaved, the chip alternated.
- Fix: in `formatStatusModelLabel`'s no-catalog fall-through, fold the id through
  a new `displayModelId()` that drops the `system.ai.` / `databricks-` gateway
  prefix and the `[1m]` suffix. Both spellings now collapse to one stable label.
- The `[1m]` (1M context) capacity is still surfaced by the context ring, which
  reads the stable `contextWindow` field, so folding it off the label hides
  nothing.

ELI5: the chip was being handed the same model under two different names and kept
repainting with whichever name arrived last. Now we always shorten to one name.

## Test Plan

- `cd web && npx vitest run src/pages/ChatPage.statusLine.test.tsx -t formatModelEffortStatusLabel`
  (runs in CI; the web toolchain was not installed in my worktree).
- Added a unit test asserting the two spellings of the same model both render as
  `claude-opus-5`, and that a `databricks-`-prefixed id folds to its bare label.
- Verified the fold logic and the preserved alias behavior (`sonnet[1m]` still
  renders "Sonnet (1M context)") with a standalone assertion run.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

The bug is a temporal flicker (the label changing over time), which a static
screenshot cannot show, and I could not capture the running app in this
environment. The unit test pins the invariant instead: both spellings map to one
label. A reviewer can confirm live by watching the composer chip on an opus-5
session, which should now stay `claude-opus-5`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [ ] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The web vitest suite is a CI gate; it could not run locally because the fresh
worktree had no web `node_modules` (and symlinking the main checkout's is a known
store-corruption hazard). The updated unit test covers the fold at the display
boundary, which is where every session type's model label is produced.

## Changelog

The model shown under the composer no longer flickers between two spellings of the same model.

This pull request and its description were written by Isaac.
