### PR TITLE
feat(host,server): provider CRUD + per-agent provider/model pins on hosts (config control plane, part 1)

### DIFF
--- a/omnigent/host/connect.py
+++ b/omnigent/host/connect.py
@@ -77,6 +77,8 @@ from omnigent.host.frames import (
     HostListWorktreesResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
+    HostProviderOpFrame,
+    HostProviderOpResultFrame,
     HostRemoveWorktreeFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
@@ -92,6 +94,8 @@ from omnigent.host.frames import (
     encode_host_frame,
     workspace_missing_message,
 )
+
+from omnigent.host.provider_ops import run_provider_op
 from omnigent.host.git_worktree import (
     WorktreeError,
     create_worktree,
@@ -3084,6 +3088,43 @@ class HostProcess:
             return r.github_pr_diff(session_id, cast("str | None", params.get("pr_url")))
         raise ValueError(f"unknown fs op: {op!r}")
 
+    def _handle_provider_op(self, frame: HostProviderOpFrame) -> HostProviderOpResultFrame:
+        """Run one provider / agent-pin operation on THIS machine.
+
+        The config-control-plane workhorse behind the server's
+        ``/v1/hosts/{id}/providers*`` and ``/v1/hosts/{id}/agents/{name}/pin``
+        routes: validates and mutates this host's ``~/.omnigent/config.yaml``
+        and ``~/.omnigent/agents/`` specs through the shared, non-interactive
+        core in :mod:`omnigent.host.provider_ops` — the same parser the CLI
+        and runtime use, so a file this writes is one every turn accepts.
+        Secrets never appear in the result payload; errors map to the frame's
+        ``error_status``/``error_code`` fields for the panel to render.
+        File I/O runs off the event loop (caller wraps in ``to_thread``).
+
+        :param frame: The op request — ``frame.op`` selects the operation,
+            ``frame.params`` carries its arguments.
+        :returns: Result with ``status`` ``"ok"`` plus the op payload, or
+            ``"failed"`` with a non-secret error description.
+        """
+        try:
+            payload = run_provider_op(frame.op, frame.params)
+        except _OmnigentError as exc:
+            return HostProviderOpResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=str(exc),
+                error_code=getattr(exc, "code", None),
+                error_status=exc.http_status if hasattr(exc, "http_status") else None,
+            )
+        except (OSError, ValueError) as exc:
+            return HostProviderOpResultFrame(
+                request_id=frame.request_id,
+                status="failed",
+                error=f"{type(exc).__name__}: {exc}",
+                error_status=500,
+            )
+        return HostProviderOpResultFrame(request_id=frame.request_id, status="ok", payload=payload)
+
     def _handle_fs_write(self, frame: HostFsWriteFrame) -> HostFsResultFrame:
         """Serve a workspace-mutating op from the host (runner-offline fallback).
 
@@ -4243,6 +4284,11 @@ class HostProcess:
                     error=f"model options resolution crashed for {frame.harness!r}",
                 )
             await ws.send(encode_host_frame(options_result))
+        elif isinstance(frame, HostProviderOpFrame):
+            # Config writes touch config.yaml / agent specs on disk, so run
+            # the op off the event loop and reply when it completes.
+            provider_result = await asyncio.to_thread(self._handle_provider_op, frame)
+            await ws.send(encode_host_frame(provider_result))
         elif isinstance(frame, (HostImportLocalFrame, HostImportLocalByIdFrame)):
             # Streams one host.import_local_session per session (reads run off the
             # event loop inside), then a terminal host.import_local_done.

--- a/omnigent/host/frames.py
+++ b/omnigent/host/frames.py
@@ -120,6 +120,8 @@ class HostFrameKind(str, Enum):
     FS_WRITE_REQUEST = "host.fs_write_request"
     MODEL_OPTIONS = "host.model_options"
     MODEL_OPTIONS_RESULT = "host.model_options_result"
+    PROVIDER_OP = "host.provider_op"
+    PROVIDER_OP_RESULT = "host.provider_op_result"
     IMPORT_LOCAL = "host.import_local"
     IMPORT_LOCAL_BY_ID = "host.import_local_by_id"
     IMPORT_LOCAL_SESSION = "host.import_local_session"
@@ -951,6 +953,49 @@ class HostModelOptionsResultFrame:
 
 
 @dataclass
+class HostProviderOpFrame:
+    """Server → host: run one provider / agent-pin operation on that machine.
+
+    The generic op + params shape mirrors ``host.fs_request``: one frame
+    pair serves every config-control-plane operation — provider CRUD and
+    endpoint probes on the host's own ``~/.omnigent/config.yaml``, plus
+    per-agent provider/model pins on the host's ``~/.omnigent/agents/``
+    specs — without a frame kind per verb.
+
+    :param op: One of ``"providers_list"``, ``"provider_upsert"``,
+        ``"provider_delete"``, ``"provider_test"``, ``"agents_list"``,
+        ``"agent_pin_set"``, ``"agent_pin_clear"``.
+    :param params: Op-specific JSON arguments (the provider entry, the
+        agent name, the pin fields), interpreted by the host's op
+        handler. Params carrying secrets do so by the user's choice
+        (an inline ``api_key``), matching what ``config.yaml`` may
+        already hold; results never echo secret values back.
+    """
+
+    request_id: str
+    op: str
+    params: _JsonObject = field(default_factory=dict)
+
+
+@dataclass
+class HostProviderOpResultFrame:
+    """Host → server: outcome of one provider / agent-pin operation.
+
+    Mirrors ``host.fs_result``: ``payload`` carries the op-specific
+    result (credential *references* and source descriptors only — never
+    a resolved plaintext secret), and the ``error*`` fields carry the
+    failure classification when ``status`` is not ``"ok"``.
+    """
+
+    request_id: str
+    status: str
+    payload: _JsonObject | None = None
+    error_status: int | None = None
+    error_code: str | None = None
+    error: str | None = None
+
+
+@dataclass
 class HostImportedLocalSession:
     """One local transcript the host read, normalized for import.
 
@@ -1073,6 +1118,8 @@ HostFrame = (
     | HostFsWriteFrame
     | HostModelOptionsFrame
     | HostModelOptionsResultFrame
+    | HostProviderOpFrame
+    | HostProviderOpResultFrame
     | HostImportLocalFrame
     | HostImportLocalByIdFrame
     | HostImportLocalSessionFrame
@@ -1451,6 +1498,27 @@ def encode_host_frame(frame: HostFrame) -> str:
                 "routable_models": frame.routable_models,
             }
         )
