### PR TITLE
fix(web): align composer PR text and open GitHub on mobile

### DIFF
--- a/tests/e2e_ui/github/test_github_tab.py
+++ b/tests/e2e_ui/github/test_github_tab.py
@@ -12,7 +12,8 @@ Three behaviours are pinned:
 1. Opening the GitHub rail tab renders the associated PR (title + number), its
    CI checks as labeled pills, and the branch-vs-base file tree — with a
    single-child directory chain (``src`` → ``app``) compacted into one row.
-2. The composer status line's ``#<pr>`` link opens that tab.
+2. The composer's PR link matches adjacent metadata text and opens GitHub on
+   desktop and mobile, with one or several PRs and default or large UI text.
 3. A host predating the ``/resources/github`` route 404s "Resource 'github'
    not found", which the panel renders as an actionable "update your host"
    empty state rather than the generic "unavailable" one.
@@ -24,10 +25,12 @@ from __future__ import annotations
 
 import json
 import re
+from pathlib import Path
 
-from playwright.sync_api import Page, expect
+import pytest
+from playwright.sync_api import Page, Route, expect
 
-from tests.e2e_ui.conftest import open_right_rail
+from tests.e2e_ui.conftest import fetch_with_retry, open_right_rail
 
 _PR_NUMBER = 4242
 
@@ -115,7 +118,7 @@ _PR_DIFF = {
 }
 
 
-def _stub_github(page: Page) -> None:
+def _stub_github(page: Page, *, pr_count: int = 1) -> None:
     """Answer the runner-backed GitHub endpoints with canned JSON — no real
     ``gh``/``git`` runs. Register before navigating so the first fetch is caught.
 
@@ -123,7 +126,24 @@ def _stub_github(page: Page) -> None:
     at the query/string boundary, so they never swallow ``/github/changes`` or
     the per-file ``/github/diff/<path>``.
     """
