### PR TITLE
fix(k8s): skip the GitHub credential broker on init clone when GIT_TOKEN is set

### DIFF
--- a/omnigent/onboarding/sandboxes/kubernetes.py
+++ b/omnigent/onboarding/sandboxes/kubernetes.py
@@ -499,18 +499,18 @@ def _render_workspace_prep_command(
     """
     script = f"set -e\nmkdir -p {shlex.quote(workspace)}\n"
     if repos:
-        # Prefer the owner's per-user credential for the clone: when they've
-        # connected GitHub, wire the broker as the sole github.com helper so a
-        # private clone authenticates as *them*. Wired ONCE (it configures the
-        # global github.com helper for every clone below). When they haven't
-        # connected this is a no-op that leaves the image's shared ``$GIT_TOKEN``
-        # helper in place; ``|| true`` keeps a broker hiccup from failing the
-        # clone (it then falls back to ``$GIT_TOKEN``). Needs OMNIGENT_HOST_TOKEN.
+        # Prefer the owner's per-user credential for the clone. Skip the
+        # broker when GIT_TOKEN is already in env: it 404s before the host
+        # registers and clearing the image helper makes clone fail Username.
         wire = (
             "from omnigent.git_credential_github import configure_clone_credentials; "
             f"configure_clone_credentials({server_url!r}, {host_id!r})"
         )
-        script += f"python3 -c {shlex.quote(wire)} || true\n"
+        script += (
+            f'if [ -z "${{GIT_TOKEN:-}}" ]; then\n'
+            f"  python3 -c {shlex.quote(wire)} || true\n"
+            f"fi\n"
+        )
         # Clone every repo concurrently, then wait on each and fail the init
         # container if ANY clone failed — a half-populated workspace must abort
         # the launch loudly, not boot the host on it. ``set -e`` stays on, but a

--- a/tests/onboarding/sandboxes/test_kubernetes.py
+++ b/tests/onboarding/sandboxes/test_kubernetes.py
@@ -117,9 +117,10 @@ def test_build_job_manifest_init_container_prepares_and_clones_workspace() -> No
     assert "mkdir -p /home/omnigent/workspace" in script
     assert "git clone --branch main --single-branch -- " in script
     assert "https://github.com/org/repo.git /home/omnigent/workspace/repo" in script
-    # The per-user broker is wired before the clone, and the init container gets
-    # the launch token (secretKeyRef) so it can reach the broker.
+    # Per-user GIT_TOKEN skips the broker (host is not registered yet).
+    assert 'if [ -z "${GIT_TOKEN:-}" ]' in script
     assert "configure_clone_credentials" in script
+    assert script.index("${GIT_TOKEN:-}") < script.index("configure_clone_credentials")
     assert script.index("configure_clone_credentials") < script.index("git clone")
     init_env = init[0]["env"]
     assert any(


### PR DESCRIPTION
## Related issue

Closes #7283

Related: #6949 (same Username failure when the credential endpoint 404s for an unconfigured provider). This PR covers the case where GitHub *is* connected but the host is not registered yet.

## Summary

`workspace-prep` installs the GitHub credential broker before `omnigent host` registers. The broker's `GET /v1/hosts/{id}/credentials/github` 404s, and `_install_broker_helper` has already cleared the image `$GIT_TOKEN` helper, so `git clone` fails with `could not read Username` even when `GIT_TOKEN` is in the init env.

Skip `configure_clone_credentials` when `GIT_TOKEN` is already set; keep the concurrent clone loop. The host still wires the broker after it is registered.

### ELI5

The sandbox tried to ask the server for a GitHub password before it had a name tag. That wiped the password it already had in `GIT_TOKEN`. Now it uses `GIT_TOKEN` for the first clone.

```text
Before: broker (404, clears helper) → git clone → Username error
After:  if GIT_TOKEN set → git clone with image helper
        else broker || true → git clone
```

## Test Plan

- `pytest tests/onboarding/sandboxes/test_kubernetes.py` — 93 passed.
- Manual: Kubernetes managed sandbox with `GIT_TOKEN` in the per-launch Secret cloned `https://github.com/<owner>/<private-repo>.git` in `workspace-prep` and the host reached Running.

## Demo

- [ ] Visual demo attached below
- [x] Non-visual evidence provided below or in Test Plan
- [ ] Not applicable — no behavioral change

Init log after the fix: `Cloning into '/home/omnigent/workspace/<repo>...'` with no Username error; Job 1/1 Running.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] UI / frontend change
- [ ] Refactor / chore
- [ ] Docs
- [ ] Test / CI
- [ ] Breaking change

## Test coverage

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] E2E tests added / updated
- [x] Manual verification completed
- [ ] Existing tests cover this change
- [ ] Not applicable

## Coverage notes

The init-script unit test asserts `if [ -z "${GIT_TOKEN:-}" ]` wraps `configure_clone_credentials` and that `git clone` still runs. Manual verification: live k8s Job cloned a private repo and the host connected.

## Changelog

Managed-sandbox workspace clones use `GIT_TOKEN` during init instead of failing with could not read Username