### PR TITLE
fix(web): prevent mobile composer focus zoom

### DIFF
--- a/tests/e2e_ui/mobile/test_composer_input_font_size.py
+++ b/tests/e2e_ui/mobile/test_composer_input_font_size.py
@@ -42,14 +42,16 @@ def _metrics(element: Locator) -> dict[str, Any]:
 
 def _exercise_input(page: Page, element: Locator, *, mobile: bool) -> None:
     expect(element).to_be_visible(timeout=30_000)
-    element.tap() if mobile else element.click()
+    # The landing's interactive skill pills can cover the input's center.
+    activate = element.tap if mobile else element.click
+    activate(position={"x": 8, "y": 8})
     expect(element).to_be_focused()
     element.fill("First line")
     element.press("Enter" if mobile else "Shift+Enter")
     page.keyboard.insert_text("Second line")
     expect(element).to_have_value("First line\nSecond line")
     element.blur()
-    element.tap() if mobile else element.click()
+    activate(position={"x": 8, "y": 8})
     expect(element).to_be_focused()
     expect(element).to_have_value("First line\nSecond line")
 

--- a/tests/e2e_ui/mobile/test_composer_input_font_size.py
+++ b/tests/e2e_ui/mobile/test_composer_input_font_size.py
@@ -1,0 +1,191 @@
+"""Composer inputs avoid Safari's small-text focus-zoom trigger without capping preferences.
+
+Desktop WebKit verifies CSS and focus, not the real iOS software keyboard's zoom.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+from tests.e2e_ui.conftest import seed_committed_turn
+from tests.e2e_ui.mobile.test_ios_ipad_safe_layout import _IOS_SHELL_INIT_SCRIPT
+from tests.e2e_ui.sessions.test_reply_quotes_session_switch import _reply_to
+
+_TOUCH = pytest.mark.browser_context_args(has_touch=True)
+_AGENT_SCAN = re.compile(r"/v1/sessions\?.*kind=any")
+
+
+def _metrics(element: Locator) -> dict[str, Any]:
+    return element.evaluate("""element => {
+        const style = getComputedStyle(element);
+        const px = property => parseFloat(style[property]) || 0;
+        const bounds = element.getBoundingClientRect();
+        return {
+            fontSize: px('fontSize'), lineHeight: px('lineHeight'),
+            fontFamily: style.fontFamily, fontWeight: style.fontWeight,
+            letterSpacing: style.letterSpacing, whiteSpace: style.whiteSpace,
+            overflowWrap: style.overflowWrap, wordBreak: style.wordBreak,
+            contentX: bounds.left + element.clientLeft + px('paddingLeft'),
+            contentY: bounds.top + element.clientTop + px('paddingTop'),
+            contentWidth: element.clientWidth - px('paddingLeft') - px('paddingRight'),
+            contentHeight: element.scrollHeight - px('paddingTop') - px('paddingBottom'),
+            scrollHeight: element.scrollHeight, clientHeight: element.clientHeight,
+            horizontalOverflow: element.scrollWidth - element.clientWidth,
+        };
+    }""")
+
+
+def _exercise_input(page: Page, element: Locator, *, mobile: bool) -> None:
+    expect(element).to_be_visible(timeout=30_000)
+    element.tap() if mobile else element.click()
+    expect(element).to_be_focused()
+    element.fill("First line")
+    element.press("Enter" if mobile else "Shift+Enter")
+    page.keyboard.insert_text("Second line")
+    expect(element).to_have_value("First line\nSecond line")
+    element.blur()
+    element.tap() if mobile else element.click()
+    expect(element).to_be_focused()
+    expect(element).to_have_value("First line\nSecond line")
+
+
+@pytest.mark.parametrize(
+    ("width", "font_size", "native"),
+    [
+        pytest.param(390, 11, False, marks=_TOUCH, id="mobile-small"),
+        pytest.param(390, 13, False, marks=_TOUCH, id="mobile-default"),
+        pytest.param(390, 18, False, marks=_TOUCH, id="mobile-large"),
+        pytest.param(1440, 11, False, id="desktop-small"),
+        pytest.param(1440, 13, False, id="desktop-default"),
+        pytest.param(1440, 18, False, id="desktop-large"),
+        pytest.param(390, 13, True, marks=_TOUCH, id="ios-default"),
+        pytest.param(390, 18, True, marks=_TOUCH, id="ios-large"),
+    ],
+)
+def test_composer_input_font_floor_and_alignment(
+    page: Page,
+    seeded_session: tuple[str, str],
+    tmp_path: Path,
+    width: int,
+    font_size: int,
+    native: bool,
+) -> None:
+    """Landing, command backdrops and interleaved replies share readable input typography."""
+    base_url, session_id = seeded_session
+    mobile = width < 768
+    page.set_viewport_size({"width": width, "height": 844})
+    page.add_init_script(f"localStorage.setItem('omnigent:ui-font-size', '{font_size}')")
+    if native:
+        page.add_init_script(_IOS_SHELL_INIT_SCRIPT)
+    quotes = ["First point to discuss.", "Second point to discuss."]
+    seed_committed_turn(session_id, prompt="Explain both points.", reply="\n\n".join(quotes))
+
+    # A bundled skill exposes the landing input's text-ui placeholder overlay.
+    page.route(
+        "**/v1/agents",
+        lambda route: route.fulfill(
+            json={
+                "data": [
+                    {
+                        "id": "ag_font_e2e",
+                        "name": "polly",
+                        "display_name": "Polly",
+                        "description": "Typography test agent",
+                        "harness": "claude-sdk",
+                        "skills": [{"name": "context", "description": "Review context"}],
+                    }
+                ]
+            }
+        ),
+    )
+    page.route(_AGENT_SCAN, lambda route: route.fulfill(json={"data": []}))
+    page.goto(f"{base_url}/")
+    landing = page.get_by_test_id("new-chat-landing-input")
+    hint = page.get_by_text("Describe a task, or try a skill", exact=True)
+    expect(hint).to_be_visible(timeout=30_000)
+    observed = {"landing-hint": _metrics(hint)}
+    skill_metrics = _metrics(page.get_by_test_id("skill-pill-context"))
+    page.screenshot(path=tmp_path / "landing-placeholder.png", animations="disabled")
+    _exercise_input(page, landing, mobile=mobile)
+    observed.update(
+        {"landing": _metrics(landing), "landing-area": _metrics(landing.locator(".."))}
+    )
+    page.screenshot(path=tmp_path / "landing-composer.png", animations="disabled")
+    page.unroute("**/v1/agents")
+    page.unroute(_AGENT_SCAN)
+
+    page.goto(f"{base_url}/c/{session_id}")
+    if native:
+        expect(page.locator(".app-shell")).to_have_attribute("data-ios-native", "true")
+    main = page.get_by_role("textbox", name="Message the agent", exact=True)
+    _exercise_input(page, main, mobile=mobile)
+    observed.update({"session": _metrics(main), "session-area": _metrics(main.locator(".."))})
+    page.screenshot(path=tmp_path / "session-composer.png", animations="disabled")
+
+    # Both mirrors must exceed the height cap so scrollHeight measures text wrapping.
+    draft = "/context " + "review this multiline draft " * 100 + "\n" + "unbroken" * 80
+    main.fill(draft)
+    expect(main).to_have_attribute("data-slash-command", "true")
+    overlay = page.get_by_test_id("composer-highlight-overlay")
+    expect(overlay).to_be_visible()
+    assert overlay.evaluate("element => element.textContent") == draft
+    observed.update({"slash-input": _metrics(main), "slash-overlay": _metrics(overlay)})
+    page.screenshot(path=tmp_path / "slash-command-overlay.png", animations="disabled")
+
+    # A nonempty introduction mounts the first editable block before its quote.
+    main.fill("My introduction.")
+    for index, quote in enumerate(quotes, start=1):
+        paragraph = page.locator('[data-role="assistant"]').get_by_text(quote, exact=True)
+        expect(paragraph).to_be_visible()
+        _reply_to(page, paragraph)
+        reply = page.get_by_role("textbox", name=f"Reply text before quote {index}", exact=True)
+        expect(reply).to_have_value("My introduction." if index == 1 else "My first answer.")
+        observed[f"reply-{index}"] = _metrics(reply)
+        main.fill("My first answer." if index == 1 else "My second answer.")
+    expect(page.get_by_test_id("composer-reply-blocks").locator("textarea")).to_have_count(2)
+    expect(overlay).to_have_count(0)
+    observed["reply-tail"] = _metrics(main)
+    quote_metrics = _metrics(
+        page.get_by_test_id("composer-reply-quote").first.locator("blockquote")
+    )
+    page.screenshot(path=tmp_path / "interleaved-replies.png", animations="disabled")
+
+    # Preserve every surface's baseline evidence before reporting typography failures.
+    print(f"Composer typography ({width}px, preference={font_size}, native={native}): {observed}")
+    ui_size = font_size * (14 / 13) if mobile else font_size
+    expected_size = max(16, ui_size) if mobile else ui_size
+    for name, measured in observed.items():
+        assert measured["fontSize"] == pytest.approx(expected_size, abs=0.01), (name, measured)
+        assert measured["lineHeight"] == pytest.approx(expected_size * 1.6, abs=0.02), (
+            name,
+            measured,
+        )
+    assert quote_metrics["fontSize"] == pytest.approx(ui_size * 0.9, abs=0.01)
+    assert skill_metrics["fontSize"] == pytest.approx(ui_size, abs=0.01)
+
+    textarea_metrics, overlay_metrics = observed["slash-input"], observed["slash-overlay"]
+    for property_name in (
+        "fontFamily",
+        "fontWeight",
+        "letterSpacing",
+        "whiteSpace",
+        "overflowWrap",
+        "wordBreak",
+    ):
+        assert textarea_metrics[property_name] == overlay_metrics[property_name], property_name
+    for measured in (textarea_metrics, overlay_metrics):
+        assert measured["scrollHeight"] > measured["clientHeight"], measured
+        assert measured["horizontalOverflow"] <= 1, measured
+    for property_name in ("contentX", "contentY", "contentWidth", "contentHeight"):
+        assert textarea_metrics[property_name] == pytest.approx(
+            overlay_metrics[property_name], abs=2
+        ), (property_name, textarea_metrics, overlay_metrics)
+
+    viewport = page.locator('meta[name="viewport"]').get_attribute("content") or ""
+    assert "user-scalable=no" not in viewport.replace(" ", "").lower()
+    assert "maximum-scale" not in viewport.lower()

--- a/web/src/components/composer/ChatComposer.test.tsx
+++ b/web/src/components/composer/ChatComposer.test.tsx
@@ -33,18 +33,19 @@ describe("ChatComposer", () => {
     expect(onSubmit).toHaveBeenCalledOnce();
   });
 
-  it("uses the settings-driven chat typography for the draft and input area", () => {
+  it("scopes responsive draft typography to the input area, not the toolbar", () => {
     render(
       <ChatComposer
         keyboard={{ submitWithModEnter: false, preventsKeyboardSubmit: false }}
         input={{ "aria-label": "Draft" }}
-        actions={{ leading: null, trailing: null }}
+        actions={{ leading: <span>Composer actions</span>, trailing: null }}
       />,
     );
     const input = screen.getByRole("textbox");
-    expect(input).toHaveClass("text-ui");
-    expect(input.parentElement).toHaveClass("text-ui");
+    expect(input).toHaveClass("composer-input-text", "text-ui");
+    expect(input.parentElement).toHaveClass("composer-input-text", "text-ui");
     expect(input).not.toHaveClass("text-[13px]", "leading-[20.8px]");
+    expect(screen.getByText("Composer actions").closest(".composer-input-text")).toBeNull();
   });
 
   it("preserves interrupt and pending-creation states", () => {

--- a/web/src/components/composer/ChatComposer.tsx
+++ b/web/src/components/composer/ChatComposer.tsx
@@ -108,7 +108,13 @@ export function ComposerTextInput({
 
 export function ComposerInputArea({ className, ...props }: ComponentPropsWithoutRef<"div">) {
   return (
-    <div className={cn("relative overflow-hidden px-3 pt-3 pb-1 text-ui", className)} {...props} />
+    <div
+      className={cn(
+        "composer-input-text relative overflow-hidden px-3 pt-3 pb-1 text-ui",
+        className,
+      )}
+      {...props}
+    />
   );
 }
 
@@ -124,7 +130,7 @@ export const ComposerTextarea = forwardRef<
     <textarea
       ref={ref}
       className={cn(
-        "relative min-h-[42px] max-h-[180px] w-full resize-none overflow-y-auto border-none bg-transparent p-0 text-ui text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground disabled:opacity-60 md:select-text [&::-webkit-scrollbar]:hidden",
+        "composer-input-text relative min-h-[42px] max-h-[180px] w-full resize-none overflow-y-auto border-none bg-transparent p-0 text-ui text-foreground outline-none [scrollbar-width:none] placeholder:text-muted-foreground disabled:opacity-60 md:select-text [&::-webkit-scrollbar]:hidden",
         className,
       )}
       {...props}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1098,6 +1098,13 @@ aside[aria-label="Workspace"][data-maximized] {
     --text-ui: var(--mobile-ui-font-size);
   }
 
+  /* Keep draft text and its mirrors above Safari's input-focus zoom threshold.
+   * Native inputs must also preserve larger Appearance sizes. */
+  .composer-input-text,
+  [data-ios-native] textarea.composer-input-text {
+    font-size: max(16px, var(--text-ui));
+  }
+
   /* Keep mobile sidebar glyphs uniform. Desktop icon geometry is unchanged. */
   .conversations-sidebar {
     --sidebar-icon-size-mobile: 16px;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3510,7 +3510,7 @@ function ComposerImpl(
               ref={backdropRef}
               aria-hidden
               data-testid="composer-highlight-overlay"
-              className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-3 pt-3 pb-1 text-ui text-foreground"
+              className="composer-input-text pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-3 pt-3 pb-1 text-ui text-foreground"
             >
               {(() => {
                 const split = splitSlashCommand(value);

--- a/web/src/shell/NewChatDialog.tsx
+++ b/web/src/shell/NewChatDialog.tsx
@@ -5544,7 +5544,7 @@ export function NewChatLandingScreen() {
                   textarea; the pills themselves opt back in. */}
                     {pillSkills.length > 0 && message.length === 0 && (
                       <div className="pointer-events-none absolute inset-x-3 top-3 flex flex-wrap items-center gap-2">
-                        <span className="text-ui text-muted-foreground">
+                        <span className="composer-input-text text-ui text-muted-foreground">
                           Describe a task, or try a skill
                         </span>
                         <SkillPills skills={pillSkills} onPick={applySkillPill} />


### PR DESCRIPTION
## Related issue

Closes #7272

## Summary

- The mobile composer rendered at 14px by default, below iPhone Safari's 16px input-focus zoom threshold. Give editable composer text a mobile-only `max(16px, var(--text-ui))` floor, without restricting pinch zoom.
- Keep the landing hint, slash-command mirror, and interleaved reply fields aligned. Preserve larger Appearance settings, desktop sizing, toolbar text, skill pills, and quote captions; the native iOS override also preserves larger input sizes.

## Test Plan

- Unfixed main `52019cc39`: new browser regressions report **8 failures / 8 passing controls** across Chromium and WebKit. Default mobile input text is 14px; the smallest preference renders at 11.85px.
- `cd web && pnpm test`: **7,604 passed**, 3 expected failures, 1 skipped. Focused composer/landing tests: **187 passed**.
- New font/focus/wrapping matrix: **16 passed** across Chromium and WebKit (`uv run --no-sync pytest tests/e2e_ui/mobile/test_composer_input_font_size.py --ui-skip-build --browser chromium --browser webkit`). Existing mobile Appearance/Enter cases: **4 passed**; composer growth/scrollbar cases: **3 passed**.
- Production build and repository pre-commit hooks passed, including TypeScript and frontend lint.
- Human check: in iPhone Safari, set Appearance font size to 13, reload, tap the session composer, type several lines, dismiss the keyboard, and focus again. Confirm the page does not automatically zoom. Repeat on New session, check larger Appearance text still grows, and confirm pinch zoom remains available.

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Real browser screenshots with synthetic data at a 390px mobile viewport. These verify the input-size safeguard and layout in WebKit, **not the physical iPhone keyboard/zoom behavior**.

Before/after session composer at the default Appearance setting (14px → 16px):

![Mobile composer text before and after the focus-zoom safeguard](https://github.com/user-attachments/assets/97d53532-bc0b-42f4-a207-4777cde1c118)

Aligned landing hint and interleaved reply fields after the fix:

![Mobile landing hint and reply inputs after the fix](https://github.com/user-attachments/assets/3172d91c-250f-43cd-8544-bbefafd20564)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Visually inspected before/after screenshots. Automated touch focus/refocus, multiline entry, computed font sizes/line heights, and long-draft wrapping cover both Chromium and WebKit. The matrix includes desktop/mobile Appearance sizes 11/13/18 and native-iOS CSS at 13/18. A physical iPhone or configured iOS simulator is unavailable here; actual keyboard-triggered zoom remains a real-device verification step.

The broader local reply/send test passed its input, rendered-message, and exact send-order assertions, then timed out awaiting the mock assistant after a host setup error. An isolated run on the unfixed code (`6b0cd27`, same source tree as main `52019cc39`) fails identically. No unrelated host/test changes are included.

## Changelog

Mobile composer text stays large enough to avoid Safari's automatic focus zoom while preserving pinch zoom and larger font preferences.
