### PR TITLE
fix(web): align and space composer workspace metadata

### DIFF
--- a/tests/e2e_ui/chat/test_composer_acceptance.py
+++ b/tests/e2e_ui/chat/test_composer_acceptance.py
@@ -14,20 +14,40 @@ from tests.e2e_ui.conftest import fetch_with_retry
 
 @pytest.mark.parametrize("theme", ["light", "dark"])
 @pytest.mark.parametrize(
-    ("viewport_width", "font_size"),
+    ("viewport_width", "font_size", "pr_number", "font_family"),
     [
-        pytest.param(1280, 13, id="desktop-default"),
+        pytest.param(1280, 13, 1234, None, id="desktop-default"),
         pytest.param(
             390,
             18,
+            1234,
+            None,
             marks=pytest.mark.browser_context_args(has_touch=True),
             id="mobile-crowded",
         ),
         pytest.param(
             375,
             18,
+            1234,
+            None,
             marks=pytest.mark.browser_context_args(has_touch=True),
             id="mobile-narrow-crowded",
+        ),
+        pytest.param(
+            375,
+            18,
+            1234567,
+            None,
+            marks=pytest.mark.browser_context_args(has_touch=True),
+            id="mobile-long-pr",
+        ),
+        pytest.param(
+            375,
+            18,
+            1234,
+            "Verdana",
+            marks=pytest.mark.browser_context_args(has_touch=True),
+            id="mobile-wide-font",
         ),
     ],
 )
@@ -38,6 +58,8 @@ def test_status_counts_and_pr_share_workspace_bar(
     theme: str,
     viewport_width: int,
     font_size: int,
+    pr_number: int,
+    font_family: str | None,
 ) -> None:
     base_url, session_id = seeded_session
     is_mobile = viewport_width < 768