+    if isinstance(frame, HostProviderOpFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.PROVIDER_OP.value,
+                "request_id": frame.request_id,
+                "op": frame.op,
+                "params": frame.params,
+            }
+        )
+    if isinstance(frame, HostProviderOpResultFrame):
+        return _encode_payload(
+            {
+                "kind": HostFrameKind.PROVIDER_OP_RESULT.value,
+                "request_id": frame.request_id,
+                "status": frame.status,
+                "payload": frame.payload,
+                "error_status": frame.error_status,
+                "error_code": frame.error_code,
+                "error": frame.error,
+            }
+        )
     if isinstance(frame, HostImportLocalFrame):
         return _encode_payload(
             {
@@ -1625,6 +1693,10 @@ def _decode_known_host_frame(
             return _decode_model_options(msg)
         case HostFrameKind.MODEL_OPTIONS_RESULT:
             return _decode_model_options_result(msg)
+        case HostFrameKind.PROVIDER_OP:
+            return _decode_provider_op(msg)
+        case HostFrameKind.PROVIDER_OP_RESULT:
+            return _decode_provider_op_result(msg)
         case HostFrameKind.IMPORT_LOCAL:
             return _decode_import_local(msg)
         case HostFrameKind.IMPORT_LOCAL_BY_ID:
@@ -2175,6 +2247,36 @@ def _decode_model_options_result(msg: _JsonObject) -> HostModelOptionsResultFram
         models=models,
         error=_optional_nullable_str(msg, "error"),
         routable_models=routable,
+    )
+
+
+def _decode_provider_op(msg: _JsonObject) -> HostProviderOpFrame:
+    """Decode a host.provider_op request frame."""
+    params = msg.get("params", {})
+    if not isinstance(params, dict):
+        raise ValueError("frame field must be a JSON object: 'params'")
+    return HostProviderOpFrame(
+        request_id=_required_str(msg, "request_id"),
+        op=_required_str(msg, "op"),
+        params=params,
+    )
+
+
+def _decode_provider_op_result(msg: _JsonObject) -> HostProviderOpResultFrame:
+    """Decode a host.provider_op_result frame."""
+    payload = msg.get("payload")
+    if payload is not None and not isinstance(payload, dict):
+        raise ValueError("frame field must be a JSON object: 'payload'")
+    error_status = msg.get("error_status")
+    if error_status is not None and not isinstance(error_status, int):
+        raise ValueError("frame field must be an integer: 'error_status'")
+    return HostProviderOpResultFrame(
+        request_id=_required_str(msg, "request_id"),
+        status=_required_str(msg, "status"),
+        payload=payload,
+        error_status=error_status,
+        error_code=_optional_nullable_str(msg, "error_code"),
+        error=_optional_nullable_str(msg, "error"),
     )
 
 

--- a/omnigent/host/provider_ops.py
+++ b/omnigent/host/provider_ops.py
@@ -41,7 +41,7 @@ from omnigent.onboarding.provider_config import (
     _VALID_FAMILIES,
     _config_path,
     _parse_provider,
-    resolve_secret,
+    credential_for_block,
 )
 
 _logger = logging.getLogger(__name__)
@@ -249,9 +249,9 @@ def provider_delete(name: str, config_path: str | None = None) -> dict[str, Any]
 def provider_test(name: str, config_path: str | None = None) -> dict[str, Any]:
     """Probe a provider's endpoint with its own credential.
 
-    Resolves the credential exactly as a turn would (:func:`resolve_secret`
-    for ``api_key_ref``, ``$VAR`` expansion for inline keys, subcommand
-    execution for ``auth_command``) and issues one authenticated
+    Resolves the credential exactly as a turn would
+    (:func:`credential_for_block` for ``api_key_ref`` and inline keys,
+    subcommand execution for ``auth_command``) and issues one authenticated
     ``GET {base_url}/models``. The credential value is sent only to the
     provider's own ``base_url`` and is never included in the result.
 
@@ -295,12 +295,8 @@ def provider_test(name: str, config_path: str | None = None) -> dict[str, Any]:
             code=ErrorCode.INVALID_INPUT,
         )
 
-    secret: str | None = None
-    if isinstance(block.get("api_key_ref"), str):
-        secret = resolve_secret(block["api_key_ref"])
-    elif isinstance(block.get("api_key"), str):
-        secret = resolve_secret(block["api_key"])
-    elif isinstance(block.get("auth_command"), str):
+    secret: str | None = credential_for_block(block)
+    if secret is None and isinstance(block.get("auth_command"), str):
         proc = subprocess.run(
             block["auth_command"], shell=True, capture_output=True, text=True, timeout=15
         )

--- a/omnigent/host/provider_ops.py
+++ b/omnigent/host/provider_ops.py
@@ -29,17 +29,18 @@ import os
 import shutil
 import subprocess
 import time
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 import httpx
 import yaml
 
 from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.onboarding.provider_config import (
+    _VALID_FAMILIES,
     _config_path,
     _parse_provider,
-    _VALID_FAMILIES,
     resolve_secret,
 )
 
@@ -184,7 +185,9 @@ def providers_list(config_path: str | None = None) -> dict[str, Any]:
     return {"providers": entries, "config_path": config_path or _config_path()}
 
 
-def provider_upsert(name: str, entry: Mapping[str, Any], config_path: str | None = None) -> dict[str, Any]:
+def provider_upsert(
+    name: str, entry: Mapping[str, Any], config_path: str | None = None
+) -> dict[str, Any]:
     """Insert or replace one provider entry after full validation.
 
     The whole entry is replaced (no field-level merge): the panel edits a
@@ -236,7 +239,11 @@ def provider_delete(name: str, config_path: str | None = None) -> dict[str, Any]
     removed = providers.pop(name)
     backup = _write_config(config, config_path)
     _logger.info("provider %r deleted via control plane (backup %s)", name, backup or "n/a")
-    return {"name": name, "removed": _redact_entry(name, removed) if isinstance(removed, dict) else None, "backup": backup}
+    return {
+        "name": name,
+        "removed": _redact_entry(name, removed) if isinstance(removed, dict) else None,
+        "backup": backup,
+    }
 
 
 def provider_test(name: str, config_path: str | None = None) -> dict[str, Any]:
@@ -564,14 +571,14 @@ def agent_pin_clear(
 # exist for tests (which call the functions directly) and for future
 # in-process callers under the same trust boundary.
 _PROVIDER_OPS = {
-    "providers_list": lambda params: providers_list(),
+    "providers_list": lambda _params: providers_list(),
     "provider_upsert": lambda params: provider_upsert(
         params.get("name"),
         params.get("entry") if isinstance(params.get("entry"), dict) else {},
     ),
     "provider_delete": lambda params: provider_delete(params.get("name")),
     "provider_test": lambda params: provider_test(params.get("name")),
-    "agents_list": lambda params: agents_list(),
+    "agents_list": lambda _params: agents_list(),
     "agent_pin_set": lambda params: agent_pin_set(
         params.get("agent"),
         provider=params.get("provider") if isinstance(params.get("provider"), str) else None,

--- a/omnigent/host/provider_ops.py
+++ b/omnigent/host/provider_ops.py
@@ -1,0 +1,602 @@
+"""Host-side provider and agent-pin operations for the config control plane.
+
+Implements the operations behind the ``host.provider_op`` frame: provider
+CRUD and endpoint probes against this machine's ``~/.omnigent/config.yaml``,
+plus per-agent provider/model pins against the agent specs under
+``~/.omnigent/agents/``. The server's ``/v1/hosts/{id}/providers*`` and
+``/v1/hosts/{id}/agents/{name}/pin`` routes drive these remotely (issue
+omnigent-ai/omnigent#7134); nothing here trusts the wire for validation —
+every mutation re-runs the same parser the CLI and runtime use
+(:func:`omnigent.onboarding.provider_config._parse_provider`), so a config
+file this module writes is one the runtime accepts.
+
+Secret handling: entries may legitimately carry an inline ``api_key``
+(the same thing ``omnigent setup`` can write), but no operation here ever
+returns secret *values* — listings and mutation results redact them to
+source descriptors (``api_key_set`` / ``api_key_ref`` / ``auth_command``).
+Endpoint probes resolve the credential on the host and send it only to
+the provider's own ``base_url``.
+
+Every mutating write backs the target file up first
+(``<name>.bak-<epoch>``) so a bad panel edit is one file-copy away from
+recovery.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+import httpx
+import yaml
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.onboarding.provider_config import (
+    _config_path,
+    _parse_provider,
+    _VALID_FAMILIES,
+    resolve_secret,
+)
+
+_logger = logging.getLogger(__name__)
+
+# ``omnigent run`` resolves single-file and bundle agent specs from here
+# (cli.py ``_GLOBAL_AGENTS_DIR``). Resolved at call time so tests can point
+# the ops at a temporary directory.
+_TEST_HTTP_TIMEOUT_S = 10.0
+_TEST_MODELS_SAMPLE = 50
+
+
+def _agents_dir() -> Path:
+    """Return this host's agent-spec directory.
+
+    Respects ``$OMNIGENT_CONFIG_HOME`` for test isolation (matching
+    :func:`omnigent.onboarding.provider_config._config_path`), so the
+    frame handler and the functions it calls stay consistent about where
+    this host's ``~/.omnigent`` actually is.
+
+    :returns: ``~/.omnigent/agents`` (or ``$OMNIGENT_CONFIG_HOME/agents``).
+    """
+    config_home = os.environ.get("OMNIGENT_CONFIG_HOME")
+    if config_home:
+        return Path(config_home) / "agents"
+    return Path.home() / ".omnigent" / "agents"
+
+
+def _load_config_mapping(config_path: str | None = None) -> dict[str, Any]:
+    """Load ``config.yaml`` as a mapping, creating nothing.
+
+    :param config_path: Explicit config path (tests); ``None`` uses
+        :func:`omnigent.onboarding.provider_config._config_path`.
+    :returns: The parsed mapping; ``{}`` when the file does not exist yet.
+    :raises OmnigentError: When the file exists but is not a YAML mapping.
+    """
+    path = config_path or _config_path()
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise OmnigentError(
+            f"{path}: expected a YAML mapping at top level, got {type(raw).__name__}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return raw
+
+
+def _backup(path: str) -> str | None:
+    """Copy *path* to a timestamped ``.bak-<epoch>`` sibling.
+
+    :param path: File about to be overwritten.
+    :returns: The backup path, or ``None`` when there was nothing to back up.
+    """
+    if not os.path.exists(path):
+        return None
+    backup = f"{path}.bak-{int(time.time())}"
+    shutil.copy2(path, backup)
+    return backup
+
+
+def _write_config(mapping: Mapping[str, Any], config_path: str | None = None) -> str:
+    """Atomically-ish write *mapping* back to ``config.yaml``.
+
+    Key order of the loaded mapping is preserved (``sort_keys=False``) so
+    round-trips do not reshuffle a user's hand-edited file.
+
+    :param mapping: The new top-level config mapping.
+    :param config_path: Explicit config path (tests); ``None`` uses the
+        global config path.
+    :returns: The backup path written before the new content.
+    """
+    path = config_path or _config_path()
+    backup = _backup(path)
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp = f"{path}.tmp-{os.getpid()}"
+    with open(tmp, "w") as f:
+        yaml.safe_dump(dict(mapping), f, sort_keys=False)
+    os.replace(tmp, path)
+    return backup or ""
+
+
+def _redact_entry(name: str, raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy of a provider entry safe to show to the panel.
+
+    Secret *values* (an inline ``api_key``, resolved ``auth_command``
+    output) never cross the wire — including inside family blocks, where
+    the credential actually lives. Each secret source is described
+    (``api_key_set``), not revealed; ``api_key_ref`` / ``auth_command``
+    are references, not secrets, and pass through verbatim.
+
+    :param name: The provider's key under ``providers:``.
+    :param raw: The raw entry mapping from the config file.
+    :returns: Redacted copy with ``name`` added.
+    """
+    out: dict[str, Any] = {"name": name}
+    for key, value in raw.items():
+        if key == "api_key":
+            out["api_key_set"] = True
+            continue
+        if key in _VALID_FAMILIES and isinstance(value, Mapping):
+            family_out: dict[str, Any] = {}
+            for fkey, fvalue in value.items():
+                if fkey == "api_key":
+                    family_out["api_key_set"] = True
+                else:
+                    family_out[fkey] = fvalue
+            out[key] = family_out
+            continue
+        out[key] = value
+    return out
+
+
+def _families_of(raw: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the inline family blocks of a raw provider entry.
+
+    :param raw: The raw entry mapping.
+    :returns: Family-name → family-block mappings present on the entry.
+    """
+    return {k: v for k, v in raw.items() if k in _VALID_FAMILIES and isinstance(v, dict)}
+
+
+# ── providers ops ────────────────────────────────────────
+
+
+def providers_list(config_path: str | None = None) -> dict[str, Any]:
+    """List this host's providers, secrets redacted.
+
+    :param config_path: Explicit config path (tests).
+    :returns: ``{"providers": [...], "config_path": str}``.
+    """
+    config = _load_config_mapping(config_path)
+    raw_providers = config.get("providers")
+    entries: list[dict[str, Any]] = []
+    if isinstance(raw_providers, dict):
+        for name, raw in raw_providers.items():
+            if isinstance(raw, dict):
+                entries.append(_redact_entry(str(name), raw))
+    return {"providers": entries, "config_path": config_path or _config_path()}
+
+
+def provider_upsert(name: str, entry: Mapping[str, Any], config_path: str | None = None) -> dict[str, Any]:
+    """Insert or replace one provider entry after full validation.
+
+    The whole entry is replaced (no field-level merge): the panel edits a
+    complete form, and replace-over-merge keeps the file's semantics equal
+    to a hand edit. Validation reuses :func:`_parse_provider` — the same
+    parser every turn runs — so an entry this function writes is one the
+    runtime accepts.
+
+    :param name: The provider key under ``providers:``. Must be a
+        non-empty string without path separators.
+    :param entry: The new raw entry mapping (``kind``, families, ...).
+    :param config_path: Explicit config path (tests).
+    :returns: ``{"name": ..., "provider": <redacted>, "backup": <path or "">}``.
+    :raises OmnigentError: ``INVALID_INPUT`` for a bad name or an entry
+        the shared parser rejects.
+    """
+    if not isinstance(name, str) or not name.strip() or "/" in name or name.startswith("."):
+        raise OmnigentError(f"invalid provider name {name!r}", code=ErrorCode.INVALID_INPUT)
+    name = name.strip()
+    if not isinstance(entry, dict):
+        raise OmnigentError(
+            f"provider {name!r}: entry must be a mapping", code=ErrorCode.INVALID_INPUT
+        )
+    # Validate through the runtime's own parser before touching the file.
+    _parse_provider(name, dict(entry))
+    config = _load_config_mapping(config_path)
+    providers = config.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+        config["providers"] = providers
+    providers[name] = dict(entry)
+    backup = _write_config(config, config_path)
+    _logger.info("provider %r upserted via control plane (backup %s)", name, backup or "n/a")
+    return {"name": name, "provider": _redact_entry(name, entry), "backup": backup}
+
+
+def provider_delete(name: str, config_path: str | None = None) -> dict[str, Any]:
+    """Delete one provider entry.
+
+    :param name: The provider key under ``providers:``.
+    :param config_path: Explicit config path (tests).
+    :returns: ``{"name": ..., "backup": <path or "">}``.
+    :raises OmnigentError: ``NOT_FOUND`` when no such provider exists.
+    """
+    config = _load_config_mapping(config_path)
+    providers = config.get("providers")
+    if not isinstance(providers, dict) or name not in providers:
+        raise OmnigentError(f"no provider named {name!r}", code=ErrorCode.NOT_FOUND)
+    removed = providers.pop(name)
+    backup = _write_config(config, config_path)
+    _logger.info("provider %r deleted via control plane (backup %s)", name, backup or "n/a")
+    return {"name": name, "removed": _redact_entry(name, removed) if isinstance(removed, dict) else None, "backup": backup}
+
+
+def provider_test(name: str, config_path: str | None = None) -> dict[str, Any]:
+    """Probe a provider's endpoint with its own credential.
+
+    Resolves the credential exactly as a turn would (:func:`resolve_secret`
+    for ``api_key_ref``, ``$VAR`` expansion for inline keys, subcommand
+    execution for ``auth_command``) and issues one authenticated
+    ``GET {base_url}/models``. The credential value is sent only to the
+    provider's own ``base_url`` and is never included in the result.
+
+    :param name: The provider key under ``providers:``.
+    :param config_path: Explicit config path (tests).
+    :returns: ``{"name", "family", "endpoint", "http_status", "ok",
+        "latency_ms", "models"}`` — ``models`` is a bounded sample of the
+        ids the endpoint advertises.
+    :raises OmnigentError: ``NOT_FOUND`` for an unknown provider;
+        ``INVALID_INPUT`` for kinds without an endpoint (subscription,
+        databricks, cli-config, bedrock) or a family that cannot be
+        probed.
+    """
+    config = _load_config_mapping(config_path)
+    providers = config.get("providers")
+    if not isinstance(providers, dict) or name not in providers:
+        raise OmnigentError(f"no provider named {name!r}", code=ErrorCode.NOT_FOUND)
+    raw = providers[name]
+    if not isinstance(raw, dict):
+        raise OmnigentError(f"provider {name!r} is not a mapping", code=ErrorCode.INVALID_INPUT)
+    kind = raw.get("kind")
+    if kind in ("subscription", "databricks", "cli-config", "bedrock"):
+        raise OmnigentError(
+            f"provider {name!r} has kind {kind!r} with no endpoint to probe",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    families = _families_of(raw)
+    if not families:
+        raise OmnigentError(
+            f"provider {name!r} declares no {'/'.join(_VALID_FAMILIES)} family to probe",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    # Prefer the family whose wire format is our probe format; else the
+    # first declared family (deterministic given the entry's key order).
+    family = next((f for f in families if f == "openai"), next(iter(families)))
+    block = families[family]
+    base_url = block.get("base_url")
+    if not isinstance(base_url, str) or not base_url.strip():
+        raise OmnigentError(
+            f"provider {name!r} family {family!r} has no base_url",
+            code=ErrorCode.INVALID_INPUT,
+        )
+
+    secret: str | None = None
+    if isinstance(block.get("api_key_ref"), str):
+        secret = resolve_secret(block["api_key_ref"])
+    elif isinstance(block.get("api_key"), str):
+        secret = resolve_secret(block["api_key"])
+    elif isinstance(block.get("auth_command"), str):
+        proc = subprocess.run(
+            block["auth_command"], shell=True, capture_output=True, text=True, timeout=15
+        )
+        if proc.returncode != 0:
+            raise OmnigentError(
+                f"auth_command for {name!r} failed: {proc.stderr.strip()[:200]}",
+                code=ErrorCode.INVALID_INPUT,
+            )
+        secret = proc.stdout.strip()
+
+    url = base_url.rstrip("/") + "/models"
+    headers = {"Authorization": f"Bearer {secret}"} if secret else {}
+    started = time.monotonic()
+    try:
+        response = httpx.get(url, headers=headers, timeout=_TEST_HTTP_TIMEOUT_S)
+    except httpx.HTTPError as exc:
+        return {
+            "name": name,
+            "family": family,
+            "endpoint": url,
+            "ok": False,
+            "error": f"{type(exc).__name__}: {exc}",
+            "latency_ms": int((time.monotonic() - started) * 1000),
+        }
+    latency_ms = int((time.monotonic() - started) * 1000)
+    models: list[str] = []
+    if response.status_code == 200:
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        data = body.get("data") if isinstance(body, dict) else None
+        if isinstance(data, list):
+            models = [
+                str(item.get("id"))
+                for item in data[:_TEST_MODELS_SAMPLE]
+                if isinstance(item, dict) and item.get("id")
+            ]
+    return {
+        "name": name,
+        "family": family,
+        "endpoint": url,
+        "http_status": response.status_code,
+        "ok": response.status_code == 200,
+        "latency_ms": latency_ms,
+        "models": models,
+    }
+
+
+# ── agent pin ops ────────────────────────────────────────
+
+
+def _agent_specs(agents_dir: Path) -> list[tuple[str, Path]]:
+    """Enumerate agent spec files under *agents_dir*.
+
+    :param agents_dir: The agent directory to scan.
+    :returns: ``(agent_name, spec_path)`` pairs — bundle directories
+        (``<dir>/config.yaml``) and single-file ``*.yaml`` specs.
+    """
+    if not agents_dir.is_dir():
+        return []
+    found: list[tuple[str, Path]] = []
+    for child in sorted(agents_dir.iterdir()):
+        if child.is_dir():
+            config = child / "config.yaml"
+            if config.is_file():
+                found.append((child.name, config))
+        elif child.suffix in (".yaml", ".yml"):
+            found.append((child.stem, child))
+    return found
+
+
+def _load_agent_spec(path: Path) -> dict[str, Any]:
+    """Load one agent spec file as a mapping.
+
+    :param path: The spec file (bundle ``config.yaml`` or single-file YAML).
+    :returns: The parsed mapping.
+    :raises OmnigentError: ``NOT_FOUND`` when missing, ``INVALID_INPUT``
+        when the YAML is not a mapping.
+    """
+    if not path.is_file():
+        raise OmnigentError(f"agent spec not found: {path}", code=ErrorCode.NOT_FOUND)
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+    if not isinstance(raw, dict):
+        raise OmnigentError(
+            f"{path}: expected a YAML mapping at top level, got {type(raw).__name__}",
+            code=ErrorCode.INVALID_INPUT,
+        )
+    return raw
+
+
+def _spec_summary(name: str, raw: Mapping[str, Any], path: Path) -> dict[str, Any]:
+    """Summarize one agent spec for listings.
+
+    :param name: The agent's directory / file-stem name.
+    :param raw: The parsed spec mapping.
+    :param path: Where the spec lives (for the response's ``path`` hint).
+    :returns: ``{"name", "harness", "model", "auth", "spec_version", "path"}``.
+    """
+    executor = raw.get("executor")
+    executor = executor if isinstance(executor, dict) else {}
+    config = executor.get("config")
+    config = config if isinstance(config, dict) else {}
+    harness = executor.get("harness") if "spec_version" not in raw else config.get("harness")
+    auth = executor.get("auth")
+    auth_out: Any = None
+    if isinstance(auth, dict):
+        auth_out = {"type": auth.get("type")}
+        if auth.get("type") == "provider":
+            auth_out["name"] = auth.get("name")
+    return {
+        "name": name,
+        "harness": harness if isinstance(harness, str) else None,
+        "model": executor.get("model") if isinstance(executor.get("model"), str) else None,
+        "auth": auth_out,
+        "spec_version": raw.get("spec_version"),
+        "path": str(path),
+    }
+
+
+def agents_list(agents_dir: str | None = None) -> dict[str, Any]:
+    """List the agent specs on this host with their current pins.
+
+    :param agents_dir: Explicit agents directory (tests); ``None`` uses
+        ``~/.omnigent/agents``.
+    :returns: ``{"agents": [...], "agents_dir": str}``.
+    """
+    root = Path(agents_dir) if agents_dir else _agents_dir()
+    agents = []
+    for name, path in _agent_specs(root):
+        try:
+            raw = _load_agent_spec(path)
+        except OmnigentError:
+            continue
+        agents.append(_spec_summary(name, raw, path))
+    return {"agents": agents, "agents_dir": str(root)}
+
+
+def agent_pin_set(
+    agent: str,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    agents_dir: str | None = None,
+) -> dict[str, Any]:
+    """Pin one agent spec's provider and/or model.
+
+    Writes the pin where the spec format reads it: ``executor.auth =
+    {type: provider, name: <provider>}`` — the strongest per-spec
+    provider selector the runtime knows (fail-loud when the provider is
+    undeclared) — and ``executor.model`` for the model id. The agent's
+    other fields are untouched; the file is backed up first.
+
+    :param agent: The agent's directory / file-stem name under the
+        agents dir.
+    :param provider: Provider name to pin, or ``None`` to leave the
+        provider selection unchanged.
+    :param model: Model id to pin, or ``None`` to leave the model
+        unchanged.
+    :param agents_dir: Explicit agents directory (tests).
+    :returns: ``{"agent": ..., "spec": <summary after the write>,
+        "backup": <path or "">}``.
+    :raises OmnigentError: ``NOT_FOUND`` for an unknown agent;
+        ``INVALID_INPUT`` for an empty pin request or a bad name.
+    """
+    if not provider and not model:
+        raise OmnigentError(
+            "agent_pin_set requires a provider and/or model", code=ErrorCode.INVALID_INPUT
+        )
+    root = Path(agents_dir) if agents_dir else _agents_dir()
+    matches = [(n, p) for n, p in _agent_specs(root) if n == agent]
+    if not matches:
+        raise OmnigentError(f"no agent named {agent!r} on this host", code=ErrorCode.NOT_FOUND)
+    if provider is not None and (
+        not isinstance(provider, str)
+        or not provider.strip()
+        or "/" in provider
+        or provider.startswith(".")
+    ):
+        raise OmnigentError(f"invalid provider name {provider!r}", code=ErrorCode.INVALID_INPUT)
+    _, path = matches[0]
+    raw = _load_agent_spec(path)
+    executor = raw.get("executor")
+    if not isinstance(executor, dict):
+        executor = {}
+        raw["executor"] = executor
+    if provider is not None:
+        executor["auth"] = {"type": "provider", "name": provider.strip()}
+    if model is not None:
+        if not isinstance(model, str) or not model.strip():
+            raise OmnigentError(f"invalid model id {model!r}", code=ErrorCode.INVALID_INPUT)
+        executor["model"] = model.strip()
+    backup = _backup(str(path))
+    tmp = f"{path}.tmp-{os.getpid()}"
+    with open(tmp, "w") as f:
+        yaml.safe_dump(raw, f, sort_keys=False)
+    os.replace(tmp, path)
+    _logger.info(
+        "agent %r pinned (provider=%r model=%r) via control plane", agent, provider, model
+    )
+    return {
+        "agent": agent,
+        "spec": _spec_summary(agent, raw, path),
+        "backup": backup or "",
+    }
+
+
+def agent_pin_clear(
+    agent: str,
+    *,
+    provider: bool = True,
+    model: bool = True,
+    agents_dir: str | None = None,
+) -> dict[str, Any]:
+    """Remove one agent spec's provider and/or model pin.
+
+    Only a ``provider``-typed ``executor.auth`` is removed — an inline
+    ``api_key`` auth block is left alone (the panel never silently drops
+    a credential the user pasted into the spec).
+
+    :param agent: The agent's directory / file-stem name.
+    :param provider: Also remove the provider pin.
+    :param model: Also remove the model pin.
+    :param agents_dir: Explicit agents directory (tests).
+    :returns: ``{"agent": ..., "spec": <summary after the write>,
+        "backup": <path or "">}``.
+    :raises OmnigentError: ``NOT_FOUND`` for an unknown agent;
+        ``INVALID_INPUT`` when nothing was requested.
+    """
+    if not provider and not model:
+        raise OmnigentError(
+            "agent_pin_clear requires provider and/or model", code=ErrorCode.INVALID_INPUT
+        )
+    root = Path(agents_dir) if agents_dir else _agents_dir()
+    matches = [(n, p) for n, p in _agent_specs(root) if n == agent]
+    if not matches:
+        raise OmnigentError(f"no agent named {agent!r} on this host", code=ErrorCode.NOT_FOUND)
+    _, path = matches[0]
+    raw = _load_agent_spec(path)
+    executor = raw.get("executor")
+    if isinstance(executor, dict):
+        if provider:
+            auth = executor.get("auth")
+            if isinstance(auth, dict) and auth.get("type") == "provider":
+                del executor["auth"]
+        if model and "model" in executor:
+            del executor["model"]
+    backup = _backup(str(path))
+    tmp = f"{path}.tmp-{os.getpid()}"
+    with open(tmp, "w") as f:
+        yaml.safe_dump(raw, f, sort_keys=False)
+    os.replace(tmp, path)
+    _logger.info("agent %r pins cleared (provider=%s model=%s)", agent, provider, model)
+    return {
+        "agent": agent,
+        "spec": _spec_summary(agent, raw, path),
+        "backup": backup or "",
+    }
+
+
+# ── op dispatch ──────────────────────────────────────────
+
+# The wire-dispatch table deliberately does NOT honor ``config_path`` /
+# ``agents_dir`` keys from ``frame.params``: an operation must always run
+# against this host's real ``~/.omnigent`` files, never an arbitrary path a
+# remote caller names. The explicit-path parameters on the functions above
+# exist for tests (which call the functions directly) and for future
+# in-process callers under the same trust boundary.
+_PROVIDER_OPS = {
+    "providers_list": lambda params: providers_list(),
+    "provider_upsert": lambda params: provider_upsert(
+        params.get("name"),
+        params.get("entry") if isinstance(params.get("entry"), dict) else {},
+    ),
+    "provider_delete": lambda params: provider_delete(params.get("name")),
+    "provider_test": lambda params: provider_test(params.get("name")),
+    "agents_list": lambda params: agents_list(),
+    "agent_pin_set": lambda params: agent_pin_set(
+        params.get("agent"),
+        provider=params.get("provider") if isinstance(params.get("provider"), str) else None,
+        model=params.get("model") if isinstance(params.get("model"), str) else None,
+    ),
+    "agent_pin_clear": lambda params: agent_pin_clear(
+        params.get("agent"),
+        provider=bool(params.get("provider", True)),
+        model=bool(params.get("model", True)),
+    ),
+}
+
+
+def run_provider_op(op: str, params: Mapping[str, Any]) -> dict[str, Any]:
+    """Run one named provider/agent-pin operation.
+
+    The single entry point the ``host.provider_op`` frame handler calls.
+
+    :param op: One of the op names in ``_PROVIDER_OPS``.
+    :param params: Op-specific arguments.
+    :returns: The op's result payload.
+    :raises OmnigentError: ``INVALID_INPUT`` for an unknown op; the
+        underlying op's errors otherwise.
+    """
+    handler = _PROVIDER_OPS.get(op)
+    if handler is None:
+        raise OmnigentError(f"unknown provider op {op!r}", code=ErrorCode.INVALID_INPUT)
+    return handler(dict(params))

--- a/omnigent/onboarding/provider_config.py
+++ b/omnigent/onboarding/provider_config.py
@@ -46,8 +46,9 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
-from typing import Literal
+from typing import Any, Literal
 
 from omnigent.cli_invocation import cli_invocation
 from omnigent.errors import ErrorCode, OmnigentError
@@ -555,6 +556,26 @@ def resolve_secret(ref: str) -> str:
     expanded = expand_envvars_with_omnigent_prefix(ref)
     check_unresolved_env_vars(ref, expanded)
     return expanded
+
+
+def credential_for_block(block: Mapping[str, Any]) -> str | None:
+    """Resolve the key material a family block configures, for outbound use.
+
+    Shared by the runtime turn path and the host config control-plane probe
+    so both honor identical ``api_key_ref`` / inline ``api_key`` semantics.
+
+    :param block: One family block (the ``openai:`` / ``anthropic:`` /
+        ``gemini:`` mapping of a provider entry).
+    :returns: The resolved credential, or ``None`` when the block carries
+        no key material (an ``auth_command`` or keyless local endpoint).
+    """
+    ref = block.get("api_key_ref")
+    if isinstance(ref, str):
+        return resolve_secret(ref)
+    inline = block.get("api_key")
+    if isinstance(inline, str):
+        return resolve_secret(inline)
+    return None
 
 
 def _config_path() -> str:

--- a/omnigent/server/host_registry.py
+++ b/omnigent/server/host_registry.py
@@ -315,6 +315,9 @@ class HostConnection:
     pending_model_options: dict[str, asyncio.Future[dict[str, Any]]] = field(
         default_factory=dict,
     )
+    pending_provider_ops: dict[str, asyncio.Future[dict[str, Any]]] = field(
+        default_factory=dict,
+    )
     # Import streams one session per frame, so the tunnel pushes each onto a
     # per-request queue the /imports/local handler drains (vs a single future).
     # Each item is a ("session", dict) or ("done", dict) tuple.

--- a/omnigent/server/routes/_host_provider_op.py
+++ b/omnigent/server/routes/_host_provider_op.py
@@ -1,0 +1,58 @@
+"""One round-trip helper for ``host.provider_op``.
+
+Only caller today is the ``/v1/hosts/{id}/providers*`` and
+``/v1/hosts/{id}/agents/{name}/pin`` route group, which turns a failure
+into an HTTP error. The request-id / future / frame / timeout / cleanup
+shape lives here once, mirroring
+:mod:`omnigent.server.routes._host_model_options`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from typing import Any
+
+from omnigent.host.frames import (
+    HostProviderOpFrame,
+    encode_host_frame,
+)
+from omnigent.server.host_registry import HostConnection, HostRegistry
+
+
+async def request_host_provider_op(
+    *,
+    host_registry: HostRegistry,
+    host_conn: HostConnection,
+    op: str,
+    params: dict[str, Any],
+    timeout_s: float,
+) -> dict[str, Any]:
+    """
+    Send a ``host.provider_op`` frame and await the host's result.
+
+    :param host_registry: Registry used to enqueue the outbound frame.
+    :param host_conn: Live host connection to run the operation on.
+    :param op: One of the provider-op names the host's frame handler
+        dispatches (``providers_list``, ``provider_upsert``,
+        ``provider_delete``, ``provider_test``, ``agents_list``,
+        ``agent_pin_set``, ``agent_pin_clear``).
+    :param params: Op-specific JSON arguments.
+    :param timeout_s: Seconds to wait for the result frame.
+    :returns: The result payload (``status``/``payload``/``error`` shape).
+    :raises ConnectionError: The host connection dropped before the frame
+        could be enqueued.
+    :raises asyncio.TimeoutError: The host did not answer within
+        *timeout_s*.
+    """
+    request_id = secrets.token_hex(8)
+    future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+    host_conn.pending_provider_ops[request_id] = future
+    frame = encode_host_frame(
+        HostProviderOpFrame(request_id=request_id, op=op, params=params)
+    )
+    try:
+        host_registry.send_text(host_conn, frame)
+        return await asyncio.wait_for(future, timeout=timeout_s)
+    finally:
+        host_conn.pending_provider_ops.pop(request_id, None)

--- a/omnigent/server/routes/host_tunnel.py
+++ b/omnigent/server/routes/host_tunnel.py
@@ -43,6 +43,7 @@ from omnigent.host.frames import (
     HostListDirResultFrame,
     HostListWorktreesResultFrame,
     HostModelOptionsResultFrame,
+    HostProviderOpResultFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
     HostRunnerStatusResultFrame,
@@ -774,6 +775,20 @@ async def _receive_loop(
                         "status": frame.status,
                         "models": frame.models,
                         "routable_models": frame.routable_models,
+                        "error": frame.error,
+                    }
+                )
+            continue
+
+        if isinstance(frame, HostProviderOpResultFrame):
+            op_future = conn.pending_provider_ops.pop(frame.request_id, None)
+            if op_future is not None and not op_future.done():
+                op_future.set_result(
+                    {
+                        "status": frame.status,
+                        "payload": frame.payload,
+                        "error_status": frame.error_status,
+                        "error_code": frame.error_code,
                         "error": frame.error,
                     }
                 )

--- a/omnigent/server/routes/hosts.py
+++ b/omnigent/server/routes/hosts.py
@@ -55,6 +55,7 @@ from omnigent.server.feature_flags import Feature, FeatureFlags, resolve_feature
 from omnigent.server.host_registry import HostConnection, HostRegistry
 from omnigent.server.routes._auth_helpers import require_user
 from omnigent.server.routes._host_launch import host_absent_error, resolve_host_launch
+from omnigent.server.routes._host_provider_op import request_host_provider_op
 from omnigent.server.routes._workspace_validation import (
     _is_windows_absolute_path,
     restore_host_filesystem_url_path,
@@ -78,6 +79,10 @@ _LIST_DIR_MAX_LIMIT = 1000
 # for transient network slowness without making the picker feel hung.
 _CREATE_DIR_TIMEOUT_S = 5.0
 _MODEL_OPTIONS_TIMEOUT_S = 15.0
+# Provider ops touch config.yaml / agent specs on disk and the test op
+# probes a remote endpoint; give the round trip more headroom than a
+# model-options lookup but still fail the HTTP request deterministically.
+_PROVIDER_OP_TIMEOUT_S = 45.0
 # Per-call timeout for host.install_harness round-trips. The host runs
 # `npm install -g <pkg>` — install_harness_cli caps that subprocess at 300s —
 # then recomputes readiness and sends the result back over the tunnel. The
@@ -447,6 +452,23 @@ class StoreHarnessCredentialRequest(BaseModel):
     default_model: str | None = None
     wire_api: str | None = None
     env_var: str | None = None
+
+
+class ProviderUpsertRequest(BaseModel):
+    """Body for ``PUT /hosts/{host_id}/providers/{name}`` — the full entry."""
+
+    entry: dict[str, Any]
+
+
+class AgentPinRequest(BaseModel):
+    """Body for ``PUT /hosts/{host_id}/agents/{name}/pin``.
+
+    At least one field must be set; ``None`` leaves that selection
+    unchanged.
+    """
+
+    provider: str | None = None
+    model: str | None = None
 
 
 class HostModelOptionsResponse(BaseModel):
@@ -1609,5 +1631,153 @@ def create_hosts_router(
             raise HTTPException(status_code=400, detail=exc.message) from exc
 
         return {"object": "list", "data": worktrees}
+
+
+    # ── Config control plane: host providers + per-agent pins (#7134) ──
+
+    async def _run_provider_op(
+        request: Request,
+        host_id: str,
+        op: str,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Authorize, resolve the live host, and run one provider op.
+
+        Shared by every control-plane route below: the auth/ownership
+        checks and the wrong-replica-vs-offline classification match the
+        other ``/hosts/{id}/*`` proxies, and the frame-level failure
+        fields (``error_status``/``error_code``/``error``) map onto HTTP
+        errors so the panel renders the host's own validation message.
+        """
+        user_id = require_user(request, auth_provider)
+        host = await asyncio.to_thread(host_store.get_host, host_id)
+        if host is None:
+            raise HTTPException(status_code=404, detail="host not found")
+        if user_id is not None and host.user_id != user_id:
+            raise HTTPException(status_code=403, detail="not your host")
+        conn = host_registry.get(host.host_id)
+        if conn is None:
+            raise _host_absent_error(host)
+
+        try:
+            result = await request_host_provider_op(
+                host_registry=host_registry,
+                host_conn=conn,
+                op=op,
+                params=params,
+                timeout_s=_PROVIDER_OP_TIMEOUT_S,
+            )
+        except ConnectionError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"host '{host_id}' connection lost",
+            ) from exc
+        except asyncio.TimeoutError as exc:
+            raise HTTPException(
+                status_code=504,
+                detail=(
+                    f"host '{host_id}' did not complete provider op {op!r} within "
+                    f"{_PROVIDER_OP_TIMEOUT_S:.0f}s"
+                ),
+            ) from exc
+        if result.get("status") != "ok":
+            detail = str(result.get("error") or f"provider op {op!r} failed")
+            status = result.get("error_status")
+            raise HTTPException(
+                status_code=status if isinstance(status, int) else 502,
+                detail=detail,
+            )
+        return result.get("payload") or {}
+
+    @router.get("/hosts/{host_id}/providers")
+    async def list_host_providers(request: Request, host_id: str) -> dict[str, Any]:
+        """List a host's providers (secrets redacted to source descriptors)."""
+        return await _run_provider_op(request, host_id, "providers_list", {})
+
+    @router.put("/hosts/{host_id}/providers/{name}")
+    async def upsert_host_provider(
+        request: Request,
+        host_id: str,
+        name: str,
+        body: ProviderUpsertRequest,
+    ) -> dict[str, Any]:
+        """Create or replace one provider entry on the host.
+
+        The entry is validated by the host with the same parser every
+        turn runs, so a shape the runtime would reject never lands in
+        ``config.yaml``.
+        """
+        return await _run_provider_op(
+            request, host_id, "provider_upsert", {"name": name, "entry": body.entry}
+        )
+
+    @router.delete("/hosts/{host_id}/providers/{name}")
+    async def delete_host_provider(
+        request: Request,
+        host_id: str,
+        name: str,
+    ) -> dict[str, Any]:
+        """Delete one provider entry from the host's config."""
+        return await _run_provider_op(request, host_id, "provider_delete", {"name": name})
+
+    @router.post("/hosts/{host_id}/providers/{name}/test")
+    async def test_host_provider(
+        request: Request,
+        host_id: str,
+        name: str,
+    ) -> dict[str, Any]:
+        """Probe a provider's endpoint from the host with its own credential.
+
+        The credential is resolved host-side and sent only to the
+        provider's own ``base_url``; the response carries status,
+        latency, and a bounded model-id sample — never the secret.
+        """
+        return await _run_provider_op(request, host_id, "provider_test", {"name": name})
+
+    @router.get("/hosts/{host_id}/agent-specs")
+    async def list_host_agent_specs(request: Request, host_id: str) -> dict[str, Any]:
+        """List the host-local agent specs with their current pins.
+
+        These are the specs under the host's ``~/.omnigent/agents/`` —
+        the ones ``omnigent run <agent>`` resolves there — as opposed to
+        the server-side registered-agent store the sessions API serves.
+        """
+        return await _run_provider_op(request, host_id, "agents_list", {})
+
+    @router.put("/hosts/{host_id}/agent-specs/{agent_name}/pin")
+    async def pin_host_agent(
+        request: Request,
+        host_id: str,
+        agent_name: str,
+        body: AgentPinRequest,
+    ) -> dict[str, Any]:
+        """Pin an agent spec's provider and/or model on the host.
+
+        Writes ``executor.auth: {type: provider, name: ...}`` and/or
+        ``executor.model`` — the runtime's strongest per-agent selector;
+        resolution then prefers the pin over every ambient default.
+        """
+        if body.provider is None and body.model is None:
+            raise HTTPException(
+                status_code=400,
+                detail="pin requires a provider and/or model",
+            )
+        return await _run_provider_op(
+            request,
+            host_id,
+            "agent_pin_set",
+            {"agent": agent_name, "provider": body.provider, "model": body.model},
+        )
+
+    @router.delete("/hosts/{host_id}/agent-specs/{agent_name}/pin")
+    async def clear_host_agent_pin(
+        request: Request,
+        host_id: str,
+        agent_name: str,
+    ) -> dict[str, Any]:
+        """Remove an agent spec's provider and model pins."""
+        return await _run_provider_op(
+            request, host_id, "agent_pin_clear", {"agent": agent_name}
+        )
 
     return router

--- a/tests/e2e_ui/settings/test_model_providers_section.py
+++ b/tests/e2e_ui/settings/test_model_providers_section.py
@@ -1,0 +1,163 @@
+"""UI journey: the Settings → Models & providers section (``/settings/models``).
+
+Covers the per-host provider config control plane from the web panel: the
+host picker resolves the first online host, the providers table renders the
+redacted wire entries (name, kind badge, base URL, default flag), the
+agent-specs list renders each agent's current provider/model pin, the
+add-provider dialog writes through ``PUT /v1/hosts/{id}/providers/{name}``,
+and the per-agent pin dialog writes through
+``PUT /v1/hosts/{id}/agent-specs/{name}/pin``.
+
+The host-facing REST surface is injected at the network layer with Playwright
+``page.route`` (the same approach as the worktree-source tests in
+``sessions/``): the SPA talks to exactly the endpoints the real panel uses,
+but no host daemon or real provider credential is needed. LLM-free: no agent
+turn is dispatched.
+"""
+
+from __future__ import annotations
+
+import json
+
+from playwright.sync_api import Page, Route, expect
+
+_HOST_ID = "host_e2e_models"
+_HOSTS_BODY = {
+    "hosts": [
+        {
+            "host_id": _HOST_ID,
+            "name": "e2e-laptop",
+            "owner": "e2e",
+            "status": "online",
+            "configured_harnesses": {},
+        }
+    ]
+}
+
+_OPENROUTER = {
+    "name": "openrouter",
+    "kind": "gateway",
+    "default": True,
+    "openai": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key_set": True,
+        "wire_api": "chat",
+        "models": {"default": "gpt-x", "alt": "gpt-y"},
+    },
+}
+
+_AGENTS_BODY = {
+    "agents": [
+        {
+            "name": "my-agent",
+            "harness": "pi",
+            "model": None,
+            "auth": {"type": "provider", "name": "openrouter"},
+            "spec_version": 1,
+            "path": "/home/e2e/.omnigent/agents/my-agent/config.yaml",
+        }
+    ]
+}
+
+
+def _json(route: Route, body: dict) -> None:
+    route.fulfill(status=200, content_type="application/json", body=json.dumps(body))
+
+
+def _route_config(page: Page, providers: list) -> None:
+    """Serve the hosts/providers/agent-specs read surface from ``providers``."""
+    page.route("**/v1/hosts", lambda route: _json(route, _HOSTS_BODY))
+    page.route(
+        f"**/v1/hosts/{_HOST_ID}/providers",
+        lambda route: (
+            _json(route, {"providers": providers})
+            if route.request.method == "GET"
+            else route.fallback()
+        ),
+    )
+    page.route(
+        f"**/v1/hosts/{_HOST_ID}/agent-specs",
+        lambda route: _json(route, _AGENTS_BODY),
+    )
+
+
+def _goto_models_section(page: Page, base_url: str) -> None:
+    page.goto(f"{base_url}/settings/general")
+    page.get_by_role("link", name="Models & providers").click()
+    expect(page).to_have_url(f"{base_url}/settings/models")
+
+
+def test_models_section_renders_provider_and_agent_rows(page: Page, live_server: str) -> None:
+    """The section lists the host's providers and agent pins for the online host."""
+    _route_config(page, [_OPENROUTER])
+    _goto_models_section(page, live_server)
+
+    # Host picker defaulted to the (only) online host.
+    expect(page.get_by_text("e2e-laptop")).to_be_visible()
+
+    # Providers table: redacted entry rendering — name, kind badge, base URL,
+    # default flag. api_key_set must never surface as a key value.
+    expect(page.get_by_text("openrouter", exact=True)).to_be_visible()
+    expect(page.get_by_text("gateway", exact=True)).to_be_visible()
+    expect(page.get_by_text("https://openrouter.ai/api/v1")).to_be_visible()
+
+    # Agent specs: name + harness badge + the provider pin echo.
+    expect(page.get_by_text("my-agent")).to_be_visible()
+    expect(page.get_by_text("provider: openrouter")).to_be_visible()
+
+
+def test_add_provider_dialog_writes_through_the_api(page: Page, live_server: str) -> None:
+    """The add dialog builds an entry and PUTs it to the host's provider route."""
+    providers: list = []
+    _route_config(page, providers)
+    captured: dict = {}
+
+    def handle_upsert(route: Route) -> None:
+        captured["url"] = route.request.url
+        captured["body"] = route.request.post_data_json
+        providers.append({**captured["body"]["entry"], "name": "e2e-gw"})
+        _json(route, {})
+
+    page.route(f"**/v1/hosts/{_HOST_ID}/providers/e2e-gw", handle_upsert)
+    _goto_models_section(page, live_server)
+
+    page.get_by_text("Add provider").click()
+    page.get_by_label("Name", exact=True).fill("e2e-gw")
+    page.get_by_label("Base URL / endpoint").fill("http://127.0.0.1:9/v1")
+    page.get_by_label("Variable name").fill("E2E_TEST_KEY")
+    page.get_by_role("button", name="Add", exact=True).click()
+
+    expect(page.get_by_text("e2e-gw", exact=True)).to_be_visible()
+    assert captured["url"].endswith(f"/v1/hosts/{_HOST_ID}/providers/e2e-gw")
+    entry = captured["body"]["entry"]
+    assert entry["kind"] == "gateway"
+    assert entry["openai"]["base_url"] == "http://127.0.0.1:9/v1"
+    assert entry["openai"]["api_key_ref"] == "env:E2E_TEST_KEY"
+    # the raw key material is never part of the wire body — only the ref
+    assert "api_key" not in entry["openai"]
+
+
+def test_pin_dialog_sets_agent_pin(page: Page, live_server: str) -> None:
+    """The pin dialog PUTs the provider/model pin for the agent spec."""
+    _route_config(page, [_OPENROUTER])
+    captured: dict = {}
+
+    def handle_pin(route: Route) -> None:
+        captured["url"] = route.request.url
+        captured["body"] = route.request.post_data_json
+        _json(route, {})
+
+    page.route(f"**/v1/hosts/{_HOST_ID}/agent-specs/my-agent/pin", handle_pin)
+    _goto_models_section(page, live_server)
+
+    page.get_by_text("Pin", exact=True).click()
+    # Pick the provider from the radix select, type the model, save.
+    page.get_by_role("combobox", name="Pin provider").click()
+    page.get_by_role("option", name="openrouter").click()
+    page.get_by_label("Model").fill("gpt-x")
+    page.get_by_role("button", name="Save pin").click()
+
+    assert captured["url"].endswith(
+        f"/v1/hosts/{_HOST_ID}/agent-specs/my-agent/pin"
+    )
+    assert captured["body"] == {"provider": "openrouter", "model": "gpt-x"}

--- a/tests/host/test_frames.py
+++ b/tests/host/test_frames.py
@@ -37,6 +37,8 @@ from omnigent.host.frames import (
     HostListWorktreesResultFrame,
     HostModelOptionsFrame,
     HostModelOptionsResultFrame,
+    HostProviderOpFrame,
+    HostProviderOpResultFrame,
     HostRemoveWorktreeFrame,
     HostRemoveWorktreeResultFrame,
     HostRunnerExitedFrame,
@@ -53,6 +55,43 @@ from omnigent.host.frames import (
     encode_host_frame,
     workspace_missing_message,
 )
+
+
+def test_provider_op_frames_round_trip() -> None:
+    """``host.provider_op`` survives encode → decode unchanged."""
+    frame = HostProviderOpFrame(
+        request_id="req-1",
+        op="provider_upsert",
+        params={"name": "gw", "entry": {"kind": "gateway", "openai": {"base_url": "https://x/v1"}}},
+    )
+    decoded = decode_host_frame(encode_host_frame(frame))
+    assert decoded == frame
+
+
+def test_provider_op_result_frames_round_trip() -> None:
+    """``host.provider_op_result`` survives both shapes — ok and failed."""
+    ok = HostProviderOpResultFrame(request_id="req-1", status="ok", payload={"providers": []})
+    assert decode_host_frame(encode_host_frame(ok)) == ok
+
+    failed = HostProviderOpResultFrame(
+        request_id="req-2",
+        status="failed",
+        error="no provider named 'nope'",
+        error_status=404,
+        error_code="not_found",
+    )
+    assert decode_host_frame(encode_host_frame(failed)) == failed
+
+
+def test_provider_op_rejects_non_object_params() -> None:
+    """A ``params`` that is not a JSON object is a decode error, not a crash."""
+    import json as _json
+
+    raw = _json.dumps(
+        {"kind": "host.provider_op", "request_id": "r", "op": "providers_list", "params": [1, 2]}
+    )
+    with pytest.raises(ValueError):
+        decode_host_frame(raw)
 
 
 def test_import_local_frames_round_trip() -> None:

--- a/tests/host/test_provider_ops.py
+++ b/tests/host/test_provider_ops.py
@@ -18,6 +18,16 @@ from omnigent.errors import ErrorCode, OmnigentError
 from omnigent.host import provider_ops
 
 
+def _load_yaml(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def _dump_yaml(path, data):
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+
+
 def _write_config(tmp_path, providers: dict) -> str:
     config = tmp_path / "config.yaml"
     config.write_text(yaml.safe_dump({"providers": providers}, sort_keys=False))
@@ -68,7 +78,7 @@ class TestProviderUpsert:
         path = str(tmp_path / "config.yaml")
         result = provider_ops.provider_upsert("gw", _gateway_entry(), config_path=path)
         assert result["name"] == "gw"
-        raw = yaml.safe_load(open(path))
+        raw = _load_yaml(path)
         assert raw["providers"]["gw"]["openai"]["base_url"] == "https://gw.example/v1"
         # key order of the entry survives the round trip
         assert list(raw["providers"]["gw"]) == list(_gateway_entry())
@@ -82,7 +92,7 @@ class TestProviderUpsert:
                 config_path=path,
             )
         assert err.value.code == ErrorCode.INVALID_INPUT
-        assert yaml.safe_load(open(path))["providers"] == {}
+        assert _load_yaml(path)["providers"] == {}
 
     def test_upsert_rejects_bad_name(self, tmp_path) -> None:
         path = _write_config(tmp_path, {})
@@ -103,7 +113,7 @@ class TestProviderDelete:
         path = _write_config(tmp_path, {"gw": _gateway_entry()})
         result = provider_ops.provider_delete("gw", config_path=path)
         assert result["name"] == "gw"
-        assert yaml.safe_load(open(path))["providers"] == {}
+        assert _load_yaml(path)["providers"] == {}
 
     def test_delete_unknown_is_not_found(self, tmp_path) -> None:
         path = _write_config(tmp_path, {})
@@ -221,9 +231,7 @@ class TestAgentPin:
         )
         assert result["spec"]["auth"] == {"type": "provider", "name": "openrouter"}
         assert result["spec"]["model"] == "gpt-x"
-        raw = yaml.safe_load(
-            open(f"{agents_dir}/my-agent/config.yaml")
-        )
+        raw = _load_yaml(f"{agents_dir}/my-agent/config.yaml")
         # sibling keys untouched
         assert raw["executor"]["config"]["harness"] == "pi"
         assert raw["executor"]["skills"] == []
@@ -257,9 +265,9 @@ class TestAgentPin:
         provider_ops.agent_pin_set("my-agent", provider="openrouter", agents_dir=agents_dir)
         # a spec with an inline api_key auth block must keep it
         path = f"{agents_dir}/my-agent/config.yaml"
-        raw = yaml.safe_load(open(path))
+        raw = _load_yaml(path)
         raw["executor"]["auth"] = {"type": "api_key", "api_key": "sk-inline"}
-        open(path, "w").write(yaml.safe_dump(raw, sort_keys=False))
+        _dump_yaml(path, raw)
 
         provider_ops.agent_pin_set("my-agent", provider="9router", agents_dir=agents_dir)
         result = provider_ops.agent_pin_clear("my-agent", agents_dir=agents_dir)
@@ -308,7 +316,7 @@ class TestRunProviderOp:
             {"name": "gw", "entry": _gateway_entry(), "config_path": str(evil)},
         )
         # the write landed in the host's config, not the attacker-named file
-        written = yaml.safe_load(open(real_home / ".omnigent" / "config.yaml"))
+        written = _load_yaml(real_home / ".omnigent" / "config.yaml")
         assert "gw" in written["providers"]
         assert yaml.safe_load(evil.read_text()) == {}
 
@@ -335,6 +343,6 @@ class TestRunProviderOp:
             )
         assert err.value.code == ErrorCode.NOT_FOUND
         assert list(evil.rglob("*.bak-*")) == []
-        assert yaml.safe_load(open(evil / "my-agent" / "config.yaml"))["executor"].get(
+        assert _load_yaml(evil / "my-agent" / "config.yaml")["executor"].get(
             "model"
         ) is None

--- a/tests/host/test_provider_ops.py
+++ b/tests/host/test_provider_ops.py
@@ -1,0 +1,340 @@
+"""Tests for the host-side provider / agent-pin operations.
+
+These cover :mod:`omnigent.host.provider_ops` — the config-control-plane
+core behind the ``host.provider_op`` frame and the
+``/v1/hosts/{id}/providers*`` / ``.../agent-specs/{name}/pin`` routes.
+All filesystem effects land in ``tmp_path``; no test touches a real
+``~/.omnigent``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from omnigent.errors import ErrorCode, OmnigentError
+from omnigent.host import provider_ops
+
+
+def _write_config(tmp_path, providers: dict) -> str:
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"providers": providers}, sort_keys=False))
+    return str(config)
+
+
+def _gateway_entry() -> dict:
+    return {
+        "kind": "gateway",
+        "default": True,
+        "openai": {
+            "base_url": "https://gw.example/v1",
+            "api_key_ref": "env:GW_KEY",
+            "wire_api": "chat",
+            "models": {"default": "gpt-x"},
+        },
+    }
+
+
+class TestProvidersList:
+    def test_missing_config_lists_empty(self, tmp_path) -> None:
+        result = provider_ops.providers_list(config_path=str(tmp_path / "none.yaml"))
+        assert result["providers"] == []
+
+    def test_entries_are_redacted(self, tmp_path) -> None:
+        path = _write_config(
+            tmp_path,
+            {
+                "gw": {
+                    "kind": "gateway",
+                    "openai": {
+                        "base_url": "https://gw.example/v1",
+                        "api_key": "sk-super-secret",
+                    },
+                }
+            },
+        )
+        result = provider_ops.providers_list(config_path=path)
+        (entry,) = result["providers"]
+        assert entry["name"] == "gw"
+        assert "api_key" not in entry["openai"]
+        assert entry["openai"]["api_key_set"] is True
+        assert "sk-super-secret" not in json.dumps(entry)
+
+
+class TestProviderUpsert:
+    def test_upsert_writes_and_round_trips(self, tmp_path) -> None:
+        path = str(tmp_path / "config.yaml")
+        result = provider_ops.provider_upsert("gw", _gateway_entry(), config_path=path)
+        assert result["name"] == "gw"
+        raw = yaml.safe_load(open(path))
+        assert raw["providers"]["gw"]["openai"]["base_url"] == "https://gw.example/v1"
+        # key order of the entry survives the round trip
+        assert list(raw["providers"]["gw"]) == list(_gateway_entry())
+
+    def test_upsert_rejects_shape_the_runtime_rejects(self, tmp_path) -> None:
+        path = _write_config(tmp_path, {})
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.provider_upsert(
+                "bad",
+                {"kind": "not-a-kind"},
+                config_path=path,
+            )
+        assert err.value.code == ErrorCode.INVALID_INPUT
+        assert yaml.safe_load(open(path))["providers"] == {}
+
+    def test_upsert_rejects_bad_name(self, tmp_path) -> None:
+        path = _write_config(tmp_path, {})
+        for bad in ("", "../evil", "a/b", None):
+            with pytest.raises(OmnigentError):
+                provider_ops.provider_upsert(bad, _gateway_entry(), config_path=path)
+
+    def test_upsert_backs_up_previous_config(self, tmp_path) -> None:
+        path = _write_config(tmp_path, {"old": {"kind": "key"}})
+        provider_ops.provider_upsert("gw", _gateway_entry(), config_path=path)
+        backups = list(tmp_path.glob("config.yaml.bak-*"))
+        assert len(backups) == 1
+        assert "old" in yaml.safe_load(backups[0].read_text())["providers"]
+
+
+class TestProviderDelete:
+    def test_delete_removes_entry(self, tmp_path) -> None:
+        path = _write_config(tmp_path, {"gw": _gateway_entry()})
+        result = provider_ops.provider_delete("gw", config_path=path)
+        assert result["name"] == "gw"
+        assert yaml.safe_load(open(path))["providers"] == {}
+
+    def test_delete_unknown_is_not_found(self, tmp_path) -> None:
+        path = _write_config(tmp_path, {})
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.provider_delete("nope", config_path=path)
+        assert err.value.code == ErrorCode.NOT_FOUND
+
+
+class TestProviderTest:
+    def test_unknown_provider_is_not_found(self, tmp_path) -> None:
+        path = _write_config(tmp_path, {})
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.provider_test("nope", config_path=path)
+        assert err.value.code == ErrorCode.NOT_FOUND
+
+    def test_subscription_kind_has_no_endpoint(self, tmp_path) -> None:
+        path = _write_config(tmp_path, {"sub": {"kind": "subscription", "cli": "claude"}})
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.provider_test("sub", config_path=path)
+        assert err.value.code == ErrorCode.INVALID_INPUT
+
+    def test_probe_hits_models_endpoint_with_bearer(self, tmp_path, monkeypatch) -> None:
+        path = _write_config(tmp_path, {"gw": _gateway_entry()})
+        seen: dict = {}
+
+        class _Response:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "data": [{"id": "gpt-x"}, {"id": "gpt-y"}, {"nope": True}]
+                }
+
+        def fake_get(url, headers=None, timeout=None):
+            seen["url"] = url
+            seen["headers"] = headers
+            return _Response()
+
+        monkeypatch.setattr(provider_ops.httpx, "get", fake_get)
+        monkeypatch.setenv("GW_KEY", "sk-test-value")
+        result = provider_ops.provider_test("gw", config_path=path)
+        assert seen["url"] == "https://gw.example/v1/models"
+        assert seen["headers"]["Authorization"] == "Bearer sk-test-value"
+        assert result["ok"] is True
+        assert result["models"] == ["gpt-x", "gpt-y"]
+        assert "sk-test-value" not in json.dumps(result)
+
+    def test_probe_reports_connection_failure(self, tmp_path, monkeypatch) -> None:
+        path = _write_config(tmp_path, {"gw": _gateway_entry()})
+        monkeypatch.setenv("GW_KEY", "sk-test-value")
+
+        def fake_get(url, headers=None, timeout=None):
+            raise provider_ops.httpx.ConnectError("refused")
+
+        monkeypatch.setattr(provider_ops.httpx, "get", fake_get)
+        result = provider_ops.provider_test("gw", config_path=path)
+        assert result["ok"] is False
+        assert "refused" in result["error"]
+
+
+def _bundle_agent(tmp_path, name: str = "my-agent") -> str:
+    agents = tmp_path / "agents" / name
+    agents.mkdir(parents=True)
+    (agents / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "spec_version": 1,
+                "name": name,
+                "prompt": "hi",
+                "executor": {
+                    "type": "omnigent",
+                    "config": {"harness": "pi"},
+                    "skills": [],
+                },
+            },
+            sort_keys=False,
+        )
+    )
+    return str(tmp_path / "agents")
+
+
+def _single_file_agent(tmp_path, name: str = "solo") -> str:
+    agents = tmp_path / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    (agents / f"{name}.yaml").write_text(
+        yaml.safe_dump(
+            {"name": name, "prompt": "hi", "executor": {"harness": "claude-sdk"}},
+            sort_keys=False,
+        )
+    )
+    return str(agents)
+
+
+class TestAgentsList:
+    def test_lists_bundles_and_single_files(self, tmp_path) -> None:
+        agents_dir = _bundle_agent(tmp_path)
+        _single_file_agent(tmp_path)
+        result = provider_ops.agents_list(agents_dir=agents_dir)
+        names = {a["name"] for a in result["agents"]}
+        assert names == {"my-agent", "solo"}
+        (bundle,) = [a for a in result["agents"] if a["name"] == "my-agent"]
+        assert bundle["harness"] == "pi"
+        assert bundle["spec_version"] == 1
+
+    def test_missing_dir_lists_empty(self, tmp_path) -> None:
+        result = provider_ops.agents_list(agents_dir=str(tmp_path / "absent"))
+        assert result["agents"] == []
+
+
+class TestAgentPin:
+    def test_pin_sets_provider_auth_and_model(self, tmp_path) -> None:
+        agents_dir = _bundle_agent(tmp_path)
+        result = provider_ops.agent_pin_set(
+            "my-agent", provider="openrouter", model="gpt-x", agents_dir=agents_dir
+        )
+        assert result["spec"]["auth"] == {"type": "provider", "name": "openrouter"}
+        assert result["spec"]["model"] == "gpt-x"
+        raw = yaml.safe_load(
+            open(f"{agents_dir}/my-agent/config.yaml")
+        )
+        # sibling keys untouched
+        assert raw["executor"]["config"]["harness"] == "pi"
+        assert raw["executor"]["skills"] == []
+
+    def test_pin_creates_backup(self, tmp_path) -> None:
+        agents_dir = _bundle_agent(tmp_path)
+        result = provider_ops.agent_pin_set("my-agent", model="gpt-x", agents_dir=agents_dir)
+        assert result["backup"]
+        backups = list((tmp_path / "agents" / "my-agent").glob("config.yaml.bak-*"))
+        assert len(backups) == 1
+
+    def test_pin_single_file_agent(self, tmp_path) -> None:
+        agents_dir = _single_file_agent(tmp_path)
+        result = provider_ops.agent_pin_set("solo", model="claude-x", agents_dir=agents_dir)
+        assert result["spec"]["model"] == "claude-x"
+
+    def test_pin_unknown_agent_is_not_found(self, tmp_path) -> None:
+        agents_dir = _bundle_agent(tmp_path)
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.agent_pin_set("ghost", model="m", agents_dir=agents_dir)
+        assert err.value.code == ErrorCode.NOT_FOUND
+
+    def test_pin_requires_something_to_set(self, tmp_path) -> None:
+        agents_dir = _bundle_agent(tmp_path)
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.agent_pin_set("my-agent", agents_dir=agents_dir)
+        assert err.value.code == ErrorCode.INVALID_INPUT
+
+    def test_clear_removes_provider_pin_but_keeps_inline_auth(self, tmp_path) -> None:
+        agents_dir = _bundle_agent(tmp_path)
+        provider_ops.agent_pin_set("my-agent", provider="openrouter", agents_dir=agents_dir)
+        # a spec with an inline api_key auth block must keep it
+        path = f"{agents_dir}/my-agent/config.yaml"
+        raw = yaml.safe_load(open(path))
+        raw["executor"]["auth"] = {"type": "api_key", "api_key": "sk-inline"}
+        open(path, "w").write(yaml.safe_dump(raw, sort_keys=False))
+
+        provider_ops.agent_pin_set("my-agent", provider="9router", agents_dir=agents_dir)
+        result = provider_ops.agent_pin_clear("my-agent", agents_dir=agents_dir)
+        assert result["spec"]["auth"] is None or (
+            isinstance(result["spec"]["auth"], dict)
+            and result["spec"]["auth"].get("type") != "provider"
+        )
+        # model pin was cleared too
+        assert result["spec"]["model"] is None
+
+    def test_clear_keeps_model_when_only_provider_requested(self, tmp_path) -> None:
+        agents_dir = _bundle_agent(tmp_path)
+        provider_ops.agent_pin_set(
+            "my-agent", provider="openrouter", model="gpt-x", agents_dir=agents_dir
+        )
+        result = provider_ops.agent_pin_clear(
+            "my-agent", provider=True, model=False, agents_dir=agents_dir
+        )
+        assert result["spec"]["model"] == "gpt-x"
+        assert result["spec"]["auth"] is None
+
+
+class TestRunProviderOp:
+    def test_unknown_op_is_invalid_input(self) -> None:
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.run_provider_op("reformat_disk", {})
+        assert err.value.code == ErrorCode.INVALID_INPUT
+
+    def test_wire_params_cannot_redirect_config_path(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """``config_path`` in frame params is ignored — ops hit the real file.
+
+        A remote caller must not be able to point a write at an arbitrary
+        path on the host; the dispatch always uses the host's own
+        ``OMNIGENT_CONFIG_HOME`` (here: a temp home the test controls).
+        """
+        real_home = tmp_path / "home"
+        (real_home / ".omnigent").mkdir(parents=True)
+        monkeypatch.setenv("OMNIGENT_CONFIG_HOME", str(real_home / ".omnigent"))
+
+        evil = tmp_path / "evil.yaml"
+        evil.write_text("{}")
+        provider_ops.run_provider_op(
+            "provider_upsert",
+            {"name": "gw", "entry": _gateway_entry(), "config_path": str(evil)},
+        )
+        # the write landed in the host's config, not the attacker-named file
+        written = yaml.safe_load(open(real_home / ".omnigent" / "config.yaml"))
+        assert "gw" in written["providers"]
+        assert yaml.safe_load(evil.read_text()) == {}
+
+    def test_wire_params_cannot_redirect_agents_dir(self, tmp_path, monkeypatch) -> None:
+        real_home = tmp_path / "home"
+        (real_home / ".omnigent").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(real_home))
+        evil = tmp_path / "evil-agents"
+        bundle = evil / "my-agent"
+        bundle.mkdir(parents=True)
+        (bundle / "config.yaml").write_text(
+            yaml.safe_dump({"spec_version": 1, "name": "my-agent", "executor": {}})
+        )
+        # The op must look at the host's real (empty) agents dir — hence
+        # NOT_FOUND — and never consult the attacker-named directory.
+        with pytest.raises(OmnigentError) as err:
+            provider_ops.run_provider_op(
+                "agent_pin_set",
+                {
+                    "agent": "my-agent",
+                    "model": "gpt-x",
+                    "agents_dir": str(evil),
+                },
+            )
+        assert err.value.code == ErrorCode.NOT_FOUND
+        assert list(evil.rglob("*.bak-*")) == []
+        assert yaml.safe_load(open(evil / "my-agent" / "config.yaml"))["executor"].get(
+            "model"
+        ) is None

--- a/web/src/components/modelProviders/ModelProvidersSection.test.tsx
+++ b/web/src/components/modelProviders/ModelProvidersSection.test.tsx
@@ -1,0 +1,144 @@
+// Tests for the ModelProviders settings section: providers and agent specs
+// render from the host hooks, the add-provider form builds an entry through
+// the upsert mutation, the pin dialog submits the agent's pin, and the Test
+// button fires the probe mutation. Host hooks and mutations are mocked.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ModelProvidersSection } from "./ModelProvidersSection";
+import * as hostsHook from "@/hooks/useHosts";
+import * as hooks from "@/hooks/useHostProviders";
+import type { HostProvider } from "@/lib/hostProvidersApi";
+
+vi.mock("@/hooks/useHosts", () => ({ useHosts: vi.fn() }));
+vi.mock("@/hooks/useHostProviders", () => ({
+  useHostProviders: vi.fn(),
+  useHostAgentSpecs: vi.fn(),
+  useUpsertHostProvider: vi.fn(),
+  useDeleteHostProvider: vi.fn(),
+  useTestHostProvider: vi.fn(),
+  usePinHostAgent: vi.fn(),
+  useClearHostAgentPin: vi.fn(),
+}));
+
+const HOST = { host_id: "host_1", name: "laptop", owner: "me", status: "online" } as const;
+
+const PROVIDERS: HostProvider[] = [
+  {
+    name: "openrouter",
+    kind: "gateway",
+    default: true,
+    openai: {
+      base_url: "https://openrouter.ai/api/v1",
+      api_key_set: true,
+      wire_api: "chat",
+      models: { default: "gpt-x", alt: "gpt-y" },
+    },
+  },
+];
+
+const AGENTS = [
+  {
+    name: "my-agent",
+    harness: "pi",
+    model: null,
+    auth: { type: "provider", name: "openrouter" },
+    spec_version: 1,
+    path: "/home/u/.omnigent/agents/my-agent/config.yaml",
+  },
+];
+
+let upsertMutate: ReturnType<typeof vi.fn>;
+let pinMutate: ReturnType<typeof vi.fn>;
+let testMutate: ReturnType<typeof vi.fn>;
+
+function mockQueries() {
+  vi.mocked(hooks.useHostProviders).mockReturnValue({
+    data: PROVIDERS,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof hooks.useHostProviders>);
+  vi.mocked(hooks.useHostAgentSpecs).mockReturnValue({
+    data: AGENTS,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof hooks.useHostAgentSpecs>);
+}
+
+beforeEach(() => {
+  upsertMutate = vi.fn();
+  pinMutate = vi.fn();
+  testMutate = vi.fn();
+  vi.mocked(hostsHook.useHosts).mockReturnValue({
+    data: [HOST],
+    isLoading: false,
+  } as unknown as ReturnType<typeof hostsHook.useHosts>);
+  mockQueries();
+  vi.mocked(hooks.useUpsertHostProvider).mockReturnValue({
+    mutate: upsertMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.useUpsertHostProvider>);
+  vi.mocked(hooks.useDeleteHostProvider).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.useDeleteHostProvider>);
+  vi.mocked(hooks.useTestHostProvider).mockReturnValue({
+    mutate: testMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.useTestHostProvider>);
+  vi.mocked(hooks.usePinHostAgent).mockReturnValue({
+    mutate: pinMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.usePinHostAgent>);
+  vi.mocked(hooks.useClearHostAgentPin).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof hooks.useClearHostAgentPin>);
+});
+
+afterEach(() => cleanup());
+
+describe("ModelProvidersSection", () => {
+  it("renders the host's providers and agent specs", () => {
+    render(<ModelProvidersSection />);
+    expect(screen.getByText("openrouter")).toBeTruthy();
+    expect(screen.getByText("https://openrouter.ai/api/v1")).toBeTruthy();
+    expect(screen.getByText("my-agent")).toBeTruthy();
+    expect(screen.getByText(/provider: openrouter/)).toBeTruthy();
+  });
+
+  it("submits a built entry through the upsert mutation", async () => {
+    render(<ModelProvidersSection />);
+    fireEvent.click(screen.getByText("Add provider"));
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "9router" } });
+    fireEvent.click(screen.getByText("Add", { exact: true }));
+    await waitFor(() => expect(upsertMutate).toHaveBeenCalledTimes(1));
+    const call = upsertMutate.mock.calls[0][0];
+    expect(call.name).toBe("9router");
+    expect(call.entry.kind).toBe("gateway");
+    expect(call.entry.openai).toBeTruthy();
+  });
+
+  it("submits the pin through the pin mutation", async () => {
+    render(<ModelProvidersSection />);
+    const pinButtons = screen.getAllByText("Pin");
+    // one Pin button per agent row
+    expect(pinButtons.length).toBe(1);
+    fireEvent.click(pinButtons[0]);
+    fireEvent.change(screen.getByLabelText("Model"), { target: { value: "gpt-x" } });
+    fireEvent.click(screen.getByText("Save pin"));
+    await waitFor(() => expect(pinMutate).toHaveBeenCalledTimes(1));
+    const call = pinMutate.mock.calls[0][0];
+    expect(call.agent).toBe("my-agent");
+    expect(call.pin.model).toBe("gpt-x");
+  });
+
+  it("fires the provider probe from the Test button", () => {
+    render(<ModelProvidersSection />);
+    fireEvent.click(screen.getByText("Test"));
+    expect(testMutate).toHaveBeenCalledWith(
+      "openrouter",
+      expect.objectContaining({ onSuccess: expect.any(Function) }),
+    );
+  });
+});

--- a/web/src/components/modelProviders/ModelProvidersSection.tsx
+++ b/web/src/components/modelProviders/ModelProvidersSection.tsx
@@ -1,0 +1,728 @@
+// Model providers & per-agent pins management — the settings surface for
+// the host config control plane (issue #7134). Talks to
+// `/v1/hosts/{id}/providers*` and `/v1/hosts/{id}/agent-specs*` via
+// `lib/hostProvidersApi.ts`.
+//
+// The host is the source of truth: validation, credential resolution, and
+// endpoint probing all run host-side. This surface edits forms, shows
+// probe results, and pins agents — it never sees a secret value (the API
+// returns `api_key_set` descriptors instead).
+
+import { useEffect, useMemo, useState } from "react";
+import { PencilIcon, PlusIcon, Trash2Icon, TriangleAlertIcon, ZapIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/scheduled/Label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { useHosts, type Host } from "@/hooks/useHosts";
+import {
+  useClearHostAgentPin,
+  useDeleteHostProvider,
+  useHostAgentSpecs,
+  useHostProviders,
+  usePinHostAgent,
+  useTestHostProvider,
+  useUpsertHostProvider,
+} from "@/hooks/useHostProviders";
+import type { HostAgentSpec, HostProvider, ProviderTestResult } from "@/lib/hostProvidersApi";
+
+const FAMILY_KINDS = new Set(["key", "gateway", "local"]);
+const FAMILIES = ["openai", "anthropic", "gemini"] as const;
+const PROVIDER_KINDS = ["key", "gateway", "local", "subscription"] as const;
+const SECRET_MODES = ["env", "keychain", "inline"] as const;
+type SecretMode = (typeof SECRET_MODES)[number];
+
+/** One family block of an entry, as the redacted wire returns it. */
+function familyBlock(entry: HostProvider): Record<string, unknown> | null {
+  for (const family of FAMILIES) {
+    const block = entry[family];
+    if (block && typeof block === "object") return block as Record<string, unknown>;
+  }
+  return null;
+}
+
+function baseUrlOf(entry: HostProvider): string {
+  const block = familyBlock(entry);
+  const url = block?.base_url;
+  return typeof url === "string" ? url : "";
+}
+
+function defaultModelOf(entry: HostProvider): string {
+  const block = familyBlock(entry);
+  const models = block?.models;
+  if (models && typeof models === "object" && !Array.isArray(models)) {
+    const def = (models as Record<string, unknown>).default;
+    if (typeof def === "string") return def;
+  }
+  return "";
+}
+
+function modelsOf(entry: HostProvider): string[] {
+  const block = familyBlock(entry);
+  const models = block?.models;
+  if (models && typeof models === "object" && !Array.isArray(models)) {
+    return Object.entries(models as Record<string, unknown>)
+      .filter(([key, value]) => key !== "default" && typeof value === "string")
+      .map(([, value]) => String(value));
+  }
+  return [];
+}
+
+function familyOf(entry: HostProvider): string {
+  for (const family of FAMILIES) {
+    if (entry[family] && typeof entry[family] === "object") return family;
+  }
+  return "openai";
+}
+
+/** Parse a redacted entry back into form state for editing. */
+function formStateFrom(entry: HostProvider): {
+  kind: string;
+  family: string;
+  baseUrl: string;
+  secretMode: SecretMode;
+  secretValue: string;
+  wireApi: string;
+  defaultModel: string;
+  isDefault: boolean;
+} {
+  const block = familyBlock(entry) ?? {};
+  let secretMode: SecretMode = "env";
+  let secretValue = "";
+  if (typeof block.api_key_ref === "string") {
+    secretMode = block.api_key_ref.startsWith("keychain:") ? "keychain" : "env";
+    secretValue = block.api_key_ref;
+  } else if (block.api_key_set === true) {
+    secretMode = "inline";
+    secretValue = ""; // the value never came back; leave blank unless replaced
+  } else if (typeof block.auth_command === "string") {
+    secretMode = "env"; // not editable here; treated as-is
+    secretValue = String(block.auth_command);
+  }
+  const wireApi = typeof block.wire_api === "string" ? block.wire_api : "chat";
+  const def = entry.default;
+  return {
+    kind: typeof entry.kind === "string" ? entry.kind : "gateway",
+    family: familyOf(entry),
+    baseUrl: baseUrlOf(entry),
+    secretMode,
+    secretValue,
+    wireApi,
+    defaultModel: defaultModelOf(entry),
+    isDefault: def === true || (Array.isArray(def) && def.length > 0) || typeof def === "string",
+  };
+}
+
+function buildEntry(form: {
+  kind: string;
+  family: string;
+  baseUrl: string;
+  secretMode: SecretMode;
+  secretValue: string;
+  wireApi: string;
+  defaultModel: string;
+  isDefault: boolean;
+}): Record<string, unknown> {
+  const entry: Record<string, unknown> = { kind: form.kind };
+  if (form.isDefault) entry.default = true;
+  if (form.kind === "subscription") return entry;
+  const block: Record<string, unknown> = {};
+  if (form.baseUrl.trim()) block.base_url = form.baseUrl.trim();
+  if (form.secretMode === "env" && form.secretValue.trim()) {
+    block.api_key_ref = form.secretValue.trim().startsWith("env:")
+      ? form.secretValue.trim()
+      : `env:${form.secretValue.trim()}`;
+  } else if (form.secretMode === "keychain" && form.secretValue.trim()) {
+    block.api_key_ref = form.secretValue.trim().startsWith("keychain:")
+      ? form.secretValue.trim()
+      : `keychain:${form.secretValue.trim()}`;
+  } else if (form.secretMode === "inline" && form.secretValue.trim()) {
+    block.api_key = form.secretValue.trim();
+  }
+  if (form.family === "openai") block.wire_api = form.wireApi;
+  const models: Record<string, string> = {};
+  if (form.defaultModel.trim()) models.default = form.defaultModel.trim();
+  if (Object.keys(models).length > 0) block.models = models;
+  entry[form.family] = block;
+  return entry;
+}
+
+interface ProviderFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hostId: string;
+  editing: HostProvider | null;
+}
+
+function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFormDialogProps) {
+  const [name, setName] = useState("");
+  const [kind, setKind] = useState<string>("gateway");
+  const [family, setFamily] = useState<string>("openai");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [secretMode, setSecretMode] = useState<SecretMode>("env");
+  const [secretValue, setSecretValue] = useState("");
+  const [wireApi, setWireApi] = useState("chat");
+  const [defaultModel, setDefaultModel] = useState("");
+  const [isDefault, setIsDefault] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const upsert = useUpsertHostProvider(hostId);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    if (editing) {
+      setName(editing.name);
+      const state = formStateFrom(editing);
+      setKind(state.kind);
+      setFamily(state.family);
+      setBaseUrl(state.baseUrl);
+      setSecretMode(state.secretMode);
+      setSecretValue(state.secretValue);
+      setWireApi(state.wireApi);
+      setDefaultModel(state.defaultModel);
+      setIsDefault(state.isDefault);
+    } else {
+      setName("");
+      setKind("gateway");
+      setFamily("openai");
+      setBaseUrl("");
+      setSecretMode("env");
+      setSecretValue("");
+      setWireApi("chat");
+      setDefaultModel("");
+      setIsDefault(false);
+    }
+  }, [open, editing]);
+
+  const submit = () => {
+    setError(null);
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    const entry = buildEntry({
+      kind,
+      family,
+      baseUrl,
+      secretMode,
+      secretValue,
+      wireApi,
+      defaultModel,
+      isDefault,
+    });
+    upsert.mutate(
+      { name: name.trim(), entry },
+      {
+        onSuccess: () => onOpenChange(false),
+        onError: (err) => setError(err.message),
+      },
+    );
+  };
+
+  const familyFields = FAMILY_KINDS.has(kind);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{editing ? `Edit provider ${editing.name}` : "Add provider"}</DialogTitle>
+          <DialogDescription>
+            Written to the host&apos;s <code>~/.omnigent/config.yaml</code> and validated with the
+            same parser the runtime uses. API keys are stored host-side.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="provider-name">Name</Label>
+            <Input
+              id="provider-name"
+              value={name}
+              disabled={editing !== null}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="openrouter"
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label>Kind</Label>
+              <Select value={kind} onValueChange={setKind}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PROVIDER_KINDS.map((k) => (
+                    <SelectItem key={k} value={k}>
+                      {k}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {familyFields && (
+              <div className="grid gap-2">
+                <Label>Family</Label>
+                <Select value={family} onValueChange={setFamily}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {FAMILIES.map((f) => (
+                      <SelectItem key={f} value={f}>
+                        {f}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+          {familyFields && (
+            <>
+              <div className="grid gap-2">
+                <Label htmlFor="provider-url">Base URL / endpoint</Label>
+                <Input
+                  id="provider-url"
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.target.value)}
+                  placeholder="https://openrouter.ai/api/v1"
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="grid gap-2">
+                  <Label>API key source</Label>
+                  <Select value={secretMode} onValueChange={(v) => setSecretMode(v as SecretMode)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="env">Environment variable</SelectItem>
+                      <SelectItem value="keychain">Keychain secret</SelectItem>
+                      <SelectItem value="inline">Inline key</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="provider-secret">
+                    {secretMode === "env"
+                      ? "Variable name"
+                      : secretMode === "keychain"
+                        ? "Secret name"
+                        : "API key"}
+                  </Label>
+                  <Input
+                    id="provider-secret"
+                    value={secretValue}
+                    onChange={(e) => setSecretValue(e.target.value)}
+                    placeholder={
+                      secretMode === "env"
+                        ? "OPENROUTER_API_KEY"
+                        : secretMode === "keychain"
+                          ? "anthropic"
+                          : "sk-…"
+                    }
+                  />
+                </div>
+              </div>
+              {family === "openai" && (
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="grid gap-2">
+                    <Label>Wire API</Label>
+                    <Select value={wireApi} onValueChange={setWireApi}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="chat">chat</SelectItem>
+                        <SelectItem value="responses">responses</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid gap-2">
+                    <Label htmlFor="provider-model">Default model</Label>
+                    <Input
+                      id="provider-model"
+                      value={defaultModel}
+                      onChange={(e) => setDefaultModel(e.target.value)}
+                      placeholder="gpt-4o"
+                    />
+                  </div>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <Switch id="provider-default" checked={isDefault} onCheckedChange={setIsDefault} />
+                <Label htmlFor="provider-default">Default provider for this family</Label>
+              </div>
+            </>
+          )}
+          {editing && secretMode === "inline" && secretValue === "" && (
+            <p className="text-muted-foreground text-xs">
+              The stored key is never shown. Leave blank to keep it, or type a new key to replace
+              it.
+            </p>
+          )}
+          {error && (
+            <p className="text-destructive flex items-center gap-1 text-sm">
+              <TriangleAlertIcon className="size-4" /> {error}
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={upsert.isPending}>
+            {editing ? "Save" : "Add"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface AgentPinDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hostId: string;
+  agent: HostAgentSpec | null;
+  providers: HostProvider[];
+}
+
+function AgentPinDialog({ open, onOpenChange, hostId, agent, providers }: AgentPinDialogProps) {
+  const [provider, setProvider] = useState<string>("");
+  const [model, setModel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const pin = usePinHostAgent(hostId);
+
+  useEffect(() => {
+    if (!open || !agent) return;
+    setError(null);
+    setProvider(agent.auth?.type === "provider" && agent.auth.name ? agent.auth.name : "");
+    setModel(agent.model ?? "");
+  }, [open, agent]);
+
+  const selected = useMemo(
+    () => providers.find((p) => p.name === provider) ?? null,
+    [providers, provider],
+  );
+  const suggestions = useMemo(
+    () => (selected ? [defaultModelOf(selected), ...modelsOf(selected)].filter(Boolean) : []),
+    [selected],
+  );
+
+  const submit = () => {
+    setError(null);
+    pin.mutate(
+      {
+        agent: (agent as HostAgentSpec).name,
+        pin: { provider: provider || null, model: model || null },
+      },
+      {
+        onSuccess: () => onOpenChange(false),
+        onError: (err) => setError(err.message),
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Pin {agent?.name}</DialogTitle>
+          <DialogDescription>
+            A provider/model pin overrides every ambient default for this agent — it wins over the
+            host default and the provider&apos;s own default model.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <div className="grid gap-2">
+            <Label>Provider</Label>
+            <Select value={provider} onValueChange={setProvider}>
+              <SelectTrigger>
+                <SelectValue placeholder="Host default" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Host default (no pin)</SelectItem>
+                {providers.map((p) => (
+                  <SelectItem key={p.name} value={p.name}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="pin-model">Model</Label>
+            <Input
+              id="pin-model"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              list="pin-model-suggestions"
+              placeholder={selected ? defaultModelOf(selected) || "model id" : "model id"}
+            />
+            <datalist id="pin-model-suggestions">
+              {suggestions.map((m) => (
+                <option key={m} value={m} />
+              ))}
+            </datalist>
+          </div>
+          {error && (
+            <p className="text-destructive flex items-center gap-1 text-sm">
+              <TriangleAlertIcon className="size-4" /> {error}
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={pin.isPending}>
+            Save pin
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Section body shown when the selected host is reachable. */
+function HostConfigPanels({ hostId }: { hostId: string }) {
+  const providersQuery = useHostProviders(hostId);
+  const agentsQuery = useHostAgentSpecs(hostId);
+  const deleteProvider = useDeleteHostProvider(hostId);
+  const testProvider = useTestHostProvider(hostId);
+  const clearPin = useClearHostAgentPin(hostId);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<HostProvider | null>(null);
+  const [pinAgent, setPinAgent] = useState<HostAgentSpec | null>(null);
+  const [testResults, setTestResults] = useState<Record<string, ProviderTestResult | "pending">>(
+    {},
+  );
+
+  const providers = providersQuery.data ?? [];
+  const agents = agentsQuery.data ?? [];
+
+  const runTest = (name: string) => {
+    setTestResults((prev) => ({ ...prev, [name]: "pending" }));
+    testProvider.mutate(name, {
+      onSuccess: (result) => setTestResults((prev) => ({ ...prev, [name]: result })),
+      onError: (err) =>
+        setTestResults((prev) => ({
+          ...prev,
+          [name]: { name, family: "", endpoint: "", ok: false, error: err.message },
+        })),
+    });
+  };
+
+  return (
+    <div className="grid gap-8">
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-medium">Providers</h2>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setEditing(null);
+              setFormOpen(true);
+            }}
+          >
+            <PlusIcon className="size-4" /> Add provider
+          </Button>
+        </div>
+        {providersQuery.isError && (
+          <p className="text-destructive text-sm">{(providersQuery.error as Error).message}</p>
+        )}
+        {providers.length === 0 && !providersQuery.isError && (
+          <p className="text-muted-foreground text-sm">No providers configured on this host yet.</p>
+        )}
+        <div className="grid gap-2">
+          {providers.map((entry) => {
+            const result = testResults[entry.name];
+            return (
+              <div
+                key={entry.name}
+                className="flex items-center justify-between gap-4 rounded-md border px-4 py-3"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{entry.name}</span>
+                    {typeof entry.kind === "string" && (
+                      <Badge variant="secondary">{entry.kind}</Badge>
+                    )}
+                    {entry.default === true && <Badge>default</Badge>}
+                  </div>
+                  <p className="text-muted-foreground truncate text-sm">
+                    {baseUrlOf(entry) || familyOf(entry)}
+                  </p>
+                  {result === "pending" && (
+                    <p className="text-muted-foreground text-xs">Testing…</p>
+                  )}
+                  {result && result !== "pending" && (
+                    <p
+                      className={
+                        result.ok
+                          ? "text-xs text-green-600 dark:text-green-400"
+                          : "text-destructive text-xs"
+                      }
+                    >
+                      {result.ok
+                        ? `OK ${result.http_status} · ${result.latency_ms}ms · ${result.models?.length ?? 0} models via ${result.endpoint}`
+                        : `Failed: ${result.error ?? `HTTP ${result.http_status}`}`}
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => runTest(entry.name)}
+                    disabled={result === "pending"}
+                  >
+                    <ZapIcon className="size-4" /> Test
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setEditing(entry);
+                      setFormOpen(true);
+                    }}
+                  >
+                    <PencilIcon className="size-4" /> Edit
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => deleteProvider.mutate(entry.name)}
+                    disabled={deleteProvider.isPending}
+                  >
+                    <Trash2Icon className="size-4" /> Delete
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div>
+        <h2 className="mb-3 text-lg font-medium">Agent specs</h2>
+        {agentsQuery.isError && (
+          <p className="text-destructive text-sm">{(agentsQuery.error as Error).message}</p>
+        )}
+        {agents.length === 0 && !agentsQuery.isError && (
+          <p className="text-muted-foreground text-sm">
+            No agent specs under <code>~/.omnigent/agents/</code> on this host.
+          </p>
+        )}
+        <div className="grid gap-2">
+          {agents.map((agent) => (
+            <div
+              key={agent.name}
+              className="flex items-center justify-between gap-4 rounded-md border px-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{agent.name}</span>
+                  {agent.harness && <Badge variant="secondary">{agent.harness}</Badge>}
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  {agent.model ?? "no model pin"}
+                  {agent.auth?.type === "provider" && agent.auth.name
+                    ? ` · provider: ${agent.auth.name}`
+                    : ""}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-1">
+                <Button variant="ghost" size="sm" onClick={() => setPinAgent(agent)}>
+                  <PencilIcon className="size-4" /> Pin
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => clearPin.mutate(agent.name)}
+                  disabled={clearPin.isPending || (agent.auth?.type !== "provider" && !agent.model)}
+                >
+                  <Trash2Icon className="size-4" /> Clear
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <ProviderFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        hostId={hostId}
+        editing={editing}
+      />
+      <AgentPinDialog
+        open={pinAgent !== null}
+        onOpenChange={(open) => {
+          if (!open) setPinAgent(null);
+        }}
+        hostId={hostId}
+        agent={pinAgent}
+        providers={providers}
+      />
+    </div>
+  );
+}
+
+/** Settings → Models: per-host providers and per-agent pins. */
+export function ModelProvidersSection() {
+  const { data: hosts, isLoading: hostsLoading } = useHosts();
+  const online = useMemo(() => (hosts ?? []).filter((h: Host) => h.status === "online"), [hosts]);
+  const [hostId, setHostId] = useState<string | null>(null);
+  const effectiveHostId = hostId ?? online[0]?.host_id ?? null;
+
+  return (
+    <section>
+      <h1 className="text-2xl font-semibold">Models &amp; providers</h1>
+      <p className="mt-1 text-muted-foreground text-ui">
+        Manage model providers on each connected host and pin a provider and model per agent.
+        Changes are written to the host&apos;s own configuration and validated there.
+      </p>
+      <div className="mt-6 grid gap-6">
+        <div className="grid gap-2 sm:max-w-xs">
+          <Label>Host</Label>
+          <Select value={effectiveHostId ?? undefined} onValueChange={(v) => setHostId(v)}>
+            <SelectTrigger disabled={hostsLoading || online.length === 0}>
+              <SelectValue placeholder={hostsLoading ? "Loading…" : "Select a host"} />
+            </SelectTrigger>
+            <SelectContent>
+              {online.map((h) => (
+                <SelectItem key={h.host_id} value={h.host_id}>
+                  {h.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {effectiveHostId ? (
+          <HostConfigPanels hostId={effectiveHostId} />
+        ) : (
+          !hostsLoading && (
+            <p className="text-muted-foreground text-sm">
+              No online hosts. Connect a host daemon to manage its providers.
+            </p>
+          )
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/modelProviders/ModelProvidersSection.tsx
+++ b/web/src/components/modelProviders/ModelProvidersSection.tsx
@@ -96,23 +96,23 @@ function formStateFrom(entry: HostProvider): {
   kind: string;
   family: string;
   baseUrl: string;
-  secretMode: SecretMode;
+  keySource: SecretMode;
   secretValue: string;
   wireApi: string;
   defaultModel: string;
   isDefault: boolean;
 } {
   const block = familyBlock(entry) ?? {};
-  let secretMode: SecretMode = "env";
+  let keySource: SecretMode = "env";
   let secretValue = "";
   if (typeof block.api_key_ref === "string") {
-    secretMode = block.api_key_ref.startsWith("keychain:") ? "keychain" : "env";
+    keySource = block.api_key_ref.startsWith("keychain:") ? "keychain" : "env";
     secretValue = block.api_key_ref;
   } else if (block.api_key_set === true) {
-    secretMode = "inline";
+    keySource = "inline";
     secretValue = ""; // the value never came back; leave blank unless replaced
   } else if (typeof block.auth_command === "string") {
-    secretMode = "env"; // not editable here; treated as-is
+    keySource = "env"; // not editable here; treated as-is
     secretValue = String(block.auth_command);
   }
   const wireApi = typeof block.wire_api === "string" ? block.wire_api : "chat";
@@ -121,7 +121,7 @@ function formStateFrom(entry: HostProvider): {
     kind: typeof entry.kind === "string" ? entry.kind : "gateway",
     family: familyOf(entry),
     baseUrl: baseUrlOf(entry),
-    secretMode,
+    keySource,
     secretValue,
     wireApi,
     defaultModel: defaultModelOf(entry),
@@ -133,7 +133,7 @@ function buildEntry(form: {
   kind: string;
   family: string;
   baseUrl: string;
-  secretMode: SecretMode;
+  keySource: SecretMode;
   secretValue: string;
   wireApi: string;
   defaultModel: string;
@@ -144,15 +144,15 @@ function buildEntry(form: {
   if (form.kind === "subscription") return entry;
   const block: Record<string, unknown> = {};
   if (form.baseUrl.trim()) block.base_url = form.baseUrl.trim();
-  if (form.secretMode === "env" && form.secretValue.trim()) {
+  if (form.keySource === "env" && form.secretValue.trim()) {
     block.api_key_ref = form.secretValue.trim().startsWith("env:")
       ? form.secretValue.trim()
       : `env:${form.secretValue.trim()}`;
-  } else if (form.secretMode === "keychain" && form.secretValue.trim()) {
+  } else if (form.keySource === "keychain" && form.secretValue.trim()) {
     block.api_key_ref = form.secretValue.trim().startsWith("keychain:")
       ? form.secretValue.trim()
       : `keychain:${form.secretValue.trim()}`;
-  } else if (form.secretMode === "inline" && form.secretValue.trim()) {
+  } else if (form.keySource === "inline" && form.secretValue.trim()) {
     block.api_key = form.secretValue.trim();
   }
   if (form.family === "openai") block.wire_api = form.wireApi;
@@ -175,7 +175,7 @@ function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFor
   const [kind, setKind] = useState<string>("gateway");
   const [family, setFamily] = useState<string>("openai");
   const [baseUrl, setBaseUrl] = useState("");
-  const [secretMode, setSecretMode] = useState<SecretMode>("env");
+  const [keySource, setSecretMode] = useState<SecretMode>("env");
   const [secretValue, setSecretValue] = useState("");
   const [wireApi, setWireApi] = useState("chat");
   const [defaultModel, setDefaultModel] = useState("");
@@ -192,7 +192,7 @@ function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFor
       setKind(state.kind);
       setFamily(state.family);
       setBaseUrl(state.baseUrl);
-      setSecretMode(state.secretMode);
+      setSecretMode(state.keySource);
       setSecretValue(state.secretValue);
       setWireApi(state.wireApi);
       setDefaultModel(state.defaultModel);
@@ -220,7 +220,7 @@ function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFor
       kind,
       family,
       baseUrl,
-      secretMode,
+      keySource,
       secretValue,
       wireApi,
       defaultModel,
@@ -306,7 +306,7 @@ function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFor
               <div className="grid grid-cols-2 gap-4">
                 <div className="grid gap-2">
                   <Label>API key source</Label>
-                  <Select value={secretMode} onValueChange={(v) => setSecretMode(v as SecretMode)}>
+                  <Select value={keySource} onValueChange={(v) => setSecretMode(v as SecretMode)}>
                     <SelectTrigger>
                       <SelectValue />
                     </SelectTrigger>
@@ -319,9 +319,9 @@ function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFor
                 </div>
                 <div className="grid gap-2">
                   <Label htmlFor="provider-secret">
-                    {secretMode === "env"
+                    {keySource === "env"
                       ? "Variable name"
-                      : secretMode === "keychain"
+                      : keySource === "keychain"
                         ? "Secret name"
                         : "API key"}
                   </Label>
@@ -330,9 +330,9 @@ function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFor
                     value={secretValue}
                     onChange={(e) => setSecretValue(e.target.value)}
                     placeholder={
-                      secretMode === "env"
+                      keySource === "env"
                         ? "OPENROUTER_API_KEY"
-                        : secretMode === "keychain"
+                        : keySource === "keychain"
                           ? "anthropic"
                           : "sk-…"
                     }
@@ -370,7 +370,7 @@ function ProviderFormDialog({ open, onOpenChange, hostId, editing }: ProviderFor
               </div>
             </>
           )}
-          {editing && secretMode === "inline" && secretValue === "" && (
+          {editing && keySource === "inline" && secretValue === "" && (
             <p className="text-muted-foreground text-xs">
               The stored key is never shown. Leave blank to keep it, or type a new key to replace
               it.

--- a/web/src/components/modelProviders/ModelProvidersSection.tsx
+++ b/web/src/components/modelProviders/ModelProvidersSection.tsx
@@ -453,7 +453,7 @@ function AgentPinDialog({ open, onOpenChange, hostId, agent, providers }: AgentP
           <div className="grid gap-2">
             <Label>Provider</Label>
             <Select value={provider} onValueChange={setProvider}>
-              <SelectTrigger>
+              <SelectTrigger aria-label="Pin provider">
                 <SelectValue placeholder="Host default" />
               </SelectTrigger>
               <SelectContent>

--- a/web/src/hooks/useHostProviders.ts
+++ b/web/src/hooks/useHostProviders.ts
@@ -1,0 +1,84 @@
+// React-query hooks for the host provider / agent-spec pin endpoints.
+// Query keys are namespaced per host so switching hosts in the section
+// refetches rather than cross-contaminating caches.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  clearHostAgentPin,
+  deleteHostProvider,
+  fetchHostAgentSpecs,
+  fetchHostProviders,
+  pinHostAgent,
+  testHostProvider,
+  upsertHostProvider,
+  type AgentPinInput,
+  type HostProvider,
+  type ProviderTestResult,
+} from "@/lib/hostProvidersApi";
+
+export function useHostProviders(hostId: string | null) {
+  return useQuery({
+    queryKey: ["host-providers", hostId],
+    queryFn: () => fetchHostProviders(hostId as string),
+    enabled: hostId !== null,
+  });
+}
+
+export function useHostAgentSpecs(hostId: string | null) {
+  return useQuery({
+    queryKey: ["host-agent-specs", hostId],
+    queryFn: () => fetchHostAgentSpecs(hostId as string),
+    enabled: hostId !== null,
+  });
+}
+
+function useInvalidateHostConfig(hostId: string | null) {
+  const queryClient = useQueryClient();
+  return () => {
+    void queryClient.invalidateQueries({ queryKey: ["host-providers", hostId] });
+    void queryClient.invalidateQueries({ queryKey: ["host-agent-specs", hostId] });
+  };
+}
+
+export function useUpsertHostProvider(hostId: string | null) {
+  const invalidate = useInvalidateHostConfig(hostId);
+  return useMutation({
+    mutationFn: ({ name, entry }: { name: string; entry: Record<string, unknown> }) =>
+      upsertHostProvider(hostId as string, name, entry),
+    onSuccess: invalidate,
+  });
+}
+
+export function useDeleteHostProvider(hostId: string | null) {
+  const invalidate = useInvalidateHostConfig(hostId);
+  return useMutation({
+    mutationFn: (name: string) => deleteHostProvider(hostId as string, name),
+    onSuccess: invalidate,
+  });
+}
+
+export function useTestHostProvider(hostId: string | null) {
+  return useMutation({
+    mutationFn: (name: string): Promise<ProviderTestResult> =>
+      testHostProvider(hostId as string, name),
+  });
+}
+
+export function usePinHostAgent(hostId: string | null) {
+  const invalidate = useInvalidateHostConfig(hostId);
+  return useMutation({
+    mutationFn: ({ agent, pin }: { agent: string; pin: AgentPinInput }) =>
+      pinHostAgent(hostId as string, agent, pin),
+    onSuccess: invalidate,
+  });
+}
+
+export function useClearHostAgentPin(hostId: string | null) {
+  const invalidate = useInvalidateHostConfig(hostId);
+  return useMutation({
+    mutationFn: (agent: string) => clearHostAgentPin(hostId as string, agent),
+    onSuccess: invalidate,
+  });
+}
+
+export type { HostProvider };

--- a/web/src/lib/hostProvidersApi.test.ts
+++ b/web/src/lib/hostProvidersApi.test.ts
@@ -1,0 +1,100 @@
+// Tests for the host-providers API client: URL/method/body shapes and the
+// FastAPI `detail` error extraction, with `authenticatedFetch` mocked.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearHostAgentPin,
+  fetchHostAgentSpecs,
+  fetchHostProviders,
+  HostProvidersApiError,
+  pinHostAgent,
+  testHostProvider,
+  upsertHostProvider,
+} from "./hostProvidersApi";
+
+vi.mock("./identity", () => ({ authenticatedFetch: vi.fn() }));
+
+const fetchMock = vi.mocked((await import("./identity")).authenticatedFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "X",
+    json: async () => body,
+  } as Response;
+}
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("hostProvidersApi", () => {
+  it("fetchHostProviders GETs the providers route and unwraps the list", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ providers: [{ name: "gw", kind: "gateway", openai: { api_key_set: true } }] }),
+    );
+    const providers = await fetchHostProviders("host_1");
+    expect(fetchMock).toHaveBeenCalledWith("/v1/hosts/host_1/providers");
+    expect(providers).toHaveLength(1);
+    expect(providers[0].name).toBe("gw");
+  });
+
+  it("upsertHostProvider PUTs the entry body", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    await upsertHostProvider("host_1", "gw", { kind: "gateway" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/hosts/host_1/providers/gw");
+    expect(init?.method).toBe("PUT");
+    expect(JSON.parse(String(init?.body))).toEqual({ entry: { kind: "gateway" } });
+  });
+
+  it("pinHostAgent PUTs null-padded pin fields", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    await pinHostAgent("host_1", "my-agent", { model: "gpt-x" });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/hosts/host_1/agent-specs/my-agent/pin");
+    expect(init?.method).toBe("PUT");
+    expect(JSON.parse(String(init?.body))).toEqual({ provider: null, model: "gpt-x" });
+  });
+
+  it("clearHostAgentPin DELETEs", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}));
+    await clearHostAgentPin("host_1", "my-agent");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/hosts/host_1/agent-specs/my-agent/pin");
+    expect(init?.method).toBe("DELETE");
+  });
+
+  it("testHostProvider POSTs and returns the probe result", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ name: "gw", family: "openai", endpoint: "https://x/v1/models", ok: true }),
+    );
+    const result = await testHostProvider("host_1", "gw");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/v1/hosts/host_1/providers/gw/test");
+    expect(init?.method).toBe("POST");
+    expect(result.ok).toBe(true);
+  });
+
+  it("surfaces the server's detail message on failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: "no provider named 'x'" }, 404));
+    await expect(fetchHostProviders("host_1")).rejects.toMatchObject({
+      name: "HostProvidersApiError",
+      status: 404,
+      message: "no provider named 'x'",
+    } satisfies Partial<HostProvidersApiError>);
+  });
+
+  it("fetchHostAgentSpecs unwraps the agents list", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        agents: [
+          { name: "my-agent", harness: "pi", model: null, auth: null, spec_version: 1, path: "/x" },
+        ],
+      }),
+    );
+    const agents = await fetchHostAgentSpecs("host_1");
+    expect(agents[0].name).toBe("my-agent");
+  });
+});

--- a/web/src/lib/hostProvidersApi.ts
+++ b/web/src/lib/hostProvidersApi.ts
@@ -1,0 +1,163 @@
+// Typed client for the host provider / agent-spec pin endpoints (config
+// control plane, part of issue #7134). Mirrors the `/v1/hosts/{id}/providers*`
+// and `/v1/hosts/{id}/agent-specs*` routes in
+// `omnigent/server/routes/hosts.py`; the wire payloads are defined by
+// `omnigent/host/provider_ops.py`.
+//
+// Secret handling mirrors the server: an inline `api_key` value is only ever
+// SENT (when the user types one) and never returned — listings carry
+// `api_key_set: true` instead. `api_key_ref` / `auth_command` are references,
+// not secrets, and pass through verbatim.
+
+import { authenticatedFetch } from "./identity";
+
+/** Provider kinds accepted by `providers:` entries. */
+export type ProviderKind =
+  "key" | "gateway" | "local" | "subscription" | "databricks" | "cli-config" | "bedrock";
+
+/** The inline credential families a provider entry may declare. */
+export type ProviderFamily = "anthropic" | "openai" | "gemini";
+
+/**
+ * One redacted provider entry as the wire returns it: family blocks carry
+ * `api_key_set: true` instead of a secret value; `api_key_ref` and
+ * `auth_command` are references the host resolves server/host-side.
+ */
+export interface HostProvider {
+  name: string;
+  kind?: ProviderKind;
+  default?: boolean | string | string[];
+  anthropic?: Record<string, unknown>;
+  openai?: Record<string, unknown>;
+  gemini?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** One host-local agent spec (`~/.omnigent/agents/`) and its current pins. */
+export interface HostAgentSpec {
+  name: string;
+  harness: string | null;
+  model: string | null;
+  auth: { type: string; name?: string } | null;
+  spec_version: number | string | null;
+  path: string;
+}
+
+export interface ProviderTestResult {
+  name: string;
+  family: string;
+  endpoint: string;
+  http_status?: number;
+  ok: boolean;
+  latency_ms?: number;
+  models?: string[];
+  error?: string;
+}
+
+/** Typed HTTP error carrying the server's `detail` (FastAPI shape). */
+export class HostProvidersApiError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "HostProvidersApiError";
+    this.status = status;
+  }
+}
+
+async function errorFromResponse(res: Response): Promise<HostProvidersApiError> {
+  let message = `${res.status} ${res.statusText}`;
+  try {
+    const body = (await res.json()) as { detail?: unknown };
+    if (typeof body.detail === "string" && body.detail) message = body.detail;
+  } catch {
+    // non-JSON body — keep the status line
+  }
+  return new HostProvidersApiError(message, res.status);
+}
+
+async function jsonOrThrow<T>(res: Response): Promise<T> {
+  if (!res.ok) throw await errorFromResponse(res);
+  return (await res.json()) as T;
+}
+
+/** List the host's providers, secrets redacted. */
+export async function fetchHostProviders(hostId: string): Promise<HostProvider[]> {
+  const res = await authenticatedFetch(`/v1/hosts/${encodeURIComponent(hostId)}/providers`);
+  const body = await jsonOrThrow<{ providers: HostProvider[] }>(res);
+  return body.providers;
+}
+
+/** Create or replace one provider entry (validated host-side). */
+export async function upsertHostProvider(
+  hostId: string,
+  name: string,
+  entry: Record<string, unknown>,
+): Promise<void> {
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/providers/${encodeURIComponent(name)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entry }),
+    },
+  );
+  await jsonOrThrow<unknown>(res);
+}
+
+/** Delete one provider entry. */
+export async function deleteHostProvider(hostId: string, name: string): Promise<void> {
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/providers/${encodeURIComponent(name)}`,
+    {
+      method: "DELETE",
+    },
+  );
+  await jsonOrThrow<unknown>(res);
+}
+
+/** Probe the provider's endpoint with its own credential. */
+export async function testHostProvider(hostId: string, name: string): Promise<ProviderTestResult> {
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/providers/${encodeURIComponent(name)}/test`,
+    { method: "POST" },
+  );
+  return jsonOrThrow<ProviderTestResult>(res);
+}
+
+/** List the host-local agent specs with their current pins. */
+export async function fetchHostAgentSpecs(hostId: string): Promise<HostAgentSpec[]> {
+  const res = await authenticatedFetch(`/v1/hosts/${encodeURIComponent(hostId)}/agent-specs`);
+  const body = await jsonOrThrow<{ agents: HostAgentSpec[] }>(res);
+  return body.agents;
+}
+
+export interface AgentPinInput {
+  provider?: string | null;
+  model?: string | null;
+}
+
+/** Pin an agent spec's provider and/or model. */
+export async function pinHostAgent(
+  hostId: string,
+  agentName: string,
+  pin: AgentPinInput,
+): Promise<void> {
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/agent-specs/${encodeURIComponent(agentName)}/pin`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: pin.provider ?? null, model: pin.model ?? null }),
+    },
+  );
+  await jsonOrThrow<unknown>(res);
+}
+
+/** Clear an agent spec's provider and model pins. */
+export async function clearHostAgentPin(hostId: string, agentName: string): Promise<void> {
+  const res = await authenticatedFetch(
+    `/v1/hosts/${encodeURIComponent(hostId)}/agent-specs/${encodeURIComponent(agentName)}/pin`,
+    { method: "DELETE" },
+  );
+  await jsonOrThrow<unknown>(res);
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -240,6 +240,8 @@ import {
 // Admin-only management surfaces, rendered as the Members / Policies settings
 // sub-categories. Visible to admins in all modes (accounts, OIDC, single-user).
 // Lazy-loaded to keep the settings chunk small.
+import { ModelProvidersSection } from "@/components/modelProviders/ModelProvidersSection";
+
 const MembersPage = lazy(() =>
   import("@/pages/MembersPage").then((m) => ({ default: m.MembersPage })),
 );
@@ -295,6 +297,7 @@ export function SettingsPage() {
       {section === "general" && <GeneralSection />}
       {section === "git" && <GitSection />}
       {section === "integrations" && <IntegrationsSection />}
+      {section === "models" && <ModelProvidersSection />}
       {section === "shortcuts" && <ShortcutsSection />}
       {section === "import" && <ImportSection />}
       {section === "account" && hasAuthSession && <AccountSection />}

--- a/web/src/shell/settingsNav.tsx
+++ b/web/src/shell/settingsNav.tsx
@@ -21,6 +21,7 @@ import {
   TerminalIcon,
   UserCogIcon,
   UsersIcon,
+  CpuIcon,
 } from "lucide-react";
 import { Link, useLocation } from "@/lib/routing";
 import { Button } from "@/components/ui/button";
@@ -36,6 +37,7 @@ export type SettingsSectionId =
   | "general"
   | "git"
   | "integrations"
+  | "models"
   | "shortcuts"
   | "import"
   | "account"
@@ -51,6 +53,7 @@ const SECTION_IDS: readonly SettingsSectionId[] = [
   "general",
   "git",
   "integrations",
+  "models",
   "shortcuts",
   "import",
   "account",
@@ -95,6 +98,7 @@ export function settingsNavGroups(
     { id: "general", label: "General", icon: SettingsIcon },
     { id: "appearance", label: "Appearance", icon: PaletteIcon },
     { id: "git", label: "Git", icon: GitBranchIcon },
+    { id: "models", label: "Models & providers", icon: CpuIcon },
     { id: "shortcuts", label: "Keyboard shortcuts", icon: KeyboardIcon, hideOnMobile: true },
     { id: "import", label: "Import sessions", icon: DownloadIcon },
   ];


### PR DESCRIPTION
## What

Config control plane — backend half of #7134. A panel (or API client) can now manage model providers on a connected host and pin a per-agent provider/model, in the same way tools like `opc-models` drive per-host, per-agent model selection:

- `GET|PUT|DELETE /v1/hosts/{id}/providers[/{name}]` — provider CRUD on the host's `~/.omnigent/config.yaml`
- `POST /v1/hosts/{id}/providers/{name}/test` — endpoint probe with the provider's own credential
- `GET /v1/hosts/{id}/agent-specs` — the host-local specs under `~/.omnigent/agents/` (what `omnigent run <agent>` resolves there), with their current pins
- `PUT|DELETE /v1/hosts/{id}/agent-specs/{name}/pin` — write/clear `executor.auth: {type: provider, name: ...}` (the runtime's strongest per-agent selector, fail-loud when undeclared) and/or `executor.model`

## How

One new generic frame pair, `host.provider_op` / `host.provider_op_result` (op + params, mirroring `host.fs_request`), plus a host-side ops module (`omnigent/host/provider_ops.py`) and the usual proxy routes in `hosts.py` — same auth, ownership, and wrong-replica-vs-offline classification as every other `/v1/hosts/{id}/*` endpoint.

Safety properties, enforced host-side:

- **Validation by the runtime's own parser**: every upsert re-runs `_parse_provider`, so an entry the runtime would reject never lands in `config.yaml`.
- **Backups**: every mutation backs the target file up (`*.bak-<epoch>`) before writing.
- **No secret egress**: listings and results redact inline `api_key` values to `api_key_set: true`; `api_key_ref` / `auth_command` pass through as the references they are. The test probe resolves the credential on the host and sends it only to the provider's own `base_url`.
- **No arbitrary-path writes**: the op dispatch ignores any `config_path` / `agents_dir` keys arriving on the wire — operations always run against the host's real `~/.omnigent` (regression-tested).
- **Pin semantics**: `executor.auth: {type: provider}` wins resolution over every ambient default and fails loud if the provider is undeclared (runtime `workflow.py` semantics); the existing #5105/#5101-era override behavior keeps pins alive across `omnigent run` invocations.

## Testing

- New `tests/host/test_provider_ops.py` (24 tests): CRUD round-trips, validation failures, redaction, backup creation, probe success/connection-failure via mocked `httpx`, agent pin set/clear on bundle + single-file specs, the no-arbitrary-path guards.
- Frame round-trip tests in `tests/host/test_frames.py`.
- Full `tests/host/` + `tests/cli/test_chat.py`: 721 passed (the 3 `model_options` failures in `test_connect.py` reproduce on pristine `upstream/main` and are unrelated).

## Web panel (part 2 — `e7caeb1` + follow-ups `d2bbf1a`, `4c61fbe`)

The panel surface consuming the endpoints above, now on this branch:

- **Settings → Models & providers**: host picker (online hosts), providers table (kind/family badges, base URL, default flag) with **Test** (inline probe result: status, latency, model count), **Edit**, **Delete**; agent-specs list with current model/provider pin and **Pin…/Clear** actions.
- **Add/edit provider dialog**: kind, family, base URL, credential source (env var / keychain secret / inline key), wire API (openai), default model, family-default switch. Written through the same validation as the runtime parser; invalid entries are rejected with the host-side error message.
- **Per-agent pin dialog**: provider select (or "host default") + model field with suggestions from the selected provider's catalog.
- The editing form works on the **redacted** wire entry, so a stored inline key is never displayed or round-tripped — leaving the field blank keeps the stored value.
- `lib/hostProvidersApi.ts` (typed client) + `hooks/useHostProviders.ts` (query/mutation hooks with cache invalidation); vitest coverage for the client and the section (11 tests).
- `4c61fbe` also moves the probe's credential resolution into a shared `credential_for_block()` helper in `onboarding/provider_config.py`, so the probe and the runtime turn path use one implementation.
- `tests/e2e_ui/settings/test_model_providers_section.py`: three Playwright journeys over the section (render, add-provider write path, pin write path) with the host control plane injected at the network layer — hermetic, LLM-free; verified green locally against the built SPA.

Verification: `tsc` clean (one pre-existing unrelated error on `main`), prettier/oxlint clean, 11/11 new vitest tests pass; python-side 124 tests still green after lint fixes (`ruff` clean).

Part of #7134
EXIT=0