-    page.route(re.compile(r"/resources/github(?:\?|$)"), lambda r: r.fulfill(json=_INFO))
+    info = _INFO
+    if pr_count > 1:
+        info = {
+            **_INFO,
+            "tracking_available": True,
+            "selected_pr_url": _INFO["pr"]["url"],
+            "prs": [
+                {
+                    "url": f"https://example.com/pr/{_PR_NUMBER + index}",
+                    "host": "example.com",
+                    "repository": "acme/app",
+                    "number": _PR_NUMBER + index,
+                    "relationship": "created",
+                }
+                for index in range(pr_count)
+            ],
+        }
+    page.route(re.compile(r"/resources/github(?:\?|$)"), lambda r: r.fulfill(json=info))
     page.route(re.compile(r"/resources/github/changes"), lambda r: r.fulfill(json=_CHANGES))
     page.route(re.compile(r"/resources/github/diff(?:\?|$)"), lambda r: r.fulfill(json=_PR_DIFF))
     page.route(
@@ -175,24 +195,97 @@ def test_github_tab_shows_summary_checks_and_file_tree(
     expect(rail.get_by_role("button", name=re.compile(r"main\.py")).first).to_be_visible()
 
 
+@pytest.mark.parametrize(
+    "viewport_width",
+    [1280, pytest.param(390, marks=pytest.mark.browser_context_args(has_touch=True))],
+    ids=["desktop", "mobile"],
+)
+@pytest.mark.parametrize("font_size", [13, 18], ids=["default-font", "large-font"])
+@pytest.mark.parametrize("pr_count", [1, 2], ids=["single-pr", "multiple-pr"])
 def test_composer_pr_link_opens_github_tab(
     page: Page,
     seeded_session: tuple[str, str],
+    tmp_path: Path,
+    viewport_width: int,
+    font_size: int,
+    pr_count: int,
 ) -> None:
-    """The composer status line's #<pr> link opens the GitHub tab."""
+    """PR metadata uses the caption size and opens the appropriate GitHub surface."""
     base_url, session_id = seeded_session
-    _stub_github(page)
+    is_mobile = viewport_width < 768
+    workspace = "/workspace/demo-app"
+    branch = "feature/pr-link"
+
+    def session_details(route: Route) -> None:
+        response = fetch_with_retry(route)
+        snapshot = response.json()
+        snapshot.update(workspace=workspace, git_branch=branch, host_id="composer-pr-host")
+        route.fulfill(response=response, json=snapshot)
+
+    page.route(re.compile(rf"/v1/sessions/{session_id}(?:\?.*)?$"), session_details)
+    page.route(
+        "**/v1/hosts/composer-pr-host/worktrees?*",
+        lambda route: route.fulfill(
+            json={
+                "data": [{"path": workspace, "branch": branch, "is_main": True, "detached": False}]
+            }
+        ),
+    )
+    _stub_github(page, pr_count=pr_count)
+    page.add_init_script(f"localStorage.setItem('omnigent:ui-font-size', '{font_size}')")
+    page.set_viewport_size({"width": viewport_width, "height": 844 if is_mobile else 900})
     page.goto(f"{base_url}/c/{session_id}")
 
-    # The link appears once GitHub info resolves (a PR is associated).
     pr_link = page.get_by_test_id("composer-pr-link")
     expect(pr_link).to_be_visible(timeout=30_000)
-    expect(pr_link).to_contain_text(f"#{_PR_NUMBER}")
+    expect(pr_link).to_have_accessible_name(f"#{_PR_NUMBER}" if pr_count == 1 else "2 PRs")
+    expect(page.get_by_test_id("composer-workspace-dir")).to_have_text("demo-app")
+    expect(page.get_by_test_id("composer-git-branch")).to_have_text(branch)
+    font_sizes = {}
+    for test_id in ("composer-pr-link", "composer-workspace-dir", "composer-git-branch"):
+        label = page.get_by_test_id(test_id).locator("span")
+        expect(label).to_be_visible()
+        font_sizes[test_id] = label.evaluate("el => parseFloat(getComputedStyle(el).fontSize)")
+    print(f"Composer fonts ({viewport_width}px, {font_size}px preference): {font_sizes}")
+    page.screenshot(path=tmp_path / "composer-pr-link.png", animations="disabled")
 
-    # Clicking it opens the rail on the GitHub tab with the PR loaded.
-    pr_link.click()
-    rail = page.get_by_role("complementary", name="Workspace")
-    expect(rail.get_by_text("Add the GitHub tab")).to_be_visible(timeout=30_000)
+    # Mobile has a full-screen drawer, not the desktop workspace tab strip.
+    if is_mobile:
+        pr_link.tap()
+    else:
+        pr_link.click()
+    panel = (
+        page.get_by_test_id("github-panel-drawer")
+        if is_mobile
+        else page.get_by_role("complementary", name="Workspace")
+    )
+    try:
+        if is_mobile:
+            expect(panel).to_have_attribute("data-state", "open")
+        else:
+            expect(panel.get_by_role("tab", name="GitHub")).to_have_attribute(
+                "aria-selected", "true"
+            )
+        expect(panel.get_by_text("Add the GitHub tab", exact=True)).to_be_visible(timeout=30_000)
+        expect(panel.get_by_label("Pull request status: Open")).to_be_visible()
+        expect(panel.get_by_text("Nice work!", exact=True)).to_be_visible()
+        if pr_count > 1:
+            expect(panel.get_by_role("combobox", name="Session pull request")).to_have_text(
+                f"example.com/acme/app #{_PR_NUMBER}"
+            )
+    finally:
+        page.screenshot(path=tmp_path / "composer-pr-link-after-click.png", animations="disabled")
+
+    if is_mobile:
+        panel.get_by_role("button", name="Close", exact=True).click()
+        expect(panel).to_have_attribute("data-state", "closed")
+        expect(pr_link).to_be_in_viewport()
+
+    for test_id in ("composer-workspace-dir", "composer-git-branch"):
+        assert font_sizes["composer-pr-link"] == pytest.approx(font_sizes[test_id], abs=0.01), (
+            f"PR label should match adjacent composer metadata at {font_size}px preference: "
+            f"{font_sizes}"
+        )
 
 
 def _stub_github_outdated_host(page: Page) -> None:

--- a/web/src/components/composer/ComposerPrLink.test.tsx
+++ b/web/src/components/composer/ComposerPrLink.test.tsx
@@ -21,6 +21,7 @@ describe("ComposerPrLink", () => {
     render(<ComposerPrLink prCount={1} prNumber={42} onOpen={onOpen} />);
     const link = screen.getByTestId("composer-pr-link");
     expect(link).toHaveTextContent("#42");
+    expect(link).toHaveClass("text-sm");
     expect(link).toHaveAttribute("title", "View this PR in the GitHub tab");
     fireEvent.click(link);
     expect(onOpen).toHaveBeenCalledTimes(1);
@@ -30,6 +31,7 @@ describe("ComposerPrLink", () => {
     render(<ComposerPrLink prCount={3} prNumber={42} onOpen={() => {}} />);
     const link = screen.getByTestId("composer-pr-link");
     expect(link).toHaveTextContent("3 PRs");
+    expect(link).toHaveClass("text-sm");
     expect(link).toHaveAttribute("title", "View these PRs in the GitHub tab");
   });
 });

--- a/web/src/components/composer/ComposerPrLink.tsx
+++ b/web/src/components/composer/ComposerPrLink.tsx
@@ -31,7 +31,7 @@ export function ComposerPrLink({
       onClick={() => onOpen()}
       title={prCount > 1 ? "View these PRs in the GitHub tab" : "View this PR in the GitHub tab"}
       className={cn(
-        "flex shrink-0 items-center gap-1.5 rounded text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        "flex shrink-0 items-center gap-1.5 rounded text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         className,
       )}
     >

--- a/web/src/shell/AppShell.githubTabVisibility.test.tsx
+++ b/web/src/shell/AppShell.githubTabVisibility.test.tsx
@@ -9,10 +9,11 @@ import type * as UseConversationsModule from "@/hooks/useConversations";
 import type * as UseGithubModule from "@/hooks/useGithub";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { Link, MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { readSessionWorkspaceState, writeSessionWorkspaceState } from "@/lib/sessionWorkspaceState";
 
 vi.mock("@/hooks/useConversations", async (importOriginal) => ({
   ...(await importOriginal<typeof UseConversationsModule>()),
@@ -56,7 +57,13 @@ vi.mock("@/hooks/useAgents", () => ({
   useUpdateMcpServer: () => ({ mutate: vi.fn(), isPending: false, error: null }),
   useDeleteMcpServer: () => ({ mutate: vi.fn(), isPending: false, error: null }),
 }));
-vi.mock("./Sidebar", () => ({ Sidebar: () => <div data-testid="sidebar" /> }));
+vi.mock("./Sidebar", () => ({
+  Sidebar: () => <div data-testid="sidebar" />,
+  isMobileViewport: vi.fn(() => false),
+}));
+vi.mock("./GithubPanel", () => ({
+  GithubPanel: () => <div data-testid="github-panel">Pull request details</div>,
+}));
 vi.mock("./FilesPanel", () => ({
   FilesPanel: () => <div data-testid="files-panel" />,
 }));
@@ -74,6 +81,8 @@ vi.mock("./TerminalsPanel", () => ({
 }));
 
 import { AppShell } from "./AppShell";
+import { useOpenGithubTab } from "./FileViewerContext";
+import { isMobileViewport } from "./Sidebar";
 import { useGithubInfo } from "@/hooks/useGithub";
 import { useConversations } from "@/hooks/useConversations";
 
@@ -86,6 +95,7 @@ beforeEach(() => {
   // localStorage; clear it so one test's writes can't leak into another.
   localStorage.clear();
   sessionStorage.clear();
+  vi.mocked(isMobileViewport).mockReturnValue(false);
   useGithubInfoMock.mockReset();
   useGithubInfoMock.mockReturnValue({ data: undefined, isLoading: true } as ReturnType<
     typeof useGithubInfo
@@ -118,6 +128,18 @@ beforeEach(() => {
   } as never);
 });
 
+function GithubLinkProbe() {
+  const openGithubTab = useOpenGithubTab();
+  return (
+    <>
+      <button type="button" onClick={() => openGithubTab?.()}>
+        Open PR
+      </button>
+      <Link to="/c/conv_other">Another session</Link>
+    </>
+  );
+}
+
 function renderShell() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
@@ -126,7 +148,7 @@ function renderShell() {
         <MemoryRouter initialEntries={["/c/conv_ws"]}>
           <Routes>
             <Route element={<AppShell />}>
-              <Route path="c/:conversationId" element={<div>chat</div>} />
+              <Route path="c/:conversationId" element={<GithubLinkProbe />} />
             </Route>
           </Routes>
         </MemoryRouter>
@@ -182,5 +204,58 @@ describe("GitHub rail tab visibility", () => {
     renderShell();
 
     expect(screen.getByRole("tab", { name: "GitHub" })).toBeInTheDocument();
+  });
+});
+
+describe("opening GitHub from the composer", () => {
+  beforeEach(() => {
+    writeSessionWorkspaceState("conv_ws", { open: false, rightRailTab: "files" });
+  });
+
+  it("opens and dismisses the mobile drawer without opening the hidden desktop rail", () => {
+    vi.mocked(isMobileViewport).mockReturnValue(true);
+    renderShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open PR" }));
+
+    const drawer = screen.getByTestId("github-panel-drawer");
+    expect(drawer).toHaveAttribute("data-state", "open");
+    expect(within(drawer).getByTestId("github-panel")).toBeInTheDocument();
+    expect(readSessionWorkspaceState("conv_ws").open).toBe(false);
+    expect(screen.getAllByTestId("github-panel")).toHaveLength(1);
+
+    fireEvent.click(within(drawer).getByRole("button", { name: "Close" }));
+
+    expect(drawer).toHaveAttribute("data-state", "closed");
+    expect(within(drawer).queryByTestId("github-panel")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open PR" })).toBeInTheDocument();
+  });
+
+  it("opens the desktop GitHub tab without mounting the mobile panel", () => {
+    renderShell();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open PR" }));
+
+    const workspace = screen.getByRole("complementary", { name: "Workspace" });
+    expect(within(workspace).getByRole("tab", { name: "GitHub" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(within(workspace).getByTestId("github-panel")).toBeInTheDocument();
+    expect(readSessionWorkspaceState("conv_ws").open).toBe(true);
+    const drawer = screen.getByTestId("github-panel-drawer");
+    expect(drawer).toHaveAttribute("data-state", "closed");
+    expect(within(drawer).queryByTestId("github-panel")).not.toBeInTheDocument();
+  });
+
+  it("closes the mobile GitHub drawer when navigating to another session", () => {
+    vi.mocked(isMobileViewport).mockReturnValue(true);
+    renderShell();
+    fireEvent.click(screen.getByRole("button", { name: "Open PR" }));
+    expect(screen.getByTestId("github-panel-drawer")).toHaveAttribute("data-state", "open");
+
+    fireEvent.click(screen.getByRole("link", { name: "Another session" }));
+
+    expect(screen.getByTestId("github-panel-drawer")).toHaveAttribute("data-state", "closed");
   });
 });

--- a/web/src/shell/AppShell.tsx
+++ b/web/src/shell/AppShell.tsx
@@ -1005,6 +1005,7 @@ export function AppShell() {
     setFilesPanelOpen(false);
     setSubagentsPanelOpen(false);
     setShellsPanelOpen(false);
+    setGithubPanelOpen(false);
     setFilesPanelShowHidden(true);
     // Drop shell interaction state carried from the outgoing session: a
     // still-armed create ref would otherwise auto-focus an unrelated shell in
@@ -1193,21 +1194,6 @@ export function AppShell() {
     },
     [setPanelInitialKey, terminalFirst, setSearchParams, conversationId],
   );
-
-  // Reveal the rail on the GitHub tab (from the composer's PR link). Mirrors
-  // openFileViewer's rail-reveal, but deselects any file/shell so the tab's
-  // own content (the stacked diff) shows rather than the FileViewer.
-  const openGithubTab = useCallback(() => {
-    setSelectedFilePath(null);
-    setSelectedTerminalKey(null);
-    if (!terminalFirst) setPanelInitialKey(null);
-    setExecutionLogsKey(null);
-    setFilesPanelOpen(false);
-    setSubagentsPanelOpen(false);
-    setRightRailTab("github");
-    setRightPanelOpen(true);
-    if (conversationId) writeSessionWorkspaceState(conversationId, { open: true });
-  }, [conversationId, terminalFirst, setPanelInitialKey]);
 
   // Strip the file-viewer URL params (file/diff/comment). Memoized on
   // ``setSearchParams`` so it always closes over react-router's *current*
@@ -1698,7 +1684,7 @@ export function AppShell() {
   // Mobile FAB → "GitHub" opens the GitHub panel as a full-screen drawer
   // (matches the desktop rail's GitHub tab; the panel handles all states —
   // not-a-git-repo, no gh CLI, unauthenticated, no PR — itself).
-  function openGithubPanel() {
+  const openGithubPanel = useCallback(() => {
     setSelectedFilePath(null); // close file viewer
     clearFileViewerUrl();
     setPanelInitialKey(null); // close terminals panel
@@ -1707,7 +1693,25 @@ export function AppShell() {
     setSubagentsPanelOpen(false); // close mobile agents drawer
     setShellsPanelOpen(false); // close mobile shells drawer
     setGithubPanelOpen(true);
-  }
+  }, [clearFileViewerUrl, setPanelInitialKey]);
+
+  // Composer links open the mobile drawer or reveal the desktop GitHub tab.
+  // Deselect files/shells so the chosen panel owns its content slot.
+  const openGithubTab = useCallback(() => {
+    if (isMobileViewport()) {
+      openGithubPanel();
+      return;
+    }
+    setSelectedFilePath(null);
+    setSelectedTerminalKey(null);
+    if (!terminalFirst) setPanelInitialKey(null);
+    setExecutionLogsKey(null);
+    setFilesPanelOpen(false);
+    setSubagentsPanelOpen(false);
+    setRightRailTab("github");
+    setRightPanelOpen(true);
+    if (conversationId) writeSessionWorkspaceState(conversationId, { open: true });
+  }, [conversationId, terminalFirst, setPanelInitialKey, openGithubPanel]);
 
   function openMainExecutionLog() {
     // Mobile FAB → "Execution logs" jumps straight to the main thread.

--- a/web/src/shell/FileViewerContext.tsx
+++ b/web/src/shell/FileViewerContext.tsx
@@ -6,7 +6,7 @@ import { createContext, useContext } from "react";
 
 interface FileViewerContextType {
   openFile: (path: string) => void;
-  /** Reveal the workspace rail and switch it to the GitHub tab. */
+  /** Open GitHub in the workspace rail or mobile drawer. */
   openGithubTab: () => void;
   /**
    * Returns true when `path` is a known workspace file (present in the
@@ -45,7 +45,7 @@ export function useFileViewer(): ((path: string) => void) | null {
 }
 
 /**
- * Returns a callback that reveals the workspace rail's GitHub tab, or `null`
+ * Returns a callback that opens the GitHub rail tab or mobile drawer, or `null`
  * when used outside AppShell (tests, Storybook).
  */
 export function useOpenGithubTab(): (() => void) | null {


### PR DESCRIPTION
## Related issue

Closes #7268

## Summary

- The composer PR link used body-sized text instead of the neighboring caption size (16px vs. 12.6px on mobile). Give single-PR and multiple-PR labels the shared, Appearance-aware `text-sm` size.
- Mobile taps previously opened only the hidden desktop rail. Reuse the existing mobile GitHub drawer, preserving desktop behavior and closing the drawer when switching sessions.

## Test Plan

- Reproduced on main `3ff3292fe`: mobile clicks leave the GitHub drawer closed in Chromium and WebKit; browser-measured PR text is larger than adjacent labels. New font and mobile callback unit assertions also fail before the fix.
- `cd web && pnpm test`: **7,604 passed**, 3 expected failures, 1 skipped.
- `uv run --no-sync pytest tests/e2e_ui/github/test_github_tab.py --ui-skip-build --browser chromium --browser webkit -vv`: **20 passed**, including 16 composer cases covering desktop/mobile, normal/large fonts, and single/multiple PRs. Mobile uses real touch events; tests verify PR details and Close back to chat.
- Production build and repository pre-commit hooks passed, including TypeScript and frontend lint.
- Human check: on mobile, open a session with a PR, compare its label with the directory/branch text, tap it to open GitHub, and tap Close. Repeat with enlarged Appearance text and confirm desktop still opens the workspace tab.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Real WebKit screenshots at 390px width with synthetic GitHub/workspace data. The check counts shown inside the demo PR are fixtures, not this PR's CI results.

Before/after composer comparison (cropped screenshots, default Appearance size):

![Before and after: PR text matches neighboring captions](https://github.com/user-attachments/assets/a60775d8-17db-4ec9-856c-1c6b12fdebc9)

After tapping the single-PR link:

![Mobile tap opens the GitHub drawer with PR details](https://github.com/user-attachments/assets/3c920c33-8ec1-42e4-b532-f26ea7a73042)

After tapping `2 PRs`:

![Multiple-PR link opens the drawer and PR selector](https://github.com/user-attachments/assets/d8f11eba-1b6b-4f4c-8fea-ccf478d55f67)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Visually inspected the before/after screenshots and opened mobile drawer. Mobile interactions were verified with Playwright touch emulation in Chromium/WebKit, not a physical iPhone. Unit coverage also checks desktop rail persistence, mobile dismissal, and drawer cleanup on session navigation.

## Changelog

Composer PR links match nearby text and open GitHub details when tapped on mobile.