@@ -72,9 +94,9 @@ def test_status_counts_and_pr_share_workspace_bar(
                 "repo": {"name_with_owner": "example/repo"},
                 "branch": "pr-head-not-checkout",
                 "pr": {
-                    "number": 1234,
+                    "number": pr_number,
                     "title": "Acceptance PR",
-                    "url": "https://github.com/example/repo/pull/1234",
+                    "url": f"https://github.com/example/repo/pull/{pr_number}",
                     "state": "OPEN",
                     "is_draft": False,
                     "checks": {"passing": 0, "failing": 0, "pending": 0, "total": 0, "runs": []},
@@ -102,15 +124,23 @@ def test_status_counts_and_pr_share_workspace_bar(
     page.emulate_media(color_scheme=theme)
     page.add_init_script(f"localStorage.setItem('web-theme', '{theme}')")
     page.add_init_script(f"localStorage.setItem('omnigent:ui-font-size', '{font_size}')")
+    if font_family is not None:
+        page.add_init_script(
+            f"localStorage.setItem('omnigent:ui-font-family', JSON.stringify('{font_family}'))"
+        )
     page.set_viewport_size({"width": viewport_width, "height": 844 if is_mobile else 900})
     _publish_status(base_url, session_id, "idle", background_task_count=2)
     page.goto(f"{base_url}/c/{session_id}")
     bar = page.get_by_test_id("composer-workspace-controls")
-    expect(bar.get_by_test_id("composer-pr-link").locator("span").last).to_have_text(
-        "#1234", timeout=30_000
-    )
+    pr_link = bar.get_by_test_id("composer-pr-link")
+    pr_label = pr_link.locator("span").last
+    expect(pr_label).to_have_text(f"#{pr_number}", timeout=30_000)
+    expect(pr_link).to_have_accessible_name(f"#{pr_number}")
     context = bar.get_by_test_id("composer-context-ring")
     expect(context).to_have_text("100%")
+    if font_family is not None:
+        applied_family = context.evaluate("el => getComputedStyle(el).fontFamily")
+        assert applied_family.split(",")[0].strip("\"' ") == font_family
     expect(bar.get_by_test_id("background-task-pill")).to_have_text("2")
     expect(bar.get_by_test_id("subagent-task-pill")).to_have_text("1")
     expect(bar).to_contain_text("live-branch")
@@ -140,7 +170,8 @@ def test_status_counts_and_pr_share_workspace_bar(
     )
     print(
         f"Status bar ({viewport_width}px, {font_size}px preference, {theme}): "
-        f"bar={bounds}, controls={control_bounds}, icons={icon_bounds}, font={measured_font}"
+        f"bar={bounds}, controls={control_bounds}, icons={icon_bounds}, "
+        f"font={measured_font}, family={font_family or 'system'}"
     )
     bar.screenshot(path=tmp_path / f"status-bar-{theme}.png", animations="disabled")
     page.screenshot(path=tmp_path / f"status-page-{theme}.png", animations="disabled")
@@ -155,6 +186,11 @@ def test_status_counts_and_pr_share_workspace_bar(
     assert trailing["x"] + trailing["width"] == pytest.approx(
         bounds["x"] + bounds["width"] - 9, abs=0.5
     )
+    if pr_number == 1234567:
+        assert pr_label.evaluate("el => el.scrollWidth > el.clientWidth")
+        expect(pr_label).to_have_attribute("title", f"#{pr_number}")
+    elif viewport_width >= 390:
+        assert pr_label.evaluate("el => el.scrollWidth <= el.clientWidth + 1")
     for test_id in status_ids:
         rect = control_bounds[test_id]
         assert rect["y"] + rect["height"] / 2 == pytest.approx(center_y, abs=0.5)
@@ -192,6 +228,15 @@ def test_status_counts_and_pr_share_workspace_bar(
         bar.get_by_test_id("subagent-task-pill").click()
     expect(page.get_by_role("dialog")).to_contain_text("Review changes")
     page.keyboard.press("Escape")
+    if is_mobile and (pr_number == 1234567 or font_family is not None):
+        pr_link.tap()
+        panel = page.get_by_test_id("github-panel-drawer")
+        expect(panel).to_have_attribute("data-state", "open")
+        expect(panel).to_be_visible()
+        panel.screenshot(path=tmp_path / "truncated-pr-open.png", animations="disabled")
+        panel.get_by_role("button", name="Close", exact=True).tap()
+        expect(panel).to_have_attribute("data-state", "closed")
+        expect(pr_link).to_be_in_viewport()
     _publish_status(base_url, session_id, "idle", background_task_count=0)
     expect(bar.get_by_test_id("background-task-pill")).to_have_count(0)
     page.unroute_all(behavior="wait")

--- a/tests/e2e_ui/chat/test_composer_acceptance.py
+++ b/tests/e2e_ui/chat/test_composer_acceptance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from itertools import pairwise
 from pathlib import Path
 
 import pytest
@@ -12,15 +13,45 @@ from tests.e2e_ui.conftest import fetch_with_retry
 
 
 @pytest.mark.parametrize("theme", ["light", "dark"])
+@pytest.mark.parametrize(
+    ("viewport_width", "font_size"),
+    [
+        pytest.param(1280, 13, id="desktop-default"),
+        pytest.param(
+            390,
+            18,
+            marks=pytest.mark.browser_context_args(has_touch=True),
+            id="mobile-crowded",
+        ),
+        pytest.param(
+            375,
+            18,
+            marks=pytest.mark.browser_context_args(has_touch=True),
+            id="mobile-narrow-crowded",
+        ),
+    ],
+)
 def test_status_counts_and_pr_share_workspace_bar(
-    page: Page, seeded_session: tuple[str, str], tmp_path: Path, theme: str
+    page: Page,
+    seeded_session: tuple[str, str],
+    tmp_path: Path,
+    theme: str,
+    viewport_width: int,
+    font_size: int,
 ) -> None:
     base_url, session_id = seeded_session
+    is_mobile = viewport_width < 768
 
     def snapshot(route):
         response = fetch_with_retry(route)
         body = response.json()
-        body.update(workspace="/work/repo", host_id="acceptance-host", git_branch="old")
+        body.update(
+            workspace="/work/repo",
+            host_id="acceptance-host",
+            git_branch="old",
+            context_window=1_000_000,
+            last_total_tokens=1_000_000,
+        )
         route.fulfill(response=response, json=body)
 
     page.route(re.compile(rf"/v1/sessions/{session_id}(?:\?.*)?$"), snapshot)
@@ -41,9 +72,9 @@ def test_status_counts_and_pr_share_workspace_bar(
                 "repo": {"name_with_owner": "example/repo"},
                 "branch": "pr-head-not-checkout",
                 "pr": {
-                    "number": 123,
+                    "number": 1234,
                     "title": "Acceptance PR",
-                    "url": "https://github.com/example/repo/pull/123",
+                    "url": "https://github.com/example/repo/pull/1234",
                     "state": "OPEN",
                     "is_draft": False,
                     "checks": {"passing": 0, "failing": 0, "pending": 0, "total": 0, "runs": []},
@@ -70,25 +101,95 @@ def test_status_counts_and_pr_share_workspace_bar(
     )
     page.emulate_media(color_scheme=theme)
     page.add_init_script(f"localStorage.setItem('web-theme', '{theme}')")
+    page.add_init_script(f"localStorage.setItem('omnigent:ui-font-size', '{font_size}')")
+    page.set_viewport_size({"width": viewport_width, "height": 844 if is_mobile else 900})
     _publish_status(base_url, session_id, "idle", background_task_count=2)
     page.goto(f"{base_url}/c/{session_id}")
     bar = page.get_by_test_id("composer-workspace-controls")
     expect(bar.get_by_test_id("composer-pr-link").locator("span").last).to_have_text(
-        "#123", timeout=30_000
+        "#1234", timeout=30_000
     )
+    context = bar.get_by_test_id("composer-context-ring")
+    expect(context).to_have_text("100%")
     expect(bar.get_by_test_id("background-task-pill")).to_have_text("2")
     expect(bar.get_by_test_id("subagent-task-pill")).to_have_text("1")
     expect(bar).to_contain_text("live-branch")
     expect(bar).not_to_contain_text("pr-head-not-checkout")
     bounds = bar.bounding_box()
     assert bounds is not None
-    for test_id in ("composer-pr-link", "background-task-pill", "subagent-task-pill"):
-        rect = bar.get_by_test_id(test_id).bounding_box()
+    status_ids = (
+        "composer-pr-link",
+        "composer-context-ring",
+        "background-task-pill",
+        "subagent-task-pill",
+    )
+    control_bounds = {}
+    icon_bounds = {}
+    for test_id in ("composer-workspace-dir", "composer-git-branch", *status_ids):
+        control = bar.get_by_test_id(test_id)
+        rect = control.bounding_box()
         assert rect is not None
-        assert rect["x"] > bounds["x"] + bounds["width"] / 2
-        assert bounds["y"] <= rect["y"] < bounds["y"] + bounds["height"]
+        control_bounds[test_id] = rect
+        icon_bounds[test_id] = []
+        for icon in control.locator("svg").all():
+            icon_rect = icon.bounding_box()
+            assert icon_rect is not None
+            icon_bounds[test_id].append(icon_rect)
+    measured_font = context.locator("span").evaluate(
+        "el => parseFloat(getComputedStyle(el).fontSize)"
+    )
+    print(
+        f"Status bar ({viewport_width}px, {font_size}px preference, {theme}): "
+        f"bar={bounds}, controls={control_bounds}, icons={icon_bounds}, font={measured_font}"
+    )
     bar.screenshot(path=tmp_path / f"status-bar-{theme}.png", animations="disabled")
-    bar.get_by_test_id("subagent-task-pill").click()
+    page.screenshot(path=tmp_path / f"status-page-{theme}.png", animations="disabled")
+    assert measured_font == pytest.approx(
+        font_size * 0.9 * (14 / 13 if is_mobile else 1), abs=0.01
+    )
+    directory_icon = icon_bounds["composer-workspace-dir"][0]
+    center_y = directory_icon["y"] + directory_icon["height"] / 2
+    assert bounds["height"] == pytest.approx(37, abs=0.5)
+    assert center_y == pytest.approx(bounds["y"] + 19, abs=0.5)
+    trailing = control_bounds[status_ids[-1]]
+    assert trailing["x"] + trailing["width"] == pytest.approx(
+        bounds["x"] + bounds["width"] - 9, abs=0.5
+    )
+    for test_id in status_ids:
+        rect = control_bounds[test_id]
+        assert rect["y"] + rect["height"] / 2 == pytest.approx(center_y, abs=0.5)
+    for test_id, rect in control_bounds.items():
+        assert rect["x"] >= bounds["x"] - 0.5, (test_id, rect, bounds)
+        assert rect["x"] + rect["width"] <= bounds["x"] + bounds["width"] + 0.5, (
+            test_id,
+            rect,
+            bounds,
+        )
+        assert rect["y"] >= bounds["y"] - 0.5, (test_id, rect, bounds)
+        assert rect["y"] + rect["height"] <= bounds["y"] + bounds["height"] + 0.5, (
+            test_id,
+            rect,
+            bounds,
+        )
+        for icon in icon_bounds[test_id]:
+            assert icon["x"] >= rect["x"] - 0.5, (test_id, icon, rect)
+            assert icon["x"] + icon["width"] <= rect["x"] + rect["width"] + 0.5, (
+                test_id,
+                icon,
+                rect,
+            )
+    ordered_icons = [(test_id, icon) for test_id, icons in icon_bounds.items() for icon in icons]
+    for (left_id, left), (right_id, right) in pairwise(ordered_icons):
+        assert left["x"] + left["width"] <= right["x"] + 0.5, (
+            left_id,
+            left,
+            right_id,
+            right,
+        )
+    if is_mobile:
+        bar.get_by_test_id("subagent-task-pill").tap()
+    else:
+        bar.get_by_test_id("subagent-task-pill").click()
     expect(page.get_by_role("dialog")).to_contain_text("Review changes")
     page.keyboard.press("Escape")
     _publish_status(base_url, session_id, "idle", background_task_count=0)

--- a/tests/e2e_ui/github/test_github_tab.py
+++ b/tests/e2e_ui/github/test_github_tab.py
@@ -12,8 +12,8 @@ Three behaviours are pinned:
 1. Opening the GitHub rail tab renders the associated PR (title + number), its
    CI checks as labeled pills, and the branch-vs-base file tree — with a
    single-child directory chain (``src`` → ``app``) compacted into one row.
-2. The composer's PR link matches adjacent metadata text and opens GitHub on
-   desktop and mobile, with one or several PRs and default or large UI text.
+2. Composer metadata stays aligned and visually grouped, and its PR link opens
+   GitHub on desktop and mobile with one or several PRs at different text sizes.
 3. A host predating the ``/resources/github`` route 404s "Resource 'github'
    not found", which the panel renders as an actionable "update your host"
    empty state rather than the generic "unavailable" one.
@@ -200,7 +200,9 @@ def test_github_tab_shows_summary_checks_and_file_tree(
     [1280, pytest.param(390, marks=pytest.mark.browser_context_args(has_touch=True))],
     ids=["desktop", "mobile"],
 )
-@pytest.mark.parametrize("font_size", [13, 18], ids=["default-font", "large-font"])
+@pytest.mark.parametrize(
+    "font_size", [11, 13, 18], ids=["small-font", "default-font", "large-font"]
+)
 @pytest.mark.parametrize("pr_count", [1, 2], ids=["single-pr", "multiple-pr"])
 def test_composer_pr_link_opens_github_tab(
     page: Page,
@@ -210,7 +212,7 @@ def test_composer_pr_link_opens_github_tab(
     font_size: int,
     pr_count: int,
 ) -> None:
-    """PR metadata uses the caption size and opens the appropriate GitHub surface."""
+    """Aligned, grouped metadata uses caption text and opens the appropriate GitHub surface."""
     base_url, session_id = seeded_session
     is_mobile = viewport_width < 768
     workspace = "/workspace/demo-app"
@@ -219,7 +221,13 @@ def test_composer_pr_link_opens_github_tab(
     def session_details(route: Route) -> None:
         response = fetch_with_retry(route)
         snapshot = response.json()
-        snapshot.update(workspace=workspace, git_branch=branch, host_id="composer-pr-host")
+        snapshot.update(
+            workspace=workspace,
+            git_branch=branch,
+            host_id="composer-pr-host",
+            context_window=1_000_000,
+            last_total_tokens=660_000,
+        )
         route.fulfill(response=response, json=snapshot)
 
     page.route(re.compile(rf"/v1/sessions/{session_id}(?:\?.*)?$"), session_details)
@@ -241,12 +249,55 @@ def test_composer_pr_link_opens_github_tab(
     expect(pr_link).to_have_accessible_name(f"#{_PR_NUMBER}" if pr_count == 1 else "2 PRs")
     expect(page.get_by_test_id("composer-workspace-dir")).to_have_text("demo-app")
     expect(page.get_by_test_id("composer-git-branch")).to_have_text(branch)
+    context = page.get_by_test_id("composer-context-ring")
+    expect(context).to_have_text("66%")
+    bar = page.get_by_test_id("composer-workspace-controls")
+    expect(bar.get_by_test_id("background-task-pill")).to_have_count(0)
+    expect(bar.get_by_test_id("subagent-task-pill")).to_have_count(0)
+    bar_bounds = bar.bounding_box()
+    assert bar_bounds is not None
     font_sizes = {}
-    for test_id in ("composer-pr-link", "composer-workspace-dir", "composer-git-branch"):
-        label = page.get_by_test_id(test_id).locator("span")
+    centers = {}
+    bounds = {}
+    for test_id in (
+        "composer-pr-link",
+        "composer-workspace-dir",
+        "composer-git-branch",
+        "composer-context-ring",
+    ):
+        indicator = page.get_by_test_id(test_id)
+        label = indicator.locator("span").last
         expect(label).to_be_visible()
         font_sizes[test_id] = label.evaluate("el => parseFloat(getComputedStyle(el).fontSize)")
+        for part, element in (("label", label), ("icon", indicator.locator("svg").first)):
+            rect = element.bounding_box()
+            assert rect is not None
+            bounds[f"{test_id}.{part}"] = rect
+            centers[f"{test_id}.{part}"] = rect["y"] + rect["height"] / 2
+    pr_bounds, context_bounds = pr_link.bounding_box(), context.bounding_box()
+    assert pr_bounds is not None and context_bounds is not None
+    group_gap = context_bounds["x"] - pr_bounds["x"] - pr_bounds["width"]
+    pair_gaps = {}
+    for test_id in ("composer-pr-link", "composer-context-ring"):
+        icon, label = bounds[f"{test_id}.icon"], bounds[f"{test_id}.label"]
+        pair_gaps[test_id] = label["x"] - icon["x"] - icon["width"]
+    painted_right_edges = {
+        "composer-pr-link": pr_link.locator("path").evaluate(
+            "path => path.getBoundingClientRect().right"
+        ),
+        "composer-context-ring": context.locator("circle").first.evaluate("""circle => {
+            const stroke = parseFloat(getComputedStyle(circle).strokeWidth);
+            return circle.getBoundingClientRect().right + stroke * circle.getScreenCTM().a / 2;
+        }"""),
+    }
+    painted_gaps = {
+        test_id: bounds[f"{test_id}.label"]["x"] - right
+        for test_id, right in painted_right_edges.items()
+    }
     print(f"Composer fonts ({viewport_width}px, {font_size}px preference): {font_sizes}")
+    print(f"Composer centers: {centers}; group gap: {group_gap}; pair gaps: {pair_gaps}")
+    print(f"Visible icon-to-label gaps: {painted_gaps}")
+    bar.screenshot(path=tmp_path / "workspace-bar.png", animations="disabled")
     page.screenshot(path=tmp_path / "composer-pr-link.png", animations="disabled")
 
     # Mobile has a full-screen drawer, not the desktop workspace tab strip.
@@ -281,11 +332,22 @@ def test_composer_pr_link_opens_github_tab(
         expect(panel).to_have_attribute("data-state", "closed")
         expect(pr_link).to_be_in_viewport()
 
-    for test_id in ("composer-workspace-dir", "composer-git-branch"):
-        assert font_sizes["composer-pr-link"] == pytest.approx(font_sizes[test_id], abs=0.01), (
-            f"PR label should match adjacent composer metadata at {font_size}px preference: "
-            f"{font_sizes}"
+    expected_font_size = font_size * 0.9 * (14 / 13 if is_mobile else 1)
+    for test_id, actual_font_size in font_sizes.items():
+        assert actual_font_size == pytest.approx(expected_font_size, abs=0.01), (
+            f"{test_id} should use the caption size at {font_size}px preference: {font_sizes}"
         )
+    reference_center = centers["composer-workspace-dir.icon"]
+    assert bar_bounds["height"] == pytest.approx(37, abs=0.1)
+    assert reference_center == pytest.approx(bar_bounds["y"] + 19, abs=0.5)
+    for name, center in centers.items():
+        assert center == pytest.approx(reference_center, abs=0.5), (name, centers)
+    for name, pair_gap in pair_gaps.items():
+        assert pair_gap == pytest.approx(4, abs=0.1), (name, pair_gaps)
+        assert group_gap > pair_gap, (group_gap, pair_gaps)
+    for name, painted_gap in painted_gaps.items():
+        assert painted_gap == pytest.approx(4, abs=0.1), (name, painted_gaps)
+    assert group_gap == pytest.approx(8, abs=0.1)
 
 
 def _stub_github_outdated_host(page: Page) -> None:

--- a/web/src/components/composer/BackgroundTaskIndicator.test.tsx
+++ b/web/src/components/composer/BackgroundTaskIndicator.test.tsx
@@ -52,6 +52,7 @@ describe("BackgroundTaskIndicator", () => {
     setBackground(1, [{ description: "Only task" }]);
     render(<BackgroundTaskIndicator />);
     expect(badge("1 background task still running")).toHaveTextContent("1");
+    expect(badge()).toHaveClass("px-0", "md:px-2");
   });
 
   it("shows the count on the badge with a plural accessible name", () => {

--- a/web/src/components/composer/BackgroundTaskIndicator.tsx
+++ b/web/src/components/composer/BackgroundTaskIndicator.tsx
@@ -81,7 +81,7 @@ export function BackgroundTaskIndicator() {
             size="xs"
             data-testid="background-task-pill"
             aria-label={`${countLabel} still running`}
-            className="ml-auto shrink-0"
+            className="ml-auto shrink-0 px-0 md:px-2"
           >
             <SquareTerminalIcon className="size-3.5" aria-hidden="true" />
             {bgCount}

--- a/web/src/components/composer/ComposerContextRing.test.tsx
+++ b/web/src/components/composer/ComposerContextRing.test.tsx
@@ -27,7 +27,16 @@ describe("ComposerContextRing", () => {
   it("shows the used percentage, rounded", () => {
     renderRing(1000, 123);
     expect(screen.getByTestId("composer-context-ring")).toHaveTextContent("12%");
+    expect(screen.getByTestId("composer-context-ring")).toHaveClass("gap-1");
     expect(screen.getByLabelText("12% of context used")).toBeInTheDocument();
+  });
+
+  it("fits the SVG to the painted ring so its padding does not widen the label gap", () => {
+    renderRing(1000, 490);
+    const svg = screen.getByTestId("composer-context-ring").querySelector("svg");
+    expect(svg).toHaveAttribute("viewBox", "1.5 1.5 13 13");
+    expect(svg).toHaveAttribute("width", "13");
+    expect(svg).toHaveAttribute("height", "13");
   });
 
   it("clamps over-full usage to 100%", () => {

--- a/web/src/components/composer/ComposerContextRing.test.tsx
+++ b/web/src/components/composer/ComposerContextRing.test.tsx
@@ -27,7 +27,7 @@ describe("ComposerContextRing", () => {
   it("shows the used percentage, rounded", () => {
     renderRing(1000, 123);
     expect(screen.getByTestId("composer-context-ring")).toHaveTextContent("12%");
-    expect(screen.getByTestId("composer-context-ring")).toHaveClass("gap-1");
+    expect(screen.getByTestId("composer-context-ring")).toHaveClass("gap-1", "shrink-0");
     expect(screen.getByLabelText("12% of context used")).toBeInTheDocument();
   });
 

--- a/web/src/components/composer/ComposerContextRing.tsx
+++ b/web/src/components/composer/ComposerContextRing.tsx
@@ -38,10 +38,11 @@ export function ComposerContextRing({
       <TooltipTrigger asChild>
         <span
           data-testid="composer-context-ring"
-          className={cn("flex items-center gap-1.5 text-muted-foreground", className)}
+          className={cn("flex items-center gap-1 text-muted-foreground", className)}
           aria-label={`${usedPct}% of context used`}
         >
-          <svg viewBox="0 0 16 16" width="16" height="16" fill="none" aria-hidden="true">
+          {/* Tight stroke bounds keep the visible icon-to-label gap consistent. */}
+          <svg viewBox="1.5 1.5 13 13" width="13" height="13" fill="none" aria-hidden="true">
             {/* Track */}
             <circle cx="8" cy="8" r="5.5" stroke="currentColor" strokeWidth="2" opacity="0.2" />
             {/* Used arc — skipped at 0, where round linecaps would still paint a dot. */}

--- a/web/src/components/composer/ComposerContextRing.tsx
+++ b/web/src/components/composer/ComposerContextRing.tsx
@@ -38,7 +38,7 @@ export function ComposerContextRing({
       <TooltipTrigger asChild>
         <span
           data-testid="composer-context-ring"
-          className={cn("flex items-center gap-1 text-muted-foreground", className)}
+          className={cn("flex shrink-0 items-center gap-1 text-muted-foreground", className)}
           aria-label={`${usedPct}% of context used`}
         >
           {/* Tight stroke bounds keep the visible icon-to-label gap consistent. */}

--- a/web/src/components/composer/ComposerControls.test.tsx
+++ b/web/src/components/composer/ComposerControls.test.tsx
@@ -12,7 +12,7 @@ describe("shared composer controls", () => {
   it("uses the same workspace header and host geometry in either context", () => {
     render(
       <>
-        <ComposerWorkspaceBar>
+        <ComposerWorkspaceBar data-testid="workspace-bar">
           <ComposerWorkspaceTrigger kind="directory" label="repo" />
           <ComposerWorkspaceTrigger kind="worktree" label="main" />
         </ComposerWorkspaceBar>
@@ -21,6 +21,14 @@ describe("shared composer controls", () => {
     );
     expect(screen.getByRole("button", { name: "repo" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "main" })).toBeInTheDocument();
+    expect(screen.getByTestId("workspace-bar")).toHaveClass(
+      "items-center",
+      "py-1.5",
+      "h-[37px]",
+      "gap-0.5",
+      "md:gap-2",
+    );
+    expect(screen.getByTestId("workspace-bar")).not.toHaveClass("items-start", "pt-1.5");
     expect(screen.getByRole("button", { name: "This machine" })).toHaveClass("w-11", "md:h-7");
   });
 
@@ -33,7 +41,13 @@ describe("shared composer controls", () => {
     );
 
     for (const trigger of screen.getAllByRole("button")) {
-      expect(trigger).toHaveClass("min-w-0", "max-w-[calc(50%-0.25rem)]");
+      expect(trigger).toHaveClass(
+        "min-w-10",
+        "md:min-w-11",
+        "px-0.5",
+        "md:px-1",
+        "max-w-[calc(50%-0.25rem)]",
+      );
       expect(trigger).not.toHaveClass("max-w-[180px]");
       expect(trigger.querySelector("span")).toHaveClass("min-w-0", "truncate");
       for (const icon of trigger.querySelectorAll("svg")) {

--- a/web/src/components/composer/ComposerControls.tsx
+++ b/web/src/components/composer/ComposerControls.tsx
@@ -21,7 +21,7 @@ export function ComposerWorkspaceBar({ className, ...props }: ComponentPropsWith
   return (
     <div
       className={cn(
-        "relative z-0 mx-3 -mb-px flex h-[37px] min-w-0 items-start gap-2 rounded-t-2xl border border-b-0 border-border bg-muted/70 px-2 pt-1.5",
+        "relative z-0 mx-3 -mb-px flex h-[37px] min-w-0 items-center gap-0.5 rounded-t-2xl border border-b-0 border-border bg-muted/70 px-2 py-1.5 md:gap-2",
         className,
       )}
       {...props}
@@ -39,7 +39,7 @@ export const ComposerWorkspaceTrigger = forwardRef<
       ref={ref}
       type="button"
       className={cn(
-        "relative inline-flex h-6 min-w-0 max-w-[calc(50%-0.25rem)] cursor-pointer items-center gap-1 rounded-md border border-transparent bg-transparent px-1 text-xs leading-4 font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-default disabled:opacity-50",
+        "relative inline-flex h-6 min-w-10 max-w-[calc(50%-0.25rem)] cursor-pointer items-center gap-1 rounded-md border border-transparent bg-transparent px-0.5 text-xs leading-4 font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-default disabled:opacity-50 md:min-w-11 md:px-1",
         className,
       )}
       {...props}

--- a/web/src/components/composer/ComposerPrLink.test.tsx
+++ b/web/src/components/composer/ComposerPrLink.test.tsx
@@ -21,7 +21,7 @@ describe("ComposerPrLink", () => {
     render(<ComposerPrLink prCount={1} prNumber={42} onOpen={onOpen} />);
     const link = screen.getByTestId("composer-pr-link");
     expect(link).toHaveTextContent("#42");
-    expect(link).toHaveClass("text-sm");
+    expect(link).toHaveClass("text-sm", "gap-1");
     expect(link).toHaveAttribute("title", "View this PR in the GitHub tab");
     fireEvent.click(link);
     expect(onOpen).toHaveBeenCalledTimes(1);
@@ -31,7 +31,7 @@ describe("ComposerPrLink", () => {
     render(<ComposerPrLink prCount={3} prNumber={42} onOpen={() => {}} />);
     const link = screen.getByTestId("composer-pr-link");
     expect(link).toHaveTextContent("3 PRs");
-    expect(link).toHaveClass("text-sm");
+    expect(link).toHaveClass("text-sm", "gap-1");
     expect(link).toHaveAttribute("title", "View these PRs in the GitHub tab");
   });
 });

--- a/web/src/components/composer/ComposerPrLink.test.tsx
+++ b/web/src/components/composer/ComposerPrLink.test.tsx
@@ -21,7 +21,11 @@ describe("ComposerPrLink", () => {
     render(<ComposerPrLink prCount={1} prNumber={42} onOpen={onOpen} />);
     const link = screen.getByTestId("composer-pr-link");
     expect(link).toHaveTextContent("#42");
-    expect(link).toHaveClass("text-sm", "gap-1");
+    expect(link).toHaveClass("text-sm", "gap-1", "min-w-0");
+    expect(link).not.toHaveClass("shrink-0");
+    expect(link.querySelector("svg")).toHaveClass("shrink-0");
+    expect(screen.getByText("#42")).toHaveClass("truncate");
+    expect(screen.getByText("#42")).toHaveAttribute("title", "#42");
     expect(link).toHaveAttribute("title", "View this PR in the GitHub tab");
     fireEvent.click(link);
     expect(onOpen).toHaveBeenCalledTimes(1);
@@ -33,5 +37,6 @@ describe("ComposerPrLink", () => {
     expect(link).toHaveTextContent("3 PRs");
     expect(link).toHaveClass("text-sm", "gap-1");
     expect(link).toHaveAttribute("title", "View these PRs in the GitHub tab");
+    expect(screen.getByText("3 PRs")).toHaveAttribute("title", "3 PRs");
   });
 });

--- a/web/src/components/composer/ComposerPrLink.tsx
+++ b/web/src/components/composer/ComposerPrLink.tsx
@@ -31,7 +31,7 @@ export function ComposerPrLink({
       onClick={() => onOpen()}
       title={prCount > 1 ? "View these PRs in the GitHub tab" : "View this PR in the GitHub tab"}
       className={cn(
-        "flex shrink-0 items-center gap-1.5 rounded text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        "flex shrink-0 items-center gap-1 rounded text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         className,
       )}
     >

--- a/web/src/components/composer/ComposerPrLink.tsx
+++ b/web/src/components/composer/ComposerPrLink.tsx
@@ -24,6 +24,8 @@ export function ComposerPrLink({
 }) {
   if (prCount <= 0 || !onOpen) return null;
 
+  const label = prCount > 1 ? `${prCount} PRs` : `#${prNumber}`;
+
   return (
     <button
       type="button"
@@ -31,13 +33,13 @@ export function ComposerPrLink({
       onClick={() => onOpen()}
       title={prCount > 1 ? "View these PRs in the GitHub tab" : "View this PR in the GitHub tab"}
       className={cn(
-        "flex shrink-0 items-center gap-1 rounded text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        "flex min-w-0 items-center gap-1 rounded text-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         className,
       )}
     >
-      <GithubMono size={14} aria-hidden />
-      <span className="tabular-nums whitespace-nowrap underline underline-offset-2">
-        {prCount > 1 ? `${prCount} PRs` : `#${prNumber}`}
+      <GithubMono size={14} className="shrink-0" aria-hidden />
+      <span className="truncate tabular-nums underline underline-offset-2" title={label}>
+        {label}
       </span>
     </button>
   );

--- a/web/src/components/composer/SubagentTaskIndicator.test.tsx
+++ b/web/src/components/composer/SubagentTaskIndicator.test.tsx
@@ -54,6 +54,7 @@ describe("SubagentTaskIndicator", () => {
     render(<SubagentTaskIndicator conversationId="conv-1" />);
     const pill = screen.getByTestId("subagent-task-pill");
     expect(pill).toHaveTextContent("1");
+    expect(pill).toHaveClass("px-0", "md:px-2");
     expect(pill).toHaveAttribute("aria-label", "1 sub-agent running");
   });
 

--- a/web/src/components/composer/SubagentTaskIndicator.tsx
+++ b/web/src/components/composer/SubagentTaskIndicator.tsx
@@ -78,7 +78,7 @@ export function SubagentTaskIndicator({ conversationId }: { conversationId: stri
             size="xs"
             data-testid="subagent-task-pill"
             aria-label={countLabel}
-            className="shrink-0"
+            className="shrink-0 px-0 md:px-2"
           >
             <BotIcon className="size-3.5" aria-hidden="true" />
             {count}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3343,10 +3343,10 @@ function ComposerImpl(
             onRefreshBranch={composerGit.refresh}
             refreshing={composerGit.refreshing}
           />
-          {/* Trailing status cluster — the wrapper owns the right alignment so
-              it holds even when the self-nulling indicators render nothing. */}
-          <div className="ml-auto flex min-w-0 shrink-0 items-center gap-1">
-            <div className="flex items-center gap-2 empty:hidden">
+          {/* Reserve two workspace triggers' icon-safe minima and two gaps;
+              only PR text truncates when the remaining status space runs out. */}
+          <div className="ml-auto flex min-w-0 max-w-[calc(100%-5.25rem)] shrink-0 items-center gap-1 md:max-w-[calc(100%-6.5rem)]">
+            <div className="flex min-w-0 items-center gap-2 empty:hidden">
               <ComposerPrLink
                 prCount={composerGit.prCount}
                 prNumber={composerGit.prNumber}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -3346,15 +3346,17 @@ function ComposerImpl(
           {/* Trailing status cluster — the wrapper owns the right alignment so
               it holds even when the self-nulling indicators render nothing. */}
           <div className="ml-auto flex min-w-0 shrink-0 items-center gap-1">
-            <ComposerPrLink
-              prCount={composerGit.prCount}
-              prNumber={composerGit.prNumber}
-              onOpen={openComposerGithubTab}
-            />
-            <ComposerContextRing
-              contextWindow={composerContextWindow}
-              tokensUsed={composerTokensUsed}
-            />
+            <div className="flex items-center gap-2 empty:hidden">
+              <ComposerPrLink
+                prCount={composerGit.prCount}
+                prNumber={composerGit.prNumber}
+                onOpen={openComposerGithubTab}
+              />
+              <ComposerContextRing
+                contextWindow={composerContextWindow}
+                tokensUsed={composerTokensUsed}
+              />
+            </div>
             <BackgroundTaskIndicator />
             <SubagentTaskIndicator conversationId={composerSessionId} />
           </div>

--- a/web/src/shell/NewChatDialog.test.tsx
+++ b/web/src/shell/NewChatDialog.test.tsx
@@ -1660,16 +1660,25 @@ describe("NewChatLandingScreen", () => {
       "-mb-px",
       "h-[37px]",
       "min-w-0",
-      "items-start",
-      "gap-2",
+      "items-center",
+      "gap-0.5",
+      "md:gap-2",
       "rounded-t-2xl",
       "border",
       "border-b-0",
       "bg-muted/70",
       "px-2",
-      "pt-1.5",
+      "py-1.5",
     );
-    expect(workspace).toHaveClass("h-6", "gap-1", "rounded-md", "px-1", "text-xs", "leading-4");
+    expect(workspace).toHaveClass(
+      "h-6",
+      "gap-1",
+      "rounded-md",
+      "px-0.5",
+      "md:px-1",
+      "text-xs",
+      "leading-4",
+    );
     expect(composer).toHaveClass("min-h-[105px]");
     expect(composer).toContainElement(actions);
     expect(actions).toHaveClass("justify-between", "gap-2", "px-2", "pt-1", "pb-2");
@@ -1714,7 +1723,8 @@ describe("NewChatLandingScreen", () => {
       "gap-1",
       "rounded-md",
       "bg-transparent",
-      "px-1",
+      "px-0.5",
+      "md:px-1",
       "text-xs",
       "leading-4",
     );
@@ -3273,7 +3283,8 @@ describe("NewChatLandingScreen", () => {
       "h-6",
       "max-w-[calc(50%-0.25rem)]",
       "gap-1",
-      "px-1",
+      "px-0.5",
+      "md:px-1",
       "text-xs",
       "leading-4",
     );


### PR DESCRIPTION
## Related issue

Closes #7278

## Summary

- Center the gray composer's workspace, branch, PR, context, and task indicators on one line. Top-aligning controls of different heights made the metadata look raised.
- Use 4px within each icon/label pair and 8px between GitHub and context. Trim the ring's transparent SVG padding so the visible gaps actually match, while preserving its painted size.
- Keep crowded 375px and 390px mobile bars contained with compact control padding and icon-safe minimum widths. Desktop geometry, text sizes, and indicator behavior stay unchanged.
- Cap the status cluster after reserving the workspace icons. Under extreme crowding or wider system fonts, only PR text ellipsizes; its full value remains accessible and the context percentage/task controls remain intact.

In short: each icon sits level with, and closer to, its own label.

## Test Plan

- 585 focused Vitest tests across the shared controls, both composer consumers, and the status indicators.
- 68 Chromium/WebKit cases: desktop/mobile, small/default/large Appearance text, one/multiple PRs, long labels, and light/dark crowded bars at 375px and 390px, including seven-digit PRs and the Verdana Appearance setting. The eight new long-PR/wide-font cases were rerun after adding mobile drawer-open/close checks.
- 16 additional Chromium/WebKit cases with DejaVu Sans reproduce CI's exact font metrics and verify the fix: trailing edge 338px instead of 347.09375px, both painted icon/label gaps 4px, and the PR/context gap 8px. Four-digit PR labels remain untruncated at 390px and on desktop.
- Browser checks measure both SVG layout gaps and painted-edge gaps, vertical centers, containment, and PR/task-badge interactions. The new assertions reproduce the original failures.
- Production SPA build and staged-file pre-commit checks pass.

```bash
uv run --no-sync pytest \
  tests/e2e_ui/github/test_github_tab.py \
  tests/e2e_ui/chat/test_composer_acceptance.py \
  tests/e2e_ui/chat/test_composer_workspace_popovers.py \
  -k 'test_composer_pr_link_opens_github_tab or test_status_counts_and_pr_share_workspace_bar or test_composer_workspace_labels_use_available_width' \
  --browser chromium --browser webkit
```

## Demo

- [x] Visual demo attached below
- [ ] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Synthetic local fixtures; no private conversation data.

| Before | After |
| --- | --- |
| ![Before: mobile metadata is raised and poorly grouped](https://github.com/user-attachments/assets/76fe8a5f-2dd7-40ab-a0c1-3d191a4fb529) | ![After: aligned metadata with equal visible icon-to-label gaps](https://github.com/user-attachments/assets/a4b8ac30-51dc-425b-96bb-6245b877d2a9) |

375px WebKit, Appearance 18, four-digit PR, 100% context, and both task badges:

![Crowded mobile controls remain aligned and inside the gray bar](https://github.com/user-attachments/assets/b40036cb-afa7-4f33-9c17-fa07e45ca5d4)

[Additional CI-font before/after screenshots and mobile-tap verification](https://github.com/omnigent-ai/omnigent/pull/7279#issuecomment-5649424720).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] E2E tests added / updated
- [x] Manual verification completed
- [x] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

Inspected the real browser screenshots and measured control geometry in Chromium and WebKit. The requester validated the alignment and equal visible gaps in a local production-backed preview before this PR. The additional 375px crowded layout is covered by automated browser checks, not a physical-device test.

Manual check: open a session with a PR and context usage, compare the centerline and icon/label grouping, then repeat at large Appearance text with task badges present and tap the PR/task controls. At 375px with Verdana at 18px, the PR label may ellipsize but every control must stay inside the bar and tapping the PR must still open GitHub.

## Changelog

The session composer's workspace bar has aligned metadata, consistent icon-to-label spacing, and more compact mobile controls.

## Issues

Resolves [OMNI-7405](https://linear.app/omnigent/issue/OMNI-7405/bug-composer-metadata-is-vertically-misaligned-and-visually-misgrouped)